### PR TITLE
DEVEXP-462 Now pushing down orderBy, limit, and offset

### DIFF
--- a/docs/reading.md
+++ b/docs/reading.md
@@ -37,6 +37,23 @@ df = spark.read.format("com.marklogic.spark") \
     .load()
 ```
 
+## Pushing down operations
+
+The Spark connector framework supports pushing down multiple operations to the connector data source. This can 
+often provide a significant performance boost by allowing the data source to perform the operation, which can result in 
+both fewer rows returned to Spark and less work for Spark to perform. The MarkLogic Spark connector supports pushing 
+down the following operations to MarkLogic:
+
+- `filter` and `where`
+- `orderBy`
+- `limit`
+- `offset`
+
+For each of the above operations, the Optic pipeline associated with the user's Optic DSL query is modified to include
+the associated Optic function. Note that if multiple partitions are used to perform the `read` operation, each 
+partition will apply the above functions on the rows that it retrieves from MarkLogic. Spark will then merge the results
+from each partition and re-apply the function calls as necessary to ensure that the correct response is returned.
+
 ## Streaming support
 
 The MarkLogic Spark connector supports

--- a/src/test/java/com/marklogic/spark/reader/AbstractPushDownTest.java
+++ b/src/test/java/com/marklogic/spark/reader/AbstractPushDownTest.java
@@ -1,0 +1,37 @@
+package com.marklogic.spark.reader;
+
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.BeforeEach;
+
+abstract class AbstractPushDownTest extends AbstractIntegrationTest {
+
+    final static String QUERY_WITH_NO_QUALIFIER = "op.fromView('Medical', 'Authors', '')";
+    final static String QUERY_ORDERED_BY_CITATION_ID = "op.fromView('Medical', 'Authors', '').orderBy(op.col('CitationID'))";
+
+    long countOfRowsReadFromMarkLogic;
+
+    @BeforeEach
+    void setup() {
+        // This is used to track how many rows were read from MarkLogic. It's used to ensure that the filtering is
+        // correctly pushed down to MarkLogic as opposed to being handled by Spark, which should make operations
+        // faster as MarkLogic is returning fewer rows. A synchronized method is used in case the test uses multiple
+        // partitions, as each will run on a separate thread.
+        MarkLogicPartitionReader.totalRowCountListener = totalRowCount -> addToRowCount(totalRowCount);
+    }
+
+    private synchronized void addToRowCount(long totalRowCount) {
+        countOfRowsReadFromMarkLogic += totalRowCount;
+    }
+
+    protected Dataset<Row> newDatasetOrderedByCitationIDWithOneBucket() {
+        return newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, QUERY_ORDERED_BY_CITATION_ID)
+            .option(Options.READ_NUM_PARTITIONS, 1)
+            .option(Options.READ_BATCH_SIZE, 0)
+            .load();
+    }
+
+}

--- a/src/test/java/com/marklogic/spark/reader/PushDownFilterTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownFilterTest.java
@@ -1,30 +1,16 @@
 package com.marklogic.spark.reader;
 
-import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class PushDownFilterTest extends AbstractIntegrationTest {
-
-    private final static String QUERY_WITH_NO_QUALIFIER = "op.fromView('Medical', 'Authors', '')";
-
-    private long countOfRowsReadFromMarkLogic;
-
-    @BeforeEach
-    void setup() {
-        // This is used to track how many rows were read from MarkLogic. It's used to ensure that the filtering is
-        // correctly pushed down to MarkLogic as opposed to being handled by Spark, which should make operations
-        // faster as MarkLogic is returning fewer rows.
-        MarkLogicPartitionReader.totalRowCountListener = totalRowCount -> this.countOfRowsReadFromMarkLogic += totalRowCount;
-    }
+public class PushDownFilterTest extends AbstractPushDownTest {
 
     /**
      * equalTo has several tests to verify that filter/where work the same (or at least appear to) and they can be

--- a/src/test/java/com/marklogic/spark/reader/PushDownOffsetTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownOffsetTest.java
@@ -1,0 +1,62 @@
+package com.marklogic.spark.reader;
+
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PushDownOffsetTest extends AbstractPushDownTest {
+
+    @Test
+    void offset() {
+        List<Row> rows = newDatasetOrderedByCitationIDWithOneBucket()
+            .filter("CitationID > 1")
+            .offset(4)
+            .collectAsList();
+
+        assertEquals(7, rows.size(),
+            "Expecting the 4 authors with CitationID=3; then the 1 with CitationID=4; then the 2 with CitationID=5");
+        assertEquals(7, countOfRowsReadFromMarkLogic);
+    }
+
+    @Test
+    void limitBeforeOffset() {
+        List<Row> rows = newDatasetOrderedByCitationIDWithOneBucket()
+            // Filter has to be before offset, otherwise Spark doesn't push it down. Spark will still apply the filter,
+            // but the connector never hears about it.
+            .filter("CitationID > 1")
+            .limit(8)
+            .offset(4)
+            .collectAsList();
+
+        verifyTheFourAuthorsWithCitationIDOfThreeWereReturned(rows);
+    }
+
+    @Test
+    void offsetBeforeLimit() {
+        List<Row> rows = newDatasetOrderedByCitationIDWithOneBucket()
+            .filter("CitationID > 1")
+            // Setting offset before limit seems like the more natural way to express the goal of "I want rows 5
+            // through 8" - i.e. skip the first 4 rows, and then give me the next 4. Under the hood, Spark actually
+            // passes a limit of 8 to the connector though, since Spark thinks in terms of "I'll first express
+            // the total number of rows to be retrieved, and then the offset within that range, and I should only get
+            // those rows".
+            .offset(4)
+            .limit(4)
+            .collectAsList();
+
+        verifyTheFourAuthorsWithCitationIDOfThreeWereReturned(rows);
+    }
+
+    private void verifyTheFourAuthorsWithCitationIDOfThreeWereReturned(List<Row> rows) {
+        assertEquals(4, rows.size());
+        rows.forEach(row -> assertEquals(3, (long) row.getAs("CitationID"),
+            "Expecting to get back the 4 authors with CitationID=3, as the 4 authors with CitationID=2 should have " +
+                "been skipped via the offset."));
+        assertEquals(4, countOfRowsReadFromMarkLogic, "Because there's a single bucket, the connector should tell " +
+            "Spark that the pushdown was 'full' and not partial, which means the connector only returns 4 rows and " +
+            "Spark doesn't need to apply the limit itself");
+    }
+}

--- a/src/test/java/com/marklogic/spark/reader/PushDownOrderByAndLimitTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownOrderByAndLimitTest.java
@@ -1,0 +1,149 @@
+package com.marklogic.spark.reader;
+
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PushDownOrderByAndLimitTest extends AbstractPushDownTest {
+
+    @Test
+    void orderByWithOneBucket() {
+        List<Row> rows = newDatasetOrderedByCitationIDWithOneBucket()
+            // No need for a Spark orderBy here as there's a single bucket, so MarkLogic is able to take care of everything.
+            .collectAsList();
+
+        assertEquals(15, rows.size());
+        verifyRowsAreOrderedByCitationID(rows);
+    }
+
+    @Test
+    void orderByWithTwoPartitions() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, QUERY_ORDERED_BY_CITATION_ID)
+            .option(Options.READ_NUM_PARTITIONS, 2)
+            .option(Options.READ_BATCH_SIZE, 0)
+            .load()
+            // With 2+ partitions, the rows from each partition reader will be ordered correctly by MarkLogic, but
+            // Spark needs to order the merged result. So Spark's orderBy must be called. Interestingly, since no
+            // limit was set, Spark won't push down the orderBy call here. So the orderBy in the Optic query isn't
+            // actually needed since Spark has to do the ordering regardless. Whether including the orderBy in
+            // the Optic query makes the overall process faster or slower would need to be verified via testing for
+            // any particular dataset and query.
+            .orderBy("CitationID")
+            .collectAsList();
+
+        assertEquals(15, rows.size());
+        verifyRowsAreOrderedByCitationID(rows);
+    }
+
+    @Test
+    void limitWithOnePartition() {
+        long count = newDefaultReader()
+            .option(Options.READ_NUM_PARTITIONS, 1)
+            .option(Options.READ_BATCH_SIZE, 5)
+            .load()
+            .limit(1)
+            .count();
+
+        assertEquals(1, count);
+        assertEquals(1, countOfRowsReadFromMarkLogic, "The batch size of 5 should cause 3 requests to be made to " +
+            "MarkLogic, since there are 15 matching rows. With 1 partition, those 3 requests would be made by the " +
+            "same partition reader. But since the first partition reader will most likely read at least 1 row, " +
+            "Spark will stop calling the partition reader once it gets that 1 row in the first request to " +
+            "MarkLogic. This is also due to the connector telling Spark that the limit is only 'partially' pushed " +
+            "due to more than one bucket existing. That tells Spark that as soon as it has read back 1 row from the " +
+            "reader, it should stop reading any more data, thereby ignoring the other 2 buckets. ");
+    }
+
+    @Test
+    void limitWithTwoPartitions() {
+        long count = newDefaultReader()
+            .option(Options.READ_NUM_PARTITIONS, 2)
+            .option(Options.READ_BATCH_SIZE, 0)
+            .load()
+            .limit(1)
+            .count();
+        assertEquals(1, count);
+        assertEquals(2, countOfRowsReadFromMarkLogic, "This test is intended to show that when 'limit' is used with " +
+            "2 or more partitions, the limit will be applied to each partition reader. And that will result in more " +
+            "rows than 'limit' being read from MarkLogic. Spark will still apply the 'limit' and only return 1 row " +
+            "to the user, but the call won't be quite as efficient since more rows are being read than desired. Note " +
+            "that there's a slightly chance this test can intermittently fail in the event that all 15 rows are " +
+            "randomly assigned to the same partition.");
+    }
+
+    @Test
+    void limitWithOnePartitionAndOrderBy() {
+        List<Row> rows = newDatasetOrderedByCitationIDWithOneBucket()
+            .limit(6)
+            .collectAsList();
+
+        assertEquals(6, rows.size());
+        assertEquals(6, countOfRowsReadFromMarkLogic, "Because there's only one bucket, only 6 rows should be " +
+            "returned from MarkLogic. And there's no need for the user to call Spark's orderBy, since the single " +
+            "partition will returned ordered rows.");
+
+        verifyRowsAreOrderedByCitationID(rows);
+    }
+
+    @Test
+    void limitWithTwoPartitionsAndOrderBy() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors', '')")
+            .option(Options.READ_NUM_PARTITIONS, 2)
+            .option(Options.READ_BATCH_SIZE, 0)
+            .load()
+            .orderBy("CitationID")
+            .limit(6)
+            .collectAsList();
+
+        assertEquals(6, rows.size());
+        assertTrue(countOfRowsReadFromMarkLogic > 6, "Expecting each partition to read back up to 6 ordered rows, " +
+            "as both the limit and the orderBy should have been pushed down to MarkLogic. Spark is then expected to " +
+            "merge the rows together and re-apply the order/limit so that the user gets the expected response. There " +
+            "is a slight chance this assertion will fail if all 15 author rows are randomly assigned to the same " +
+            "partition. Unexpected count: " + countOfRowsReadFromMarkLogic);
+
+        verifyRowsAreOrderedByCitationID(rows);
+    }
+
+    @Test
+    void limitWithTwoPartitionsAndOrderByLastNameDescending() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors', '')")
+            .option(Options.READ_NUM_PARTITIONS, 2)
+            .option(Options.READ_BATCH_SIZE, 0)
+            .load()
+            .orderBy(new Column("LastName").desc())
+            .limit(3)
+            .collectAsList();
+
+        assertEquals(3, rows.size());
+        assertTrue(countOfRowsReadFromMarkLogic > 3, "Because two partitions were used with a limit of 3, it's " +
+            "expected that each partition reader will read at least 1 row (and up to 3 rows) from MarkLogic. There " +
+            "is a slight chance this assertion will fail if all 15 author rows are randomly assigned to the same " +
+            "partition. Unexpected count: " + countOfRowsReadFromMarkLogic);
+
+        assertEquals("Wooles", rows.get(0).getAs("LastName"));
+        assertEquals("Tonnesen", rows.get(1).getAs("LastName"));
+        assertEquals("Shoebotham", rows.get(2).getAs("LastName"));
+    }
+
+    private void verifyRowsAreOrderedByCitationID(List<Row> rows) {
+        // Lowest known CitationID is 1, so start comparisons against that.
+        long previousValue = 1;
+        for (int i = 0; i < rows.size(); i++) {
+            Row row = rows.get(i);
+            long citationId = row.getLong(0);
+            assertTrue(citationId > previousValue || citationId == previousValue,
+                "Out-of-order row: " + row + "; index: " + i + "; previous value: " + previousValue);
+            previousValue = citationId;
+        }
+    }
+}


### PR DESCRIPTION
Realized that orderBy needs to be done with limit per Spark's `SupportsPushDownTopN` interface. 

All 3 are implemented simply by adding the appropriate operator to the user's serialized Optic plan.