### PR TITLE
Updated minimum versions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ reading data from and writing data to MarkLogic.
 The connector has the following system requirements:
 
 * Apache Spark 3.4.0 or higher; earlier versions of Spark 3.x may work but have not been tested.
-* For writing data, MarkLogic 9 or higher.
-* For reading data, MarkLogic 10.0-6 or higher.
+* For writing data, MarkLogic 9.0-9 or higher.
+* For reading data, MarkLogic 10.0-9 or higher.
 
 Please see the [Getting Started guide](getting-started/getting-started.md) to begin using the connector. 

--- a/src/main/java/com/marklogic/spark/DefaultSource.java
+++ b/src/main/java/com/marklogic/spark/DefaultSource.java
@@ -54,6 +54,7 @@ public class DefaultSource implements TableProvider {
         RowManager rowManager = new ContextSupport(caseSensitiveOptions).connectToMarkLogic().newRowManager();
         RawQueryDSLPlan dslPlan = rowManager.newRawQueryDSLPlan(new StringHandle(query));
         try {
+            // columnInfo is what forces a minimum MarkLogic version of 10.0-9 or higher.
             StringHandle columnInfoHandle = rowManager.columnInfo(dslPlan, new StringHandle());
             return SchemaInferrer.inferSchema(columnInfoHandle.get());
         } catch (Exception ex) {


### PR DESCRIPTION
All tests pass on 10.0-9, which introduced the `columnInfo` arg for /v1/rows.

The writer tests all pass in 9.0-9, which is the oldest version of MarkLogic available from hub.docker.