### PR TITLE
DEVEXP-451 Can now use readStream

### DIFF
--- a/docs/getting-started-pyspark.md
+++ b/docs/getting-started-pyspark.md
@@ -87,6 +87,14 @@ a similar mechanism for including third party connectors; please see the documen
 environment. In the example above, the `--jars` option allows for the MarkLogic Spark connector to be used within 
 PySpark. 
 
+When PySpark starts, you should see information like this on how to configure logging:
+
+    Setting default log level to "WARN".
+    To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
+
+Setting the default log level to "INFO" or "DEBUG" will show logging from the MarkLogic Spark connector. This will also
+include potentially significant amounts of log messages from PySpark itself. 
+
 ### Reading data with the connector
 
 The connector reads data from MarkLogic as rows to construct a Spark DataFrame. To see this in action, 

--- a/src/main/java/com/marklogic/spark/ContextSupport.java
+++ b/src/main/java/com/marklogic/spark/ContextSupport.java
@@ -20,7 +20,12 @@ public class ContextSupport implements Serializable {
 
     public DatabaseClient connectToMarkLogic() {
         Map<String, String> connectionProps = buildConnectionProperties();
-        DatabaseClient client = DatabaseClientFactory.newClient(propertyName -> connectionProps.get("spark." + propertyName));
+        DatabaseClient client;
+        try {
+            client = DatabaseClientFactory.newClient(propertyName -> connectionProps.get("spark." + propertyName));
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("Unable to connect to MarkLogic; cause: %s", e.getMessage()), e);
+        }
         DatabaseClient.ConnectionResult result = client.checkConnection();
         if (!result.isConnected()) {
             throw new RuntimeException(String.format("Unable to connect to MarkLogic; status code: %d; error message: %s", result.getStatusCode(), result.getErrorMessage()));

--- a/src/main/java/com/marklogic/spark/MarkLogicTable.java
+++ b/src/main/java/com/marklogic/spark/MarkLogicTable.java
@@ -40,6 +40,7 @@ public class MarkLogicTable implements SupportsRead, SupportsWrite {
     static {
         capabilities = new HashSet<>();
         capabilities.add(TableCapability.BATCH_READ);
+        capabilities.add(TableCapability.MICRO_BATCH_READ);
         capabilities.add(TableCapability.BATCH_WRITE);
         capabilities.add(TableCapability.STREAMING_WRITE);
     }

--- a/src/main/java/com/marklogic/spark/reader/MarkLogicMicroBatchStream.java
+++ b/src/main/java/com/marklogic/spark/reader/MarkLogicMicroBatchStream.java
@@ -1,0 +1,88 @@
+package com.marklogic.spark.reader;
+
+import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
+import org.apache.spark.sql.connector.read.streaming.Offset;
+import org.apache.spark.sql.execution.streaming.LongOffset;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Interprets a "micro batch" as a bucket. This gives the user control over how many micro batches will be created, as
+ * the user can adjust the number of partitions and the batch size to affect how many buckets are created.
+ * <p>
+ * Within the scope of this class, an offset is equivalent to an index in the list of all buckets across all partitions
+ * present in the {@code PlanAnalysis}. Each bucket is defined by lower/upper row ID bounds. So to refer to a bucket,
+ * we simply need to know the index of the bucket in the list of all buckets. And thus, an offset is simply the index of
+ * a bucket in that list.
+ */
+class MarkLogicMicroBatchStream implements MicroBatchStream {
+
+    private final static Logger logger = LoggerFactory.getLogger(MarkLogicMicroBatchStream.class);
+
+    private ReadContext readContext;
+    private List<PlanAnalysis.Bucket> allBuckets;
+    private int bucketIndex;
+
+    MarkLogicMicroBatchStream(ReadContext readContext) {
+        this.readContext = readContext;
+        this.allBuckets = this.readContext.getPlanAnalysis().getAllBuckets();
+    }
+
+    @Override
+    public Offset latestOffset() {
+        if (bucketIndex >= this.allBuckets.size()) {
+            return null;
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("Returning latest offset: {}", bucketIndex);
+        }
+        return new LongOffset(bucketIndex++);
+    }
+
+    /**
+     * The offset is treated as the index of a bucket in the list of buckets. Thus, the concept of "start" and "end"
+     * isn't relevant here - just the "end" offset is needed, which identifies the next bucket to process.
+     *
+     * @param start
+     * @param end
+     * @return
+     */
+    @Override
+    public InputPartition[] planInputPartitions(Offset start, Offset end) {
+        int index = (int) ((LongOffset) end).offset();
+        return index >= allBuckets.size() ?
+            null :
+            new InputPartition[]{new PlanAnalysis.Partition(index, allBuckets.get(index))};
+    }
+
+    @Override
+    public PartitionReaderFactory createReaderFactory() {
+        return new MarkLogicPartitionReaderFactory(this.readContext);
+    }
+
+    @Override
+    public Offset initialOffset() {
+        return new LongOffset(0);
+    }
+
+    @Override
+    public Offset deserializeOffset(String json) {
+        return new LongOffset(Long.parseLong(json));
+    }
+
+    @Override
+    public void commit(Offset end) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Committing offset: {}", end);
+        }
+    }
+
+    @Override
+    public void stop() {
+        logger.info("Stopping");
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/MarkLogicScan.java
+++ b/src/main/java/com/marklogic/spark/reader/MarkLogicScan.java
@@ -18,6 +18,7 @@ package com.marklogic.spark.reader;
 
 import org.apache.spark.sql.connector.read.Batch;
 import org.apache.spark.sql.connector.read.Scan;
+import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
 import org.apache.spark.sql.types.StructType;
 
 class MarkLogicScan implements Scan {
@@ -41,5 +42,10 @@ class MarkLogicScan implements Scan {
     @Override
     public Batch toBatch() {
         return new MarkLogicBatch(readContext);
+    }
+
+    @Override
+    public MicroBatchStream toMicroBatchStream(String checkpointLocation) {
+        return new MarkLogicMicroBatchStream(readContext);
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/PlanAnalysis.java
+++ b/src/main/java/com/marklogic/spark/reader/PlanAnalysis.java
@@ -20,6 +20,7 @@ import org.apache.spark.sql.connector.read.InputPartition;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -80,6 +81,18 @@ class PlanAnalysis implements Serializable {
                 buckets.add(new Bucket(lowerBoundStr, upperBoundStr));
                 nextLowerBound = nextLowerBound + bucketSize + 1;
             }
+        }
+
+        /**
+         * For micro-batch reading, where each Spark task is intended to process a single bucket, and thus each
+         * partition should contain a single bucket.
+         *
+         * @param bucketIndex
+         * @param bucket
+         */
+        Partition(int bucketIndex, Bucket bucket) {
+            this.identifier = bucketIndex + "";
+            this.buckets = Arrays.asList(bucket);
         }
 
         @Override

--- a/src/main/java/com/marklogic/spark/reader/ReadContext.java
+++ b/src/main/java/com/marklogic/spark/reader/ReadContext.java
@@ -69,7 +69,9 @@ public class ReadContext extends ContextSupport {
             SparkSession.active().sparkContext().defaultMinPartitions(), 1);
         final long batchSize = getNumericOption(ReadConstants.BATCH_SIZE, DEFAULT_BATCH_SIZE, 0);
         final String dslQuery = properties.get(ReadConstants.OPTIC_DSL);
-
+        if (dslQuery == null || dslQuery.trim().length() < 1) {
+            throw new IllegalArgumentException(String.format("No Optic query found; must define %s", ReadConstants.OPTIC_DSL));
+        }
         DatabaseClient client = connectToMarkLogic();
         RawQueryDSLPlan dslPlan = client.newRowManager().newRawQueryDSLPlan(new StringHandle(dslQuery));
 

--- a/src/test/java/com/marklogic/spark/reader/ReadStreamOfRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/ReadStreamOfRowsTest.java
@@ -1,0 +1,81 @@
+package com.marklogic.spark.reader;
+
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ReadStreamOfRowsTest extends AbstractIntegrationTest {
+
+    @Test
+    void readAndWriteMicroBatches(@TempDir Path tempDir) throws Exception {
+        newSparkSession()
+            .readStream()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            // With 3 partitions, the logging will show 3 queries to MarkLogic with a "write" occurring after each one.
+            .option(ReadConstants.NUM_PARTITIONS, 3)
+            .option(ReadConstants.OPTIC_DSL, "op.fromView('Medical','Authors')")
+            .load()
+            .writeStream()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.WRITE_COLLECTIONS, "output")
+            .option(Options.WRITE_PERMISSIONS, "spark-user-role,read,spark-user-role,update")
+            .option(Options.WRITE_URI_PREFIX, "/output/")
+            .option("checkpointLocation", tempDir.toFile().getAbsolutePath())
+            .start()
+            .processAllAvailable();
+
+        assertCollectionSize("output", 15);
+    }
+
+    @Test
+    void readAndWriteStreamToMemory(@TempDir Path tempDir) throws Exception {
+        AtomicInteger microBatchCounter = new AtomicInteger();
+        AtomicLong rowCount = new AtomicLong();
+
+        newSparkSession()
+            .readStream()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(ReadConstants.NUM_PARTITIONS, 2)
+            .option(ReadConstants.OPTIC_DSL, "op.fromView('Medical','Authors')")
+            .load()
+            .writeStream()
+            .format("memory")
+            .option("queryName", "anything works here")
+            .foreachBatch((dataset, batchId) -> {
+                rowCount.addAndGet(dataset.count());
+                microBatchCounter.incrementAndGet();
+            })
+            .start()
+            .processAllAvailable();
+
+        assertEquals(15, rowCount.get());
+        assertEquals(2, microBatchCounter.get(), "Expecting 2 micro batches, as 2 buckets should have been created " +
+            "based on the partition count and batch size (there is a small chance that every row ended up in one " +
+            "bucket, but that should be extremely rare).");
+    }
+
+    @Test
+    void readWithNoQuery() {
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> newSparkSession()
+                .readStream()
+                .format(CONNECTOR_IDENTIFIER)
+                .option(Options.CLIENT_URI, makeClientUri())
+                .load()
+        );
+
+        assertEquals("No Optic query found; must define spark.marklogic.read.opticDsl", ex.getMessage());
+    }
+}

--- a/src/test/java/com/marklogic/spark/reader/ReadWithClientUriTest.java
+++ b/src/test/java/com/marklogic/spark/reader/ReadWithClientUriTest.java
@@ -75,7 +75,7 @@ public class ReadWithClientUriTest extends AbstractIntegrationTest {
     private List<Row> readRowsWithClientUri(String clientUri) {
         return newSparkSession()
             .read()
-            .format("com.marklogic.spark")
+            .format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, clientUri)
             .option(ReadConstants.OPTIC_DSL, "op.fromView('Medical','Authors')")
             .load()

--- a/src/test/java/com/marklogic/spark/writer/AbstractWriteTest.java
+++ b/src/test/java/com/marklogic/spark/writer/AbstractWriteTest.java
@@ -36,7 +36,7 @@ abstract class AbstractWriteTest extends AbstractIntegrationTest {
             .csv("src/test/resources/" + csvFilename)
             .repartition(partitionCount)
             .write()
-            .format("com.marklogic.spark")
+            .format(CONNECTOR_IDENTIFIER)
             .mode(SaveMode.Append)
             .option("spark.marklogic.client.host", testConfig.getHost())
             .option("spark.marklogic.client.port", testConfig.getRestPort())

--- a/src/test/java/com/marklogic/spark/writer/StreamRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/StreamRowsTest.java
@@ -76,12 +76,9 @@ public class StreamRowsTest extends AbstractIntegrationTest {
             .format("csv")
             .load("src/test/resources/inputForStream")
             .writeStream()
-            .format("com.marklogic.spark")
+            .format(CONNECTOR_IDENTIFIER)
             .option("checkpointLocation", tempDir.toFile().getAbsolutePath())
-            .option("spark.marklogic.client.host", testConfig.getHost())
-            .option("spark.marklogic.client.port", testConfig.getRestPort())
-            .option("spark.marklogic.client.username", TEST_USERNAME)
-            .option("spark.marklogic.client.password", TEST_PASSWORD)
+            .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.WRITE_PERMISSIONS, "rest-extension-user,read,rest-writer,update");
     }
 

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
@@ -133,6 +133,20 @@ public class WriteRowsTest extends AbstractWriteTest {
         verifyFailureIsDueToLackOfPermission(ex);
     }
 
+    @Test
+    void invalidPassword() {
+        SparkException ex = assertThrows(SparkException.class,
+            () -> newWriter()
+                .option(Options.CLIENT_URI, "spark-test-user:wrong-password@" + testConfig.getHost() + ":" + testConfig.getRestPort())
+                .save()
+        );
+
+        assertTrue(ex.getCause() instanceof RuntimeException, "Expecting a RuntimeException due to the invalid " +
+            "credentials; unexpected cause: " + ex.getCause());
+
+        assertEquals("Unable to connect to MarkLogic; status code: 401; error message: Unauthorized", ex.getCause().getMessage());
+    }
+
     /**
      * Uses a batch size of 1 to ensure that the write() method in the data writer should fail, as each write() call
      * should result in a request to MarkLogic, which should cause a failure before commit() is called.


### PR DESCRIPTION
Most of the new stuff is in the new `MarkLogicMicroBatchStream` class, which uses a bucket index as an offset.