### PR TITLE
DEVEXP-390 Only inferring schema if necessary

### DIFF
--- a/src/main/java/com/marklogic/spark/DefaultSource.java
+++ b/src/main/java/com/marklogic/spark/DefaultSource.java
@@ -38,7 +38,7 @@ public class DefaultSource implements TableProvider {
     @Override
     public StructType inferSchema(CaseInsensitiveStringMap options) {
         Map<String, String> serializableProperties = options.asCaseSensitiveMap();
-        this.readContext = new ReadContext(serializableProperties);
+        this.readContext = new ReadContext(serializableProperties, true);
         return this.readContext.getSchema();
     }
 


### PR DESCRIPTION
And ensuring an error occurs if the serverTimestamp is not set. That scenario cannot be tested and there's no way to force it to happen, it's more to guard against a bug in the future.