### PR TITLE
DEVEXP-468 Can now push down required columns

### DIFF
--- a/docs/reading.md
+++ b/docs/reading.md
@@ -18,7 +18,7 @@ adheres to as well.
 
 ## Schema inference
 
-The MarkLogic Spark connector will infer a Spark schema automatically based on the view that is used referenced in 
+The connector will infer a Spark schema automatically based on the view identified by `op.fromView`
 the Optic DSL query. Each column returned by your Optic DSL query will be mapped to a Spark schema column with the 
 same name and an appropriate type. 
 
@@ -41,9 +41,11 @@ df = spark.read.format("com.marklogic.spark") \
 
 The Spark connector framework supports pushing down multiple operations to the connector data source. This can 
 often provide a significant performance boost by allowing the data source to perform the operation, which can result in 
-both fewer rows returned to Spark and less work for Spark to perform. The MarkLogic Spark connector supports pushing 
+both fewer rows returned to Spark and less work for Spark to perform. The connector supports pushing 
 down the following operations to MarkLogic:
 
+- `count`
+- `drop` and `select`
 - `filter` and `where`
 - `orderBy`
 - `limit`
@@ -56,7 +58,7 @@ from each partition and re-apply the function calls as necessary to ensure that 
 
 ## Streaming support
 
-The MarkLogic Spark connector supports
+The connector supports
 [streaming reads](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html) from MarkLogic
 via micro-batches. The connector configuration does not change; instead, different Spark APIs are used to read a 
 stream of data from MarkLogic.
@@ -104,7 +106,7 @@ spark.readStream \
 
 ## Tuning performance
 
-The primary factor affecting how quickly the MarkLogic Spark connector can retrieve rows is MarkLogic's ability to 
+The primary factor affecting how quickly the connector can retrieve rows is MarkLogic's ability to 
 process your Optic DSL query. The 
 [MarkLogic Optic performance documentation](https://docs.marklogic.com/guide/app-dev/OpticAPI#id_91398) can help with 
 optimizing your query to maximize performance. 
@@ -141,7 +143,7 @@ one. This will result in the connector sending a single request to MarkLogic.
 
 ### More detail on partitions
 
-This section is solely informational and is not required understanding for using the MarkLogic Spark connector 
+This section is solely informational and is not required understanding for using the connector 
 successfully. 
 
 For MarkLogic users familiar with the [Data Movement SDK](https://docs.marklogic.com/guide/java/data-movement), the 
@@ -149,7 +151,7 @@ concept of a "partition" may suggest that the number and location of forests in 
 the ability of an Optic query to perform joins across documents, the goal of running a query against a single forest 
 is not meaningful, as constructing a row may require data from documents in many forests across many hosts. 
 
-Instead of referring to forests, a "partition" in the scope of the MarkLogic Spark connector refers to a set of 
+Instead of referring to forests, a "partition" in the scope of the connector refers to a set of 
 internal row identifiers that are generated at a particular server timestamp. Each row matching an Optic query is 
 assigned a random identifier, which can be any number in the range from zero to the max unsigned long value. A 
 partition is then a slice of numbers within that range. Because row identifiers are generated randomly, matching rows 

--- a/src/main/java/com/marklogic/spark/reader/MarkLogicScanBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/MarkLogicScanBuilder.java
@@ -27,8 +27,10 @@ import org.apache.spark.sql.connector.read.SupportsPushDownAggregates;
 import org.apache.spark.sql.connector.read.SupportsPushDownFilters;
 import org.apache.spark.sql.connector.read.SupportsPushDownLimit;
 import org.apache.spark.sql.connector.read.SupportsPushDownOffset;
+import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns;
 import org.apache.spark.sql.connector.read.SupportsPushDownTopN;
 import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +38,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class MarkLogicScanBuilder implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownOffset, SupportsPushDownTopN, SupportsPushDownAggregates {
+public class MarkLogicScanBuilder implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownLimit,
+    SupportsPushDownOffset, SupportsPushDownTopN, SupportsPushDownAggregates, SupportsPushDownRequiredColumns {
 
     private final static Logger logger = LoggerFactory.getLogger(MarkLogicScanBuilder.class);
 
@@ -151,5 +154,13 @@ public class MarkLogicScanBuilder implements ScanBuilder, SupportsPushDownFilter
         // Only a single "count()" call is supported so far. Will expand as we add support for other aggregations.
         AggregateFunc[] expressions = aggregation.aggregateExpressions();
         return expressions != null && expressions.length == 1 && expressions[0] instanceof CountStar;
+    }
+
+    @Override
+    public void pruneColumns(StructType requiredSchema) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Pushing down required schema: {}", requiredSchema.json());
+        }
+        readContext.pushDownRequiredSchema(requiredSchema);
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/PlanUtil.java
+++ b/src/main/java/com/marklogic/spark/reader/PlanUtil.java
@@ -1,0 +1,81 @@
+package com.marklogic.spark.reader;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.spark.reader.filter.OpticFilter;
+import org.apache.spark.sql.connector.expressions.SortDirection;
+import org.apache.spark.sql.connector.expressions.SortOrder;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Methods for modifying a serialized Optic plan. These were moved here both to facilitate unit testing for some of them
+ * and to simplify {@code ReadContext}.
+ */
+abstract class PlanUtil {
+
+    private final static ObjectMapper objectMapper = new ObjectMapper();
+
+    static ObjectNode buildGroupByCount() {
+        return newOperation("group-by", args -> args
+            .add(objectMapper.nullNode())
+            // Using "null" is the equivalent of "count(*)" - it counts rows, not values.
+            .addObject().put("ns", "op").put("fn", "count").putArray("args").add("Count").add(objectMapper.nullNode()));
+    }
+
+    static ObjectNode buildLimit(int limit) {
+        return newOperation("limit", args -> args.add(limit));
+    }
+
+    static ObjectNode buildOffset(int offset) {
+        return newOperation("offset", args -> args.add(offset));
+    }
+
+    static ObjectNode buildOrderBy(SortOrder sortOrder) {
+        final String direction = SortDirection.ASCENDING.equals(sortOrder.direction()) ? "asc" : "desc";
+        final String columnName = sortOrder.expression().describe();
+        return newOperation("order-by", args -> args.addObject()
+            .put("ns", "op").put("fn", direction)
+            .putArray("args").addObject()
+            .put("ns", "op").put("fn", "col").putArray("args").add(columnName));
+    }
+
+    static ObjectNode buildSelect(StructType schema) {
+        return newOperation("select", args -> {
+            ArrayNode innerArgs = args.addArray();
+            for (StructField field : schema.fields()) {
+                ArrayNode colArgs = innerArgs.addObject().put("ns", "op").put("fn", "schema-col").putArray("args");
+                String[] parts = field.name().split("\\.");
+                if (parts.length == 3) {
+                    colArgs.add(parts[0]).add(parts[1]).add(parts[2]);
+                } else if (parts.length == 2) {
+                    colArgs.add(objectMapper.nullNode()).add(parts[0]).add(parts[1]);
+                } else {
+                    colArgs.add(objectMapper.nullNode()).add(objectMapper.nullNode()).add(parts[0]);
+                }
+            }
+        });
+    }
+
+    static ObjectNode buildWhere(List<OpticFilter> opticFilters) {
+        return newOperation("where", args -> {
+            // If there's only one filter, can toss it into the "where" clause. Else, toss an "and" into the "where" and
+            // then toss every filter into the "and" clause (which accepts 2 to N args).
+            final ArrayNode targetArgs = opticFilters.size() == 1 ?
+                args :
+                args.addObject().put("ns", "op").put("fn", "and").putArray("args");
+
+            opticFilters.forEach(planFilter -> planFilter.populateArg(targetArgs.addObject()));
+        });
+    }
+
+    private static ObjectNode newOperation(String name, Consumer<ArrayNode> withArgs) {
+        ObjectNode operation = objectMapper.createObjectNode().put("ns", "op").put("fn", name);
+        withArgs.accept(operation.putArray("args"));
+        return operation;
+    }
+}

--- a/src/test/java/com/marklogic/spark/reader/PlanUtilTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PlanUtilTest.java
@@ -1,0 +1,49 @@
+package com.marklogic.spark.reader;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PlanUtilTest {
+
+    @Test
+    void buildSelectWithNoQualifier() {
+        ObjectNode select = PlanUtil.buildSelect(new StructType()
+            .add("myField", DataTypes.StringType));
+
+        JsonNode schemaColArgs = select.get("args").get(0).get(0).get("args");
+        assertEquals(3, schemaColArgs.size());
+        assertEquals(JsonNodeType.NULL, schemaColArgs.get(0).getNodeType());
+        assertEquals(JsonNodeType.NULL, schemaColArgs.get(1).getNodeType());
+        assertEquals("myField", schemaColArgs.get(2).asText());
+    }
+
+    @Test
+    void buildSelectWithViewQualifier() {
+        ObjectNode select = PlanUtil.buildSelect(new StructType()
+            .add("myView.myField", DataTypes.StringType));
+
+        JsonNode schemaColArgs = select.get("args").get(0).get(0).get("args");
+        assertEquals(3, schemaColArgs.size());
+        assertEquals(JsonNodeType.NULL, schemaColArgs.get(0).getNodeType());
+        assertEquals("myView", schemaColArgs.get(1).asText());
+        assertEquals("myField", schemaColArgs.get(2).asText());
+    }
+
+    @Test
+    void buildSelectWithSchemaAndViewQualifiers() {
+        ObjectNode select = PlanUtil.buildSelect(new StructType()
+            .add("mySchema.myView.myField", DataTypes.StringType));
+
+        JsonNode schemaColArgs = select.get("args").get(0).get(0).get("args");
+        assertEquals(3, schemaColArgs.size());
+        assertEquals("mySchema", schemaColArgs.get(0).asText());
+        assertEquals("myView", schemaColArgs.get(1).asText());
+        assertEquals("myField", schemaColArgs.get(2).asText());
+    }
+}

--- a/src/test/java/com/marklogic/spark/reader/PushDownRequiredColumnsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownRequiredColumnsTest.java
@@ -1,0 +1,80 @@
+package com.marklogic.spark.reader;
+
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * There's not a great way to verify that what MarkLogic is returning only has the required columns. We'd need to add
+ * a test-only hook that captures the actual JSON, as opposed to the current hook that only fires when the partition
+ * reader has "close()" called. Checking on that test-only hook for every single row seems potentially excessive.
+ * <p>
+ * So this test verifies that "select" works in various scenarios, but really need to check the logging to verify that
+ * MarkLogic is only returning the selected columns.
+ */
+public class PushDownRequiredColumnsTest extends AbstractPushDownTest {
+
+    @Test
+    void withNoQualifier() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
+            .load()
+            .orderBy("ForeName")
+            .select("ForeName", "LastName")
+            .collectAsList();
+
+        assertEquals(15, rows.size());
+        assertEquals("Aida", rows.get(0).getAs("ForeName"));
+        assertEquals("Humbee", rows.get(0).getAs("LastName"));
+    }
+
+    @Test
+    void withSchemaAndViewQualifiers() {
+        List<Row> rows = newDefaultReader()
+            .load()
+            .orderBy("`Medical.Authors.ForeName`")
+            .select("`Medical.Authors.ForeName`", "`Medical.Authors.LastName`")
+            .collectAsList();
+
+        assertEquals(15, rows.size());
+        assertEquals("Aida", rows.get(0).getAs("Medical.Authors.ForeName"));
+        assertEquals("Humbee", rows.get(0).getAs("Medical.Authors.LastName"));
+    }
+
+    @Test
+    void withViewQualifier() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors', 'hey')")
+            .load()
+            .orderBy("`hey.ForeName`")
+            .select("`hey.ForeName`", "`hey.LastName`")
+            .collectAsList();
+
+        assertEquals(15, rows.size());
+        assertEquals("Aida", rows.get(0).getAs("hey.ForeName"));
+        assertEquals("Humbee", rows.get(0).getAs("hey.LastName"));
+    }
+
+    @Test
+    void dropColumns() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
+            .load()
+            .orderBy("ForeName")
+            .drop("CitationID", "LastName")
+            .collectAsList();
+
+        assertEquals(15, rows.size());
+
+        Row row = rows.get(0);
+        assertEquals("Aida", row.getString(0), "ForeName should be the first column since CitationID and " +
+            "LastName were dropped");
+        assertThrows(IllegalArgumentException.class, () -> row.getAs("CitationID"));
+        assertThrows(IllegalArgumentException.class, () -> row.getAs("LastName"));
+    }
+}


### PR DESCRIPTION
Extracted `PlanUtil` as well so that all the plan manipulations happen in one place, and it's easier to unit test those.