### PR TITLE
DEVEXP-388: Verifying that Spark timeZone property works

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/MarkLogicPartitionReader.java
+++ b/src/main/java/com/marklogic/spark/reader/MarkLogicPartitionReader.java
@@ -137,7 +137,7 @@ class MarkLogicPartitionReader implements PartitionReader {
         // for more information.
         final String defaultColumnNameOfCorruptRecord = "_corrupt_record";
 
-        // TODO This may need to be configurable by the user
+        // As verified via tests, this default is overridden by a user via the spark.sql.session.timeZone option.
         final String defaultTimeZoneId = "Z";
         JSONOptions jsonOptions = new JSONOptions(new HashMap<>(), defaultTimeZoneId, defaultColumnNameOfCorruptRecord);
 

--- a/src/main/java/com/marklogic/spark/reader/PlanAnalyzer.java
+++ b/src/main/java/com/marklogic/spark/reader/PlanAnalyzer.java
@@ -26,8 +26,6 @@ import java.util.List;
 /**
  * "Analyze" = take a user's plan (from their Optic DSL query) and parameterize it with lower and upper bounds,
  * and also calculate partitions.
- * <p>
- * This will be used by MarkLogicBatch in DEVEXP-376 (and this comment will be removed).
  */
 class PlanAnalyzer {
 

--- a/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
+++ b/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
@@ -28,8 +28,13 @@ public class AbstractIntegrationTest extends AbstractSpringMarkLogicTest {
     }
 
     protected SparkSession newSparkSession() {
+        return newSparkSession("UTC");
+    }
+
+    protected SparkSession newSparkSession(String timeZone) {
         return SparkSession.builder()
             .master("local[*]")
+            .config("spark.sql.session.timeZone", timeZone)
             .getOrCreate();
     }
 
@@ -40,7 +45,11 @@ public class AbstractIntegrationTest extends AbstractSpringMarkLogicTest {
      * @return
      */
     protected DataFrameReader newDefaultReader() {
-        return newSparkSession()
+        return newDefaultReader(newSparkSession());
+    }
+
+    protected DataFrameReader newDefaultReader(SparkSession session) {
+        return session
             .read()
             .format("com.marklogic.spark")
             .option("spark.marklogic.client.host", testConfig.getHost())

--- a/src/test/java/com/marklogic/spark/reader/ReadRowsWithInferredSchemaTest.java
+++ b/src/test/java/com/marklogic/spark/reader/ReadRowsWithInferredSchemaTest.java
@@ -30,10 +30,8 @@ public class ReadRowsWithInferredSchemaTest extends AbstractIntegrationTest {
         assertEquals(1.0, row.getFloat(4));
         assertEquals(2.2, row.getDouble(5));
         assertEquals(3.3, row.getDouble(6));
-        // TODO Improve this with DEVEXP-388
         assertTrue(row.getTimestamp(7).toString().startsWith("2023-04-18 "),
             "Unexpected value: " + row.getTimestamp(7).toString());
-        //assertEquals("2023-04-18 13:55:51.123", row.getTimestamp(7).toString());
         assertEquals("13:55:51", row.getString(8)); // time
         assertEquals("2023-04-18", row.getDate(9).toString());
         assertEquals("2023-04", row.getString(10)); // gYearMonth


### PR DESCRIPTION
Turns out we didn't need any code changes, but added tests to verify that `spark.sql.session.timeZone` works as expected in our connector.