### PR TITLE
DEVEXP-386 Can now use connector in PySpark

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,8 @@
+This is an evolving guide for developers interested in developing and testing this project. This guide assumes that you
+have cloned this repository to your local workstation. 
+
+# Running the tests
+
 To deploy the test application, first create `./gradle-local.properties` and add the following to it:
 
     mlPassword=the password of your admin user
@@ -9,3 +14,60 @@ Then deploy the test application:
 You can then run all the tests:
 
     ./gradlew test
+
+# Testing with PySpark
+
+First, [follow the instructions](https://spark.apache.org/docs/latest/api/python/getting_started/install.html) on 
+installing PySpark. You'll need to install Python 3 first. [pyenv](https://github.com/pyenv/pyenv#installation) is 
+recommended for doing so, as it simplifies installing multiple versions of Python and easily switching between them. 
+
+Once you've installed PySpark, run it to make sure all is well:
+
+    pyspark
+
+That should open up a Python shell and print some logging like this:
+
+```
+Using Python version 3.9.11 (main, Sep 27 2022 13:33:29)
+Spark context Web UI available at http://10.114.228.34:4040
+Spark context available as 'sc' (master = local[*], app id = local-1682019905427).
+SparkSession available as 'spark'.
+```
+
+Quit out of the Python shell by hitting `ctrl-D`. 
+
+Build the MarkLogic Spark connector:
+
+    ./gradlew clean shadowJar
+
+This will produce a single jar file for the connector in the `./build/libs` directory. 
+
+Next, from any directory, run the following, assuming that you cloned this project to `/Users/myusername`:
+
+    pyspark --jars /Users/myusername/marklogic-spark-connector/build/libs/marklogic-spark-connector-1.0-SNAPSHOT-all.jar
+
+The above command will start another Python shell, and the MarkLogic Spark connector will be available to Spark. 
+
+Now, let's make use of the connector - paste the following into the Python terminal, altering the connection details
+and the Optic query as necessary (this defaults to a query that will work against this project's test application, 
+which can be deployed via the instructions above for running this project's tests):
+
+```
+df = spark.read.format("com.marklogic.spark")\
+    .option("marklogic.client.host", "localhost")\
+    .option("marklogic.client.port", "8016")\
+    .option("marklogic.client.username", "admin")\
+    .option("marklogic.client.password", "admin")\
+    .option("marklogic.client.authType", "digest")\
+    .option("marklogic.optic_dsl", "op.fromView('Medical', 'Authors')")\
+    .load()
+```
+
+You now have a Spark dataframe - try some commands out on it:
+
+    df.count()
+    df.show(10)
+    df.head()
+
+Check out the [PySpark docs](https://spark.apache.org/docs/latest/api/python/getting_started/quickstart_df.html) for 
+more commands you can try out. 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id 'java'
   id 'net.saliman.properties' version '1.5.2'
+  id 'com.github.johnrengelman.shadow' version '7.1.2'
   id "com.marklogic.ml-gradle" version "4.5.1"
 }
 
@@ -12,19 +13,21 @@ repositories {
   maven {
     url "https://nexus.marklogic.com/repository/maven-snapshots/"
   }
-
   mavenCentral()
 }
 
 dependencies {
-  implementation 'org.apache.spark:spark-sql_2.13:3.4.0'
-
-  implementation "org.apache.spark:spark-launcher_2.13:3.4.0"
-  implementation "org.apache.spark:spark-catalyst_2.13:3.4.0"
-  implementation "org.apache.spark:spark-streaming_2.13:3.4.0"
-  implementation "org.apache.spark:spark-core_2.13:3.4.0"
+  compileOnly 'org.apache.spark:spark-sql_2.12:3.4.0'
   implementation "com.marklogic:marklogic-client-api:6.2-SNAPSHOT"
 
+  // Makes it possible to use lambdas in Java 8 to implement Spark's Function1 and Function2 interfaces
+  // See https://github.com/scala/scala-java8-compat for more information
+  implementation ("org.scala-lang.modules:scala-java8-compat_2.12:1.0.2") {
+    // Prefer the Scala libraries used within the user's Spark runtime.
+    exclude module: "scala-library"
+  }
+
+  testImplementation 'org.apache.spark:spark-sql_2.12:3.4.0'
   testImplementation 'com.marklogic:marklogic-junit5:1.3.0'
   testImplementation "ch.qos.logback:logback-classic:1.3.5"
   testImplementation "org.slf4j:jcl-over-slf4j:1.7.36"
@@ -33,4 +36,12 @@ dependencies {
 
 test {
   useJUnitPlatform()
+}
+
+shadowJar {
+  // Spark uses an older version of OkHttp; see
+  // https://stackoverflow.com/questions/61147800/how-to-override-spark-jars-while-running-spark-submit-command-in-cluster-mode
+  // for more information on why these are relocated.
+  relocate "okhttp3", "com.marklogic.okhttp3"
+  relocate "okio", "com.marklogic.okio"
 }

--- a/src/main/java/com/marklogic/spark/DefaultSource.java
+++ b/src/main/java/com/marklogic/spark/DefaultSource.java
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.spark.reader;
+package com.marklogic.spark;
 
+import com.marklogic.spark.reader.ReadContext;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableProvider;
 import org.apache.spark.sql.connector.expressions.Transform;
@@ -23,7 +24,11 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 import java.util.Map;
 
-public class MarkLogicTableProvider implements TableProvider {
+/**
+ * The name "DefaultSource" is used here so that this connector can be loaded using the Spark V2 approach, where the
+ * user specifies a package name and the class name is assumed to be "DefaultSource".
+ */
+public class DefaultSource implements TableProvider {
 
     private ReadContext readContext;
 
@@ -42,7 +47,7 @@ public class MarkLogicTableProvider implements TableProvider {
         if (this.readContext == null) {
             this.readContext = new ReadContext(properties, schema);
         }
-        return new MarkLogicReader(this.readContext);
+        return new MarkLogicTable(this.readContext);
     }
 
     /**

--- a/src/main/java/com/marklogic/spark/MarkLogicTable.java
+++ b/src/main/java/com/marklogic/spark/MarkLogicTable.java
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.spark.reader;
+package com.marklogic.spark;
 
+import com.marklogic.spark.reader.MarkLogicScanBuilder;
+import com.marklogic.spark.reader.ReadContext;
 import org.apache.spark.sql.connector.catalog.SupportsRead;
 import org.apache.spark.sql.connector.catalog.TableCapability;
 import org.apache.spark.sql.connector.read.ScanBuilder;
@@ -24,12 +26,12 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import java.util.HashSet;
 import java.util.Set;
 
-class MarkLogicReader implements SupportsRead {
+class MarkLogicTable implements SupportsRead {
 
     private ReadContext readContext;
     private final Set<TableCapability> capabilities;
 
-    MarkLogicReader(ReadContext readContext) {
+    MarkLogicTable(ReadContext readContext) {
         this.readContext = readContext;
         capabilities = new HashSet<>();
         capabilities.add(TableCapability.BATCH_READ);

--- a/src/main/java/com/marklogic/spark/reader/MarkLogicScanBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/MarkLogicScanBuilder.java
@@ -18,11 +18,11 @@ package com.marklogic.spark.reader;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
 
-class MarkLogicScanBuilder implements ScanBuilder {
+public class MarkLogicScanBuilder implements ScanBuilder {
 
     private ReadContext readContext;
 
-    MarkLogicScanBuilder(ReadContext readContext) {
+    public MarkLogicScanBuilder(ReadContext readContext) {
         this.readContext = readContext;
     }
 

--- a/src/main/java/com/marklogic/spark/reader/ReadContext.java
+++ b/src/main/java/com/marklogic/spark/reader/ReadContext.java
@@ -40,7 +40,7 @@ import java.util.Map;
  * Also simplifies passing state around to the various Spark-required classes, as we only need one argument instead of
  * N arguments.
  */
-class ReadContext implements Serializable {
+public class ReadContext implements Serializable {
 
     final static long serialVersionUID = 1;
 
@@ -52,7 +52,7 @@ class ReadContext implements Serializable {
     private StructType schema;
     private long serverTimestamp;
 
-    ReadContext(Map<String, String> properties, StructType schema) {
+    public ReadContext(Map<String, String> properties, StructType schema) {
         this(properties);
         // TODO Using the above constructor is a little inefficient, as we're always inferring the schema so that we can
         // also establish a server timestamp. We'll optimize this before the 1.0 release - i.e. if the user gives us a
@@ -66,7 +66,7 @@ class ReadContext implements Serializable {
      *
      * @param properties
      */
-    ReadContext(Map<String, String> properties) {
+    public ReadContext(Map<String, String> properties) {
         this.properties = properties;
 
         int partitionCount = getNumericOption("marklogic.num_partitions", SparkSession.active().sparkContext().defaultMinPartitions());
@@ -153,7 +153,7 @@ class ReadContext implements Serializable {
         return rowManager.resultRows(builtPlan, resultHandle).iterator();
     }
 
-    StructType getSchema() {
+    public StructType getSchema() {
         return schema;
     }
 

--- a/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
+++ b/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
@@ -2,7 +2,6 @@ package com.marklogic.spark;
 
 import com.marklogic.junit5.spring.AbstractSpringMarkLogicTest;
 import com.marklogic.junit5.spring.SimpleTestConfig;
-import com.marklogic.spark.reader.MarkLogicTableProvider;
 import org.apache.spark.sql.DataFrameReader;
 import org.apache.spark.sql.SparkSession;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,7 +41,7 @@ public class AbstractIntegrationTest extends AbstractSpringMarkLogicTest {
     protected DataFrameReader newDefaultReader() {
         return newSparkSession()
             .read()
-            .format(MarkLogicTableProvider.class.getName())
+            .format("com.marklogic.spark")
             .option("marklogic.client.host", testConfig.getHost())
             .option("marklogic.client.port", testConfig.getRestPort())
             .option("marklogic.client.username", testConfig.getUsername())
@@ -50,7 +49,7 @@ public class AbstractIntegrationTest extends AbstractSpringMarkLogicTest {
             .option("marklogic.client.authType", "digest")
             .option("marklogic.optic_dsl", "op.fromView('Medical','Authors')");
     }
-    
+
     protected String readClasspathFile(String path) {
         try {
             return new String(FileCopyUtils.copyToByteArray(new ClassPathResource(path).getInputStream()));

--- a/src/test/java/com/marklogic/spark/reader/PerformanceTester.java
+++ b/src/test/java/com/marklogic/spark/reader/PerformanceTester.java
@@ -1,5 +1,6 @@
 package com.marklogic.spark.reader;
 
+import com.marklogic.spark.DefaultSource;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -34,7 +35,7 @@ public class PerformanceTester {
             .master(String.format("local[%d]", sparkConcurrentTaskCount))
             .getOrCreate()
             .read()
-            .format(MarkLogicTableProvider.class.getName())
+            .format("com.marklogic.spark")
             .option("marklogic.client.host", "localhost")
             .option("marklogic.client.port", 8009)
             .option("marklogic.client.username", "admin")


### PR DESCRIPTION
Had to move some things around:

- Moved MarkLogicTableProvider to `com.marklogic.spark` and renamed it `DefaultSource` to follow the Spark 2 convention, which PySpark seems to rely on.
- Renamed `MarkLogicReader` to `MarkLogicTable` as we'll be adding "write" support to that soon.
- Added details to the CONTRIB file on how to use PySpark.