### PR TITLE
authType can now be overridden

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'java'
   id 'net.saliman.properties' version '1.5.2'
   id 'com.github.johnrengelman.shadow' version '7.1.2'
-  id "com.marklogic.ml-gradle" version "4.5.1"
+  id "com.marklogic.ml-gradle" version "4.5.2"
   id 'maven-publish'
 }
 
@@ -30,6 +30,7 @@ dependencies {
   }
 
   testImplementation 'org.apache.spark:spark-sql_2.12:3.4.0'
+  testImplementation 'com.marklogic:ml-app-deployer:4.5.2'
   testImplementation 'com.marklogic:marklogic-junit5:1.3.0'
   testImplementation "ch.qos.logback:logback-classic:1.3.5"
   testImplementation "org.slf4j:jcl-over-slf4j:1.7.36"

--- a/src/main/java/com/marklogic/spark/DefaultSource.java
+++ b/src/main/java/com/marklogic/spark/DefaultSource.java
@@ -46,11 +46,12 @@ public class DefaultSource implements TableProvider {
      */
     @Override
     public StructType inferSchema(CaseInsensitiveStringMap options) {
-        final String query = options.get(Options.READ_OPTIC_DSL);
+        final Map<String, String> caseSensitiveOptions = options.asCaseSensitiveMap();
+        final String query = caseSensitiveOptions.get(Options.READ_OPTIC_DSL);
         if (query == null || query.trim().length() < 1) {
             throw new IllegalArgumentException(String.format("No Optic query found; must define %s", Options.READ_OPTIC_DSL));
         }
-        RowManager rowManager = new ContextSupport(options).connectToMarkLogic().newRowManager();
+        RowManager rowManager = new ContextSupport(caseSensitiveOptions).connectToMarkLogic().newRowManager();
         RawQueryDSLPlan dslPlan = rowManager.newRawQueryDSLPlan(new StringHandle(query));
         try {
             StringHandle columnInfoHandle = rowManager.columnInfo(dslPlan, new StringHandle());

--- a/src/main/java/com/marklogic/spark/MarkLogicTable.java
+++ b/src/main/java/com/marklogic/spark/MarkLogicTable.java
@@ -66,10 +66,10 @@ public class MarkLogicTable implements SupportsRead, SupportsWrite {
     /**
      * We ignore the {@code options} map per the class's Javadocs, which note that it's intended to provide
      * options for v2 implementations which expect case-insensitive keys. The map of properties provided by the
-     * {@code TableProvider} are sufficient for our connector.
+     * {@code TableProvider} are sufficient for our connector, particularly as those keys are case-sensitive, which is
+     * expected by the Java Client's method for creating a client based on case-sensitive property names.
      *
-     * @param options The options for reading, which is an immutable case-insensitive
-     *                string-to-string map.
+     * @param options The options for reading, which is an immutable case-insensitive string-to-string map.
      * @return
      */
     @Override

--- a/src/test/java/com/marklogic/spark/reader/ReadRowsWithBasicAuthTest.java
+++ b/src/test/java/com/marklogic/spark/reader/ReadRowsWithBasicAuthTest.java
@@ -1,0 +1,52 @@
+package com.marklogic.spark.reader;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marklogic.mgmt.ManageClient;
+import com.marklogic.mgmt.ManageConfig;
+import com.marklogic.mgmt.resource.appservers.ServerManager;
+import com.marklogic.spark.AbstractIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ReadRowsWithBasicAuthTest extends AbstractIntegrationTest {
+
+    private com.marklogic.mgmt.ManageClient manageClient;
+
+    @BeforeEach
+    void changeAuthToBasic() {
+        manageClient = new ManageClient(new ManageConfig(testConfig.getHost(), 8002,
+            testConfig.getUsername(), testConfig.getPassword()));
+        setServerAuthentication("basic");
+    }
+
+    @AfterEach
+    void changeAuthToDigest() {
+        setServerAuthentication("digest");
+    }
+
+    /**
+     * Verifies that case-sensitive options, like "authType", work properly. Spark lower-cases options by default, but
+     * makes a case-sensitive version of them available to the connector. This verifies that our connector uses the
+     * case-sensitive version.
+     */
+    @Test
+    void test() {
+        long count = newDefaultReader()
+            .option("spark.marklogic.client.authType", "basic")
+            .load()
+            .count();
+
+        assertEquals(15, count);
+    }
+
+    private void setServerAuthentication(String value) {
+        new ServerManager(manageClient).save(new ObjectMapper().createObjectNode()
+            .put("server-name", "spark-test-test")
+            .put("group-name", "Default")
+            .put("authentication", value)
+            .toString());
+    }
+}


### PR DESCRIPTION
Issue was that the case-insensitive map was used for inferring a schema, which meant that "authType" became "authtype" and was thus ignored by the Java Client.