### PR TITLE
DEVEXP-459 Now using the latest server timestamp on each separate query

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/MarkLogicBatch.java
+++ b/src/main/java/com/marklogic/spark/reader/MarkLogicBatch.java
@@ -18,8 +18,12 @@ package com.marklogic.spark.reader;
 import org.apache.spark.sql.connector.read.Batch;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class MarkLogicBatch implements Batch {
+
+    private final static Logger logger = LoggerFactory.getLogger(MarkLogicBatch.class);
 
     private final ReadContext readContext;
 
@@ -37,6 +41,9 @@ class MarkLogicBatch implements Batch {
 
     @Override
     public PartitionReaderFactory createReaderFactory() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Creating new partition reader factory");
+        }
         return new MarkLogicPartitionReaderFactory(readContext);
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/MarkLogicPartitionReader.java
+++ b/src/main/java/com/marklogic/spark/reader/MarkLogicPartitionReader.java
@@ -18,9 +18,9 @@ package com.marklogic.spark.reader;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.spark.Util;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -53,7 +53,7 @@ class MarkLogicPartitionReader implements PartitionReader {
     private final Function2<JsonFactory, String, JsonParser> jsonParserCreator;
     private final Function1<String, UTF8String> utf8StringCreator;
 
-    private Iterator<StringHandle> rowIterator;
+    private Iterator<JsonNode> rowIterator;
     private int nextBucketIndex;
     private int currentBucketRowCount;
 
@@ -117,8 +117,8 @@ class MarkLogicPartitionReader implements PartitionReader {
     public InternalRow get() {
         this.currentBucketRowCount++;
         this.totalRowCount++;
-        String row = rowIterator.next().get();
-        return this.jacksonParser.parse(row, this.jsonParserCreator, this.utf8StringCreator).head();
+        JsonNode row = rowIterator.next();
+        return this.jacksonParser.parse(row.toString(), this.jsonParserCreator, this.utf8StringCreator).head();
     }
 
     @Override

--- a/src/main/java/com/marklogic/spark/reader/MarkLogicScan.java
+++ b/src/main/java/com/marklogic/spark/reader/MarkLogicScan.java
@@ -20,8 +20,12 @@ import org.apache.spark.sql.connector.read.Batch;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
 import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class MarkLogicScan implements Scan {
+
+    private final static Logger logger = LoggerFactory.getLogger(MarkLogicScan.class);
 
     private ReadContext readContext;
 
@@ -41,6 +45,9 @@ class MarkLogicScan implements Scan {
 
     @Override
     public Batch toBatch() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Creating new batch");
+        }
         return new MarkLogicBatch(readContext);
     }
 

--- a/src/main/java/com/marklogic/spark/reader/MarkLogicScanBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/MarkLogicScanBuilder.java
@@ -17,8 +17,12 @@ package com.marklogic.spark.reader;
 
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MarkLogicScanBuilder implements ScanBuilder {
+
+    private final static Logger logger = LoggerFactory.getLogger(MarkLogicScanBuilder.class);
 
     private ReadContext readContext;
 
@@ -28,6 +32,9 @@ public class MarkLogicScanBuilder implements ScanBuilder {
 
     @Override
     public Scan build() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Creating new scan");
+        }
         return new MarkLogicScan(readContext);
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/SchemaInferrer.java
+++ b/src/main/java/com/marklogic/spark/reader/SchemaInferrer.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Map;
 
-abstract class SchemaInferrer {
+public abstract class SchemaInferrer {
 
     private final static Logger logger = LoggerFactory.getLogger(SchemaInferrer.class);
     private final static ObjectMapper objectMapper = new ObjectMapper();
@@ -51,7 +51,7 @@ abstract class SchemaInferrer {
      *                           returns a String of newline-delimited JSON objects
      * @return
      */
-    static StructType inferSchema(String columnInfoResponse) {
+    public static StructType inferSchema(String columnInfoResponse) {
         StructType schema = new StructType();
         for (String columnInfo : columnInfoResponse.split("\n")) {
             try {

--- a/src/test/java/com/marklogic/spark/reader/ReadRowsMultipleTimesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/ReadRowsMultipleTimesTest.java
@@ -1,0 +1,51 @@
+package com.marklogic.spark.reader;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ReadRowsMultipleTimesTest extends AbstractIntegrationTest {
+
+    /**
+     * Log statements are included here so it's easy to see what classes get created based on different Spark API calls.
+     */
+    @Test
+    void twoReadsWithInsertInBetween() throws Exception {
+        logger.info("Creating reader");
+        Dataset<Row> dataset = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, "op.fromView('sparkTest', 'allTypes')")
+            .option(Options.READ_NUM_PARTITIONS, 1)
+            .option(Options.READ_BATCH_SIZE, 0)
+            .load();
+
+        logger.info("Calling count() the first time");
+        assertEquals(3, dataset.count());
+
+        insertDocThatProjectsASecondRow();
+
+        logger.info("Calling count() the second time");
+        assertEquals(4, dataset.count(), "Because a 'load' in Spark doesn't actually load data, the " +
+            "user expectation is that when a Spark function is called that does force data to be loaded, the " +
+            "data should be loaded from MarkLogic at that particular timestamp, not when the dataset was first " +
+            "created.");
+
+        logger.info("Finished with test");
+    }
+
+    private void insertDocThatProjectsASecondRow() {
+        ObjectNode doc = new ObjectMapper().createObjectNode();
+        doc.putArray("allTypes").addObject().put("intValue", 10);
+        getDatabaseClient().newJSONDocumentManager().write("/allTypes2.json",
+            new DocumentMetadataHandle().withPermission("spark-user-role", DocumentMetadataHandle.Capability.READ,
+                DocumentMetadataHandle.Capability.UPDATE),
+            new JacksonHandle(doc));
+    }
+}


### PR DESCRIPTION
The primary change is that `ReadContext` is now created in the scan builder instead of in `DefaultSource`. This ensures a new one is created each time the user queries for data. 

Added some debug logging so it's easy to see when certain  objects are created. 

Also switched from `resultRows` to `resultDoc`. Going to create a bug for the Java Client as `resultRows` ignores server timestamp as an input.