### PR TITLE
DEVEXP-436 Can now configure document props

### DIFF
--- a/caddy/config/Caddyfile
+++ b/caddy/config/Caddyfile
@@ -5,6 +5,10 @@
     reverse_proxy bootstrap_3n.local:8016 node2.local:8016 node3.local:8016 {
     }
 }
+:8815 {
+    reverse_proxy bootstrap_3n.local:8015 node2.local:8015 node3.local:8015 {
+    }
+}
 
 # For the examples/pyspark application.
 :8820 {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
     ports:
       # For running marklogic-spark-connector tests against the 3-node cluster
       - 8016:8816
+      - 8015:8815
       # For running performance tests against quick-table data
       - 8009:8809
       # For the pyspark-example project

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,8 +47,15 @@ information on how data is read from MarkLogic.
 These options control how the connector writes data to MarkLogic. See [the guide on writing](writing.md) for more 
 information on how data is written to MarkLogic.
 
-| Option | Description                                                                                       | 
-| --- |---------------------------------------------------------------------------------------------------|
+| Option | Description                                                                       | 
+| --- |-----------------------------------------------------------------------------------|
 | spark.marklogic.write.batchSize | The number of documents written in a call to MarkLogic; defaults to 100. |
 | spark.marklogic.write.threadCount | The number of threads used within each partition to send documents to MarkLogic; defaults to 4. |
-
+| spark.marklogic.write.collections | Comma-delimited string of collection names to add to each document |
+| spark.marklogic.write.permissions | Comma-delimited string of role names and capabilities to add to each document - e.g. role1,read,role2,update,role3,execute |
+| spark.marklogic.write.temporalCollection | Name of a temporal collection to assign each document to |
+| spark.marklogic.write.transform | Name of a REST transform to apply to each document |
+| spark.marklogic.write.transformParams | Comma-delimited string of transform parameter names and values - e.g. param1,value1,param2,value2 |
+| spark.marklogic.write.transformParamsDelimiter | Delimiter to use instead of a command for the `transformParams` option |
+| spark.marklogic.write.uriPrefix | String to prepend to each document URI, where the URI defaults to a UUID |
+| spark.marklogic.write.uriSuffix | String to append to each document URI, where the URI defaults to a UUID |

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -8,4 +8,13 @@ public interface Options {
     String WRITE_BATCH_SIZE = "spark.marklogic.write.batchSize";
     String WRITE_THREAD_COUNT = "spark.marklogic.write.threadCount";
 
+    String WRITE_COLLECTIONS = "spark.marklogic.write.collections";
+    String WRITE_PERMISSIONS = "spark.marklogic.write.permissions";
+    String WRITE_TEMPORAL_COLLECTION = "spark.marklogic.write.temporalCollection";
+    String WRITE_URI_PREFIX = "spark.marklogic.write.uriPrefix";
+    String WRITE_URI_SUFFIX = "spark.marklogic.write.uriSuffix";
+
+    String WRITE_TRANSFORM_NAME = "spark.marklogic.write.transform";
+    String WRITE_TRANSFORM_PARAMS = "spark.marklogic.write.transformParams";
+    String WRITE_TRANSFORM_PARAMS_DELIMITER = "spark.marklogic.write.transformParamsDelimiter";
 }

--- a/src/main/java/com/marklogic/spark/writer/DocBuilder.java
+++ b/src/main/java/com/marklogic/spark/writer/DocBuilder.java
@@ -1,0 +1,27 @@
+package com.marklogic.spark.writer;
+
+import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.client.impl.DocumentWriteOperationImpl;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.marker.AbstractWriteHandle;
+
+/**
+ * This is intended to be replaced by something generic in the Java Client which can then be reused in other Java-based
+ * connectors that must support a similar use case of taking a set of user options and producing a
+ * DocumentWriteOperation.
+ */
+class DocBuilder {
+
+    private DocumentWriteOperation.DocumentUriMaker uriMaker;
+    private DocumentMetadataHandle metadata;
+
+
+    DocBuilder(DocumentWriteOperation.DocumentUriMaker uriMaker, DocumentMetadataHandle metadata) {
+        this.uriMaker = uriMaker;
+        this.metadata = metadata;
+    }
+
+    DocumentWriteOperation build(AbstractWriteHandle contentHandle) {
+        return new DocumentWriteOperationImpl(uriMaker.apply(contentHandle), metadata, contentHandle);
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/DocBuilderFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/DocBuilderFactory.java
@@ -1,0 +1,69 @@
+package com.marklogic.spark.writer;
+
+import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.client.io.DocumentMetadataHandle;
+
+import java.util.UUID;
+
+/**
+ * This is intended to migrate to java-client-api and likely just be a Builder class on DocumentWriteOperation.
+ */
+class DocBuilderFactory {
+
+    private DocumentMetadataHandle metadata;
+    private DocumentWriteOperation.DocumentUriMaker uriMaker;
+
+    DocBuilderFactory() {
+        this.metadata = new DocumentMetadataHandle();
+    }
+
+    DocBuilder newDocBuilder() {
+        return new DocBuilder(uriMaker, metadata);
+    }
+
+    DocBuilderFactory withCollections(String collections) {
+        if (collections != null && collections.trim().length() > 0) {
+            metadata.withCollections(collections.split(","));
+        }
+        return this;
+    }
+
+    DocBuilderFactory withPermissions(String permissionsString) {
+        DocumentMetadataHandle.DocumentPermissions permissions = metadata.getPermissions();
+        // TODO Copied from ml-javaclient-util. Should be in java-client-api.
+        if (permissionsString != null && permissionsString.trim().length() > 0) {
+            String[] tokens = permissionsString.split(",");
+            for (int i = 0; i < tokens.length; i += 2) {
+                String role = tokens[i];
+                if (i + 1 >= tokens.length) {
+                    throw new IllegalArgumentException("Unable to parse permissions string, which must be a comma-separated " +
+                        "list of role names and capabilities - i.e. role1,read,role2,update,role3,execute; string: " + permissionsString);
+                }
+                DocumentMetadataHandle.Capability c;
+                try {
+                    c = DocumentMetadataHandle.Capability.getValueOf(tokens[i + 1]);
+                } catch (Exception e) {
+                    throw new IllegalArgumentException("Unable to parse permissions string: " + permissionsString + "; cause: " + e.getMessage());
+                }
+                if (permissions.containsKey(role)) {
+                    permissions.get(role).add(c);
+                } else {
+                    permissions.add(role, c);
+                }
+            }
+        }
+        return this;
+    }
+
+    DocBuilderFactory withSimpleUriStrategy(String prefix, String suffix) {
+        this.uriMaker = contentHandle -> {
+            String uri = "";
+            if (prefix != null) {
+                uri += prefix;
+            }
+            uri += UUID.randomUUID().toString();
+            return suffix != null ? uri + suffix : uri;
+        };
+        return this;
+    }
+}

--- a/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
+++ b/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
@@ -33,7 +33,10 @@ public class AbstractIntegrationTest extends AbstractSpringMarkLogicTest {
 
     @Override
     protected String getJavascriptForDeletingDocumentsBeforeTestRuns() {
-        return "declareUpdate(); xdmp.collectionDelete('my-test-data')";
+        return "declareUpdate(); " +
+            "for (var uri of cts.uris(null, null, cts.notQuery(cts.collectionQuery('test-config')))) {" +
+            "  xdmp.documentDelete(uri);" +
+            "}";
     }
 
     protected SparkSession newSparkSession() {

--- a/src/test/java/com/marklogic/spark/writer/AbstractWriteTest.java
+++ b/src/test/java/com/marklogic/spark/writer/AbstractWriteTest.java
@@ -1,0 +1,47 @@
+package com.marklogic.spark.writer;
+
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.DataFrameWriter;
+import org.apache.spark.sql.SaveMode;
+
+abstract class AbstractWriteTest extends AbstractIntegrationTest {
+
+    protected final static String COLLECTION = "write-test";
+
+    protected DataFrameWriter newWriter() {
+        return newWriter(1);
+    }
+
+    protected DataFrameWriter newWriterForSingleRow() {
+        return newWriterWithDefaultConfig("temporal-data.csv", 1);
+    }
+
+    protected DataFrameWriter newWriter(int partitionCount) {
+        return newWriterWithDefaultConfig("data.csv", partitionCount);
+    }
+
+    protected DataFrameWriter newWriterWithDefaultConfig(String csvFilename, int partitionCount) {
+        return newWriterWithoutDocumentConfig(csvFilename, partitionCount)
+            .option(Options.WRITE_COLLECTIONS, COLLECTION)
+            .option(Options.WRITE_PERMISSIONS, "spark-user-role,read,spark-user-role,update")
+            .option(Options.WRITE_URI_PREFIX, "/test/")
+            .option(Options.WRITE_URI_SUFFIX, ".json");
+    }
+
+    protected DataFrameWriter newWriterWithoutDocumentConfig(String csvFilename, int partitionCount) {
+        return newSparkSession().read()
+            .option("header", true)
+            .format("csv")
+            .csv("src/test/resources/" + csvFilename)
+            .repartition(partitionCount)
+            .write()
+            .format("com.marklogic.spark")
+            .mode(SaveMode.Append)
+            .option("spark.marklogic.client.host", testConfig.getHost())
+            .option("spark.marklogic.client.port", testConfig.getRestPort())
+            .option("spark.marklogic.client.username", "spark-test-user")
+            .option("spark.marklogic.client.password", "spark")
+            .option("spark.marklogic.client.authType", "digest");
+    }
+}

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsWithTransformTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsWithTransformTest.java
@@ -1,0 +1,107 @@
+package com.marklogic.spark.writer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.junit5.MarkLogicNamespaceProvider;
+import com.marklogic.junit5.NamespaceProvider;
+import com.marklogic.junit5.XmlNode;
+import com.marklogic.spark.Options;
+import org.apache.spark.SparkException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WriteRowsWithTransformTest extends AbstractWriteTest {
+
+    @Override
+    protected NamespaceProvider getNamespaceProvider() {
+        // Overridden so XmlNode can be used below with the basic JSON namespace.
+        return new MarkLogicNamespaceProvider(
+            "jb", "http://marklogic.com/xdmp/json/basic"
+        );
+    }
+
+    /**
+     * This also verifies that a user can write XML documents without support from the connector. The user can use a
+     * REST transform to convert the JSON representation of a Spark row into whatever XML document they want, along with
+     * giving it a more meaningful suffix of ".xml".
+     */
+    @Test
+    void transformToXml() {
+        newWriterForSingleRow()
+            .option(Options.WRITE_TRANSFORM_NAME, "transformToXml")
+            // Surprisingly, the REST API is fine with writing an XML document with a suffix of ".json". But making this
+            // a more realistic scenario, as a user would almost certainly want ".xml" instead.
+            .option(Options.WRITE_URI_SUFFIX, ".xml")
+            .save();
+
+        String uri = getUrisInCollection(COLLECTION, 1).get(0);
+        assertTrue(uri.endsWith(".xml"), "Unexpected URI: " + uri);
+
+        XmlNode doc = readXmlDocument(uri);
+        String message = "Verifying that one XML element exists, which is sufficient for knowing that the " +
+            "JSON sent from the Spark connector was successfully converted into XML";
+        doc.assertElementValue(message, "/jb:json/jb:content", "hello world");
+    }
+
+    @Test
+    void withParams() {
+        newWriterForSingleRow()
+            .option(Options.WRITE_TRANSFORM_NAME, "withParams")
+            .option(Options.WRITE_TRANSFORM_PARAMS, "param1,value1,param2,value2")
+            .save();
+
+        String uri = getUrisInCollection(COLLECTION, 1).get(0);
+        JsonNode doc = readJsonDocument(uri);
+        assertTrue(doc.has("params"), "Expected the withParams transform to toss all the params into the document");
+        assertEquals("value1", doc.get("params").get("param1").asText());
+        assertEquals("value2", doc.get("params").get("param2").asText());
+    }
+
+    @Test
+    void withParamsAndCustomDelimiter() {
+        newWriterForSingleRow()
+            .option(Options.WRITE_TRANSFORM_NAME, "withParams")
+            .option(Options.WRITE_TRANSFORM_PARAMS, "param1;value,1;param2;value,2")
+            .option(Options.WRITE_TRANSFORM_PARAMS_DELIMITER, ";")
+            .save();
+
+        String uri = getUrisInCollection(COLLECTION, 1).get(0);
+        JsonNode doc = readJsonDocument(uri);
+        assertTrue(doc.has("params"), "Expected the withParams transform to toss all the params into the document");
+        assertEquals("value,1", doc.get("params").get("param1").asText());
+        assertEquals("value,2", doc.get("params").get("param2").asText());
+    }
+
+    @Test
+    void invalidTransform() {
+        SparkException ex = assertThrows(SparkException.class,
+            () -> newWriterForSingleRow()
+                .option(Options.WRITE_TRANSFORM_NAME, "this-doesnt-exist")
+                .save());
+
+        assertTrue(ex.getCause() instanceof IOException);
+        assertTrue(ex.getCause().getMessage().contains("Extension this-doesnt-exist or a dependency does not exist"),
+            "The connector can't easily validate that a REST transform is valid, but the expectation is that the " +
+                "error message from the REST API will make the problem evident to the user; " +
+                "unexpected message: " + ex.getCause().getMessage());
+    }
+
+    @Test
+    void invalidTransformParams() {
+        SparkException ex = assertThrows(SparkException.class,
+            () -> newWriterForSingleRow()
+                .option(Options.WRITE_TRANSFORM_NAME, "withParams")
+                .option(Options.WRITE_TRANSFORM_PARAMS, "param1,value1,param2")
+                .save());
+
+        assertTrue(ex.getCause() instanceof IllegalArgumentException);
+        assertEquals(
+            "The spark.marklogic.write.transformParams option must contain an equal number of parameter names and values; received: param1,value1,param2",
+            ex.getCause().getMessage()
+        );
+    }
+}

--- a/src/test/ml-config/temporal/axes/temporal-system-axis.json
+++ b/src/test/ml-config/temporal/axes/temporal-system-axis.json
@@ -1,0 +1,15 @@
+{
+	"axis-name": "system",
+	"axis-start": {
+		"element-reference": {
+			"namespace-uri": "",
+			"localname": "systemStart"
+		}
+	},
+	"axis-end": {
+		"element-reference": {
+			"namespace-uri": "",
+			"localname": "systemEnd"
+		}
+	}
+}

--- a/src/test/ml-config/temporal/axes/temporal-valid-axis.json
+++ b/src/test/ml-config/temporal/axes/temporal-valid-axis.json
@@ -1,0 +1,15 @@
+{
+	"axis-name": "valid",
+	"axis-start": {
+		"element-reference": {
+			"namespace-uri": "",
+			"localname": "validStart"
+		}
+	},
+	"axis-end": {
+		"element-reference": {
+			"namespace-uri": "",
+			"localname": "validEnd"
+		}
+	}
+}

--- a/src/test/ml-config/temporal/collections/temporal-collection.json
+++ b/src/test/ml-config/temporal/collections/temporal-collection.json
@@ -1,0 +1,8 @@
+{
+  "collection-name": "temporal-collection",
+  "system-axis": "system",
+  "valid-axis": "valid",
+  "option": [
+    "updates-admin-override"
+  ]
+}

--- a/src/test/ml-data/collections.properties
+++ b/src/test/ml-data/collections.properties
@@ -1,0 +1,1 @@
+*=test-config

--- a/src/test/ml-modules/transforms/transformToXml.xqy
+++ b/src/test/ml-modules/transforms/transformToXml.xqy
@@ -1,0 +1,16 @@
+xquery version "1.0-ml";
+
+module namespace transform = "http://marklogic.com/rest-api/transform/transformToXml";
+
+import module namespace json="http://marklogic.com/xdmp/json" at "/MarkLogic/json/json.xqy";
+
+declare function transform(
+  $context as map:map,
+  $params as map:map,
+  $content as document-node()
+  ) as document-node()
+{
+  document {
+    json:transform-from-json($content)
+  }
+};

--- a/src/test/ml-modules/transforms/withParams.sjs
+++ b/src/test/ml-modules/transforms/withParams.sjs
@@ -1,0 +1,9 @@
+function transform(context, params, content)
+{
+  return {
+    "content": content,
+    "params": params,
+    "context": context
+  }
+};
+exports.transform = transform;

--- a/src/test/resources/temporal-data.csv
+++ b/src/test/resources/temporal-data.csv
@@ -1,0 +1,2 @@
+content,systemStart,systemEnd,validStart,validEnd
+hello world,2014-04-03T11:00:00,2014-04-03T16:00:00,2014-04-03T11:00:00,2014-04-03T16:00:00


### PR DESCRIPTION
Had to add temporal config to the test app so we can test temporal stuff, so that added several new files. 

Also modified the docker-compose stuff so that 8015 can be used during mlDeploy in order to deploy the REST transforms.