### PR TITLE
Fixes for count/orderBy on qualified column names

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/MarkLogicPartitionReader.java
+++ b/src/main/java/com/marklogic/spark/reader/MarkLogicPartitionReader.java
@@ -90,8 +90,8 @@ class MarkLogicPartitionReader implements PartitionReader {
             if (rowIterator.hasNext()) {
                 return true;
             } else {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Count of rows for partition {} and bucket {}: {}", this.partition,
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Count of rows for partition {} and bucket {}: {}", this.partition,
                         this.partition.buckets.get(nextBucketIndex - 1), currentBucketRowCount);
                 }
                 currentBucketRowCount = 0;

--- a/src/main/java/com/marklogic/spark/reader/PlanUtil.java
+++ b/src/main/java/com/marklogic/spark/reader/PlanUtil.java
@@ -4,10 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.spark.reader.filter.OpticFilter;
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.expressions.SortDirection;
 import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -18,13 +22,22 @@ import java.util.function.Consumer;
  */
 abstract class PlanUtil {
 
+    private final static Logger logger = LoggerFactory.getLogger(PlanUtil.class);
+
     private final static ObjectMapper objectMapper = new ObjectMapper();
 
     static ObjectNode buildGroupByCount() {
         return newOperation("group-by", args -> args
             .add(objectMapper.nullNode())
-            // Using "null" is the equivalent of "count(*)" - it counts rows, not values.
             .addObject().put("ns", "op").put("fn", "count").putArray("args").add("count").add(objectMapper.nullNode()));
+    }
+
+    static ObjectNode buildGroupByCount(String columnName) {
+        return newOperation("group-by", args -> {
+            populateSchemaCol(args.addObject(), columnName);
+            // Using "null" is the equivalent of "count(*)" - it counts rows, not values.
+            args.addObject().put("ns", "op").put("fn", "count").putArray("args").add("count").add(objectMapper.nullNode());
+        });
     }
 
     static ObjectNode buildLimit(int limit) {
@@ -37,28 +50,39 @@ abstract class PlanUtil {
 
     static ObjectNode buildOrderBy(SortOrder sortOrder) {
         final String direction = SortDirection.ASCENDING.equals(sortOrder.direction()) ? "asc" : "desc";
-        final String columnName = sortOrder.expression().describe();
-        return newOperation("order-by", args -> args.addObject()
-            .put("ns", "op").put("fn", direction)
-            .putArray("args").addObject()
-            .put("ns", "op").put("fn", "col").putArray("args").add(columnName));
+        final String columnName = expressionToColumnName(sortOrder.expression());
+        return newOperation("order-by", args -> {
+            ArrayNode orderByArgs = args.addObject().put("ns", "op").put("fn", direction).putArray("args");
+            // This may be a bad hack to account for when the user does a groupBy/count/orderBy/limit, which does not
+            // seem like the correct approach - the Spark ScanBuilder javadocs indicate that it should be limit/orderBy
+            // instead. In the former scenario, we get "COUNT(*)" as the expression to order by, and we know that's not
+            // the column name.
+            if (logger.isDebugEnabled()) {
+                logger.debug("Adjusting `COUNT(*)` column to be `count`");
+            }
+            populateSchemaCol(orderByArgs.addObject(), "COUNT(*)".equals(columnName) ? "count" : columnName);
+        });
     }
 
     static ObjectNode buildSelect(StructType schema) {
         return newOperation("select", args -> {
             ArrayNode innerArgs = args.addArray();
             for (StructField field : schema.fields()) {
-                ArrayNode colArgs = innerArgs.addObject().put("ns", "op").put("fn", "schema-col").putArray("args");
-                String[] parts = field.name().split("\\.");
-                if (parts.length == 3) {
-                    colArgs.add(parts[0]).add(parts[1]).add(parts[2]);
-                } else if (parts.length == 2) {
-                    colArgs.add(objectMapper.nullNode()).add(parts[0]).add(parts[1]);
-                } else {
-                    colArgs.add(objectMapper.nullNode()).add(objectMapper.nullNode()).add(parts[0]);
-                }
+                populateSchemaCol(innerArgs.addObject(), field.name());
             }
         });
+    }
+
+    private static void populateSchemaCol(ObjectNode node, String columnName) {
+        ArrayNode colArgs = node.put("ns", "op").put("fn", "schema-col").putArray("args");
+        String[] parts = columnName.split("\\.");
+        if (parts.length == 3) {
+            colArgs.add(parts[0]).add(parts[1]).add(parts[2]);
+        } else if (parts.length == 2) {
+            colArgs.add(objectMapper.nullNode()).add(parts[0]).add(parts[1]);
+        } else {
+            colArgs.add(objectMapper.nullNode()).add(objectMapper.nullNode()).add(parts[0]);
+        }
     }
 
     static ObjectNode buildWhere(List<OpticFilter> opticFilters) {
@@ -77,5 +101,20 @@ abstract class PlanUtil {
         ObjectNode operation = objectMapper.createObjectNode().put("ns", "op").put("fn", name);
         withArgs.accept(operation.putArray("args"));
         return operation;
+    }
+
+    static String expressionToColumnName(Expression expression) {
+        // The structure of an Expression isn't well-understood yet. But when it refers to a single column, the
+        // column name can be found in the below manner. Anything else is not supported yet.
+        NamedReference[] refs = expression.references();
+        if (refs == null || refs.length < 1) {
+            return expression.describe();
+        }
+        String[] fieldNames = refs[0].fieldNames();
+        if (fieldNames.length != 1) {
+            throw new IllegalArgumentException("Unsupported expression: " + expression + "; expecting expression " +
+                "to have exactly one field name.");
+        }
+        return fieldNames[0];
     }
 }

--- a/src/test/java/com/marklogic/spark/reader/PushDownCountTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownCountTest.java
@@ -26,24 +26,4 @@ public class PushDownCountTest extends AbstractPushDownTest {
             "that regardless of the number of matching rows, MarkLogic can efficiently determine a count in a single " +
             "request.");
     }
-
-    @Test
-    void groupByAndCount() {
-        List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
-            .load()
-            .groupBy("CitationID")
-            .count()
-            .orderBy("CitationID")
-            .collectAsList();
-
-        assertEquals(15, countOfRowsReadFromMarkLogic, "groupBy + count is not yet being pushed down to MarkLogic; " +
-            "only count() by itself is being pushed down. So expecting all rows to be read for now.");
-
-        assertEquals(4, (long) rows.get(0).getAs("count"));
-        assertEquals(4, (long) rows.get(1).getAs("count"));
-        assertEquals(4, (long) rows.get(2).getAs("count"));
-        assertEquals(1, (long) rows.get(3).getAs("count"));
-        assertEquals(2, (long) rows.get(4).getAs("count"));
-    }
 }

--- a/src/test/java/com/marklogic/spark/reader/PushDownGroupByCountTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownGroupByCountTest.java
@@ -1,0 +1,103 @@
+package com.marklogic.spark.reader;
+
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PushDownGroupByCountTest extends AbstractPushDownTest {
+
+    @Test
+    void groupByWithNoQualifier() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
+            .load()
+            .groupBy("CitationID")
+            .count()
+            .orderBy("CitationID")
+            .collectAsList();
+
+        verifyGroupByWasPushedDown(rows);
+        assertEquals(1l, (long) rows.get(0).getAs("CitationID"));
+    }
+
+    @Test
+    void groupByWithView() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors', 'example')")
+            .load()
+            .groupBy("`example.CitationID`")
+            .count()
+            .orderBy("`example.CitationID`")
+            .collectAsList();
+
+        verifyGroupByWasPushedDown(rows);
+        assertEquals(1l, (long) rows.get(0).getAs("example.CitationID"));
+    }
+
+    @Test
+    void groupByWithSchemaAndView() {
+        List<Row> rows = newDefaultReader()
+            .load()
+            .groupBy("`Medical.Authors.CitationID`")
+            .count()
+            .orderBy("`Medical.Authors.CitationID`")
+            .collectAsList();
+
+        verifyGroupByWasPushedDown(rows);
+        assertEquals(1l, (long) rows.get(0).getAs("Medical.Authors.CitationID"));
+    }
+
+    @Test
+    void groupByCountLimitOrderBy() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
+            .load()
+            .groupBy("CitationID")
+            .count()
+            .limit(4)
+            // When the user puts the orderBy after limit, Spark doesn't push the orderBy down. Spark will instead
+            // apply the orderBy itself.
+            .orderBy("count")
+            .collectAsList();
+
+        assertEquals(4, rows.size());
+        assertEquals(4, countOfRowsReadFromMarkLogic);
+        assertEquals(4l, (long) rows.get(0).getAs("CitationID"));
+        assertEquals(1l, (long) rows.get(0).getAs("count"));
+    }
+
+    @Test
+    void groupByCountOrderByLimit() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
+            .load()
+            .groupBy("CitationID")
+            .count()
+            // If the user puts orderBy before limit, Spark will send "COUNT(*)" as the column name for the orderBy.
+            // The connector is expected to translate that into "count"; not sure how it should work otherwise. Spark
+            // is expected to push down the limit as well.
+            .orderBy("count")
+            .limit(4)
+            .collectAsList();
+
+        assertEquals(4, rows.size());
+        assertEquals(4, countOfRowsReadFromMarkLogic);
+        assertEquals(4l, (long) rows.get(0).getAs("CitationID"));
+        assertEquals(1l, (long) rows.get(0).getAs("count"));
+    }
+
+    private void verifyGroupByWasPushedDown(List<Row> rows) {
+        assertEquals(5, countOfRowsReadFromMarkLogic, "groupBy should be pushed down to MarkLogic when used with " +
+            "count, and since there are 5 CitationID values, 5 rows should be returned.");
+
+        assertEquals(4, (long) rows.get(0).getAs("count"));
+        assertEquals(4, (long) rows.get(1).getAs("count"));
+        assertEquals(4, (long) rows.get(2).getAs("count"));
+        assertEquals(1, (long) rows.get(3).getAs("count"));
+        assertEquals(2, (long) rows.get(4).getAs("count"));
+    }
+}

--- a/src/test/java/com/marklogic/spark/reader/PushDownOrderByAndLimitTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownOrderByAndLimitTest.java
@@ -95,7 +95,7 @@ public class PushDownOrderByAndLimitTest extends AbstractPushDownTest {
     @Test
     void limitWithTwoPartitionsAndOrderBy() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors', '')")
+            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
             .option(Options.READ_NUM_PARTITIONS, 2)
             .option(Options.READ_BATCH_SIZE, 0)
             .load()
@@ -133,6 +133,44 @@ public class PushDownOrderByAndLimitTest extends AbstractPushDownTest {
         assertEquals("Wooles", rows.get(0).getAs("LastName"));
         assertEquals("Tonnesen", rows.get(1).getAs("LastName"));
         assertEquals("Shoebotham", rows.get(2).getAs("LastName"));
+    }
+
+    @Test
+    void orderByWithSchemaAndView() {
+        List<Row> rows = newDefaultReader()
+            .load()
+            .orderBy("`Medical.Authors.CitationID`")
+            .limit(10)
+            .collectAsList();
+
+        assertEquals(10, rows.size());
+        verifyRowsAreOrderedByCitationID(rows);
+    }
+
+    @Test
+    void orderByWithView() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors', 'myQualifier')")
+            .load()
+            .orderBy("`myQualifier.CitationID`")
+            .limit(8)
+            .collectAsList();
+
+        assertEquals(8, rows.size());
+        verifyRowsAreOrderedByCitationID(rows);
+    }
+
+    @Test
+    void sort() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
+            .load()
+            .sort("CitationID")
+            .limit(8)
+            .collectAsList();
+
+        assertEquals(8, rows.size());
+        verifyRowsAreOrderedByCitationID(rows);
     }
 
     private void verifyRowsAreOrderedByCitationID(List<Row> rows) {


### PR DESCRIPTION
And... I implemented groupBy + count while I was in here fixing things as it was trivial to do. Also tweaked some logging based on testing. But the main thing is the addition of tests to verify that column names work, regardless of whether they have no qualifier, only a view, or a schema + view.