### PR TITLE
DEVEXP-378 Now using multiple hosts in a cluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,18 @@ plugins {
 group 'org.example'
 version '1.0-SNAPSHOT'
 
+java {
+  sourceCompatibility = 1.8
+  targetCompatibility = 1.8
+}
+
 repositories {
   // Temporarily here for resolving Java Client 6.2-SNAPSHOT.
   maven {
     url "https://nexus.marklogic.com/repository/maven-snapshots/"
   }
+  mavenLocal()
+
   mavenCentral()
 }
 
@@ -22,7 +29,7 @@ dependencies {
 
   // Makes it possible to use lambdas in Java 8 to implement Spark's Function1 and Function2 interfaces
   // See https://github.com/scala/scala-java8-compat for more information
-  implementation ("org.scala-lang.modules:scala-java8-compat_2.12:1.0.2") {
+  implementation("org.scala-lang.modules:scala-java8-compat_2.12:1.0.2") {
     // Prefer the Scala libraries used within the user's Spark runtime.
     exclude module: "scala-library"
   }
@@ -32,6 +39,7 @@ dependencies {
   testImplementation "ch.qos.logback:logback-classic:1.3.5"
   testImplementation "org.slf4j:jcl-over-slf4j:1.7.36"
   testImplementation "org.skyscreamer:jsonassert:1.5.1"
+  testImplementation "com.marklogic:ml-app-deployer:4.5.1"
 }
 
 test {

--- a/src/main/java/com/marklogic/spark/MarkLogicTable.java
+++ b/src/main/java/com/marklogic/spark/MarkLogicTable.java
@@ -57,6 +57,8 @@ class MarkLogicTable implements SupportsRead {
         return "test-project";
     }
 
+    // This is marked as deprecated in the Table interface.
+    @Deprecated
     @Override
     public StructType schema() {
         return readContext.getSchema();

--- a/src/main/java/com/marklogic/spark/reader/HostUtil.java
+++ b/src/main/java/com/marklogic/spark/reader/HostUtil.java
@@ -1,0 +1,66 @@
+package com.marklogic.spark.reader;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.datamovement.Forest;
+import com.marklogic.client.datamovement.ForestConfiguration;
+import com.marklogic.client.datamovement.impl.DataMovementManagerImpl;
+import com.marklogic.client.row.RowManager;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Determines hosts for distributing load. A "data host" (or "d-node") is one with at least forest associated with the
+ * database that the given Java Client points to.
+ * <p>
+ * Mostly copied from BatcherImpl and RowBatcherImpl in the Java Client.
+ */
+abstract class HostUtil {
+
+    static class DataHost {
+        final String hostName;
+        final RowManager rowManager;
+
+        DataHost(DatabaseClient client) {
+            this.hostName = client.getHost();
+            this.rowManager = client.newRowManager();
+            // Nested values won't work with JacksonParser, so we ask for type info to not be in the rows.
+            this.rowManager.setDatatypeStyle(RowManager.RowSetPart.HEADER);
+        }
+    }
+
+    static List<DataHost> getDataHosts(DatabaseClient client) {
+        DataMovementManagerImpl dmm = (DataMovementManagerImpl) client.newDataMovementManager();
+        ForestConfiguration forestConfig = dmm.readForestConfig();
+        Set<String> hostNames = getHostNamesForForests(forestConfig.listForests());
+        return hostNames
+            .stream()
+            .map(hostName -> new DataHost(dmm.getHostClient(hostName)))
+            .collect(Collectors.toList());
+    }
+
+    private static Set<String> getHostNamesForForests(Forest[] forests) {
+        Set<String> hosts = new HashSet<>();
+        for (Forest forest : forests) {
+            if (forest.getPreferredHost() == null) {
+                throw new IllegalStateException("Hostname must not be null for any forest; forest name: " + forest.getForestName());
+            }
+            hosts.add(forest.getPreferredHost());
+        }
+        // This is copied from BatcherImpl. An example of this occurs locally, where the hostName for a forest may be
+        // e.g. "macpro-1234.marklogic.com", and the requestHost is "localhost". This code will remove the former from
+        // the list of hosts, presumably because the former is not accessible while the latter is.
+        for (Forest forest : forests) {
+            String hostName = forest.getHost();
+            boolean hostNameShouldNotBeUsed =
+                forest.getPreferredHostType() == Forest.HostType.REQUEST_HOST &&
+                    !hostName.equalsIgnoreCase(forest.getRequestHost());
+            if (hostNameShouldNotBeUsed && hosts.contains(hostName)) {
+                hosts.remove(hostName);
+            }
+        }
+        return hosts;
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/MarkLogicPartitionReaderFactory.java
+++ b/src/main/java/com/marklogic/spark/reader/MarkLogicPartitionReaderFactory.java
@@ -15,12 +15,17 @@
  */
 package com.marklogic.spark.reader;
 
+import com.marklogic.client.DatabaseClient;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 class MarkLogicPartitionReaderFactory implements PartitionReaderFactory {
 
@@ -36,6 +41,22 @@ class MarkLogicPartitionReaderFactory implements PartitionReaderFactory {
     @Override
     public PartitionReader<InternalRow> createReader(InputPartition partition) {
         logger.info("Creating reader for partition: {}", partition);
-        return new MarkLogicPartitionReader(this.readContext, (PlanAnalysis.Partition) partition);
+        List<HostUtil.DataHost> dataHosts = determineDataHosts();
+        return new MarkLogicPartitionReader(this.readContext, (PlanAnalysis.Partition) partition, dataHosts);
+    }
+
+    private List<HostUtil.DataHost> determineDataHosts() {
+        List<HostUtil.DataHost> dataHosts;
+        DatabaseClient client = readContext.connectToMarkLogic();
+        if (DatabaseClient.ConnectionType.GATEWAY.equals(client.getConnectionType())) {
+            dataHosts = Arrays.asList(new HostUtil.DataHost(client));
+        } else {
+            dataHosts = HostUtil.getDataHosts(client);
+            List<String> hostNames = dataHosts.stream().map(host -> host.hostName).collect(Collectors.toList());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Will connect to hosts: {}", hostNames);
+            }
+        }
+        return dataHosts;
     }
 }

--- a/src/test/java/com/marklogic/spark/reader/GetDataHostsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/GetDataHostsTest.java
@@ -1,0 +1,37 @@
+package com.marklogic.spark.reader;
+
+import com.marklogic.mgmt.ManageClient;
+import com.marklogic.mgmt.ManageConfig;
+import com.marklogic.mgmt.resource.hosts.HostManager;
+import com.marklogic.spark.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GetDataHostsTest extends AbstractIntegrationTest {
+
+    @Test
+    void test() {
+        final List<String> expectedHostNames = getExpectedHostNames();
+
+        List<HostUtil.DataHost> dataHosts = HostUtil.getDataHosts(getDatabaseClient());
+        assertEquals(expectedHostNames.size(), dataHosts.size(), "Expecting each host in the cluster to be returned, " +
+            "assuming that each has a forest with the associated database.");
+
+        final String expectedBootstrapHostName = testConfig.getHost();
+        assertEquals(expectedBootstrapHostName, dataHosts.get(0).hostName,
+            "The first host in the list is expected to be the 'bootstrap' host and should have a 'request host' name " +
+                "equal to that of the 'mlHost' property that our test plumbing uses to connect to MarkLogic. " +
+                "The code that was copied from the Java Client to determine hosts will prefer using the 'request host' " +
+                "name as opposed to the actual MarkLogic host name.");
+    }
+
+    private List<String> getExpectedHostNames() {
+        ManageConfig config = new ManageConfig(
+            testConfig.getHost(), 8002, testConfig.getUsername(), testConfig.getPassword()
+        );
+        return new HostManager(new ManageClient(config)).getHostNames();
+    }
+}


### PR DESCRIPTION
I wrote up DEVEXP-406 to address what happens when a particular host stops working; DMSDK has support for that - i.e. that client is removed and not used again. 

To fully test this, we need a multi-node cluster, and ideally with at least 1 node not having a forest for the database. That will be addressed in a follow-up PR that adds a docker-compose file for building such a cluster and doing manual testing with it.