### PR TITLE
Fix for not pushing down when count of rows is zero

### DIFF
--- a/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
+++ b/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
@@ -38,6 +38,7 @@ public class AbstractIntegrationTest extends AbstractSpringMarkLogicTest {
     protected final static String TEST_USERNAME = "spark-test-user";
     protected final static String TEST_PASSWORD = "spark";
     protected final static String CONNECTOR_IDENTIFIER = "com.marklogic.spark";
+    protected final static String NO_AUTHORS_QUERY = "op.fromView('Medical', 'NoAuthors', '')";
 
     private static MarkLogicVersion markLogicVersion;
 

--- a/src/test/java/com/marklogic/spark/reader/PushDownCountTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownCountTest.java
@@ -38,4 +38,16 @@ public class PushDownCountTest extends AbstractPushDownTest {
             "that regardless of the number of matching rows, MarkLogic can efficiently determine a count in a single " +
             "request.");
     }
+
+    @Test
+    void noRowsFound() {
+        long count = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, NO_AUTHORS_QUERY)
+            .load()
+            .count();
+
+        assertEquals(0, count);
+        assertEquals(0, countOfRowsReadFromMarkLogic, "When no rows exist, neither the count() operation nor the " +
+            "pruneColumns() operation should be pushed down since there's no optimization to be done.");
+    }
 }

--- a/src/test/java/com/marklogic/spark/reader/PushDownFilterTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownFilterTest.java
@@ -59,6 +59,17 @@ public class PushDownFilterTest extends AbstractPushDownTest {
     }
 
     @Test
+    void noRowsFound() {
+        assertEquals(0, newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, NO_AUTHORS_QUERY)
+            .load()
+            .filter("CitationID == 1")
+            .collectAsList()
+            .size());
+        assertEquals(0, countOfRowsReadFromMarkLogic);
+    }
+
+    @Test
     void equalToWithWhere() {
         assertEquals(2, getCountOfRowsWithFilter("CitationID = 5"));
         assertEquals(2, countOfRowsReadFromMarkLogic);

--- a/src/test/java/com/marklogic/spark/reader/PushDownGroupByCountTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownGroupByCountTest.java
@@ -40,6 +40,20 @@ public class PushDownGroupByCountTest extends AbstractPushDownTest {
     }
 
     @Test
+    void noRowsFound() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, NO_AUTHORS_QUERY)
+            .load()
+            .groupBy("CitationID")
+            .count()
+            .orderBy("CitationID")
+            .collectAsList();
+
+        assertEquals(0, rows.size());
+        assertEquals(0, countOfRowsReadFromMarkLogic);
+    }
+
+    @Test
     void groupByWithView() {
         List<Row> rows = newDefaultReader()
             .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors', 'example')")

--- a/src/test/java/com/marklogic/spark/reader/PushDownOffsetTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownOffsetTest.java
@@ -15,6 +15,7 @@
  */
 package com.marklogic.spark.reader;
 
+import com.marklogic.spark.Options;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +35,18 @@ public class PushDownOffsetTest extends AbstractPushDownTest {
         assertEquals(7, rows.size(),
             "Expecting the 4 authors with CitationID=3; then the 1 with CitationID=4; then the 2 with CitationID=5");
         assertEquals(7, countOfRowsReadFromMarkLogic);
+    }
+
+    @Test
+    void noRowsFound() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, NO_AUTHORS_QUERY)
+            .load()
+            .offset(1)
+            .collectAsList();
+
+        assertEquals(0, rows.size());
+        assertEquals(0, countOfRowsReadFromMarkLogic);
     }
 
     @Test

--- a/src/test/java/com/marklogic/spark/reader/PushDownRequiredColumnsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownRequiredColumnsTest.java
@@ -49,6 +49,18 @@ public class PushDownRequiredColumnsTest extends AbstractPushDownTest {
     }
 
     @Test
+    void noRowsFound() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_DSL, NO_AUTHORS_QUERY)
+            .load()
+            .select("CitationID")
+            .collectAsList();
+
+        assertEquals(0, rows.size());
+        assertEquals(0, countOfRowsReadFromMarkLogic);
+    }
+
+    @Test
     void withSchemaAndViewQualifiers() {
         List<Row> rows = newDefaultReader()
             .load()

--- a/src/test/java/com/marklogic/spark/reader/ReadRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/ReadRowsTest.java
@@ -71,7 +71,7 @@ public class ReadRowsTest extends AbstractIntegrationTest {
     @Test
     void queryReturnsZeroRows() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'NoAuthors')")
+            .option(Options.READ_OPTIC_DSL, NO_AUTHORS_QUERY)
             .load()
             .collectAsList();
 

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -191,6 +192,7 @@ public class WriteRowsTest extends AbstractWriteTest {
     }
 
     private void verifyFailureIsDueToLackOfPermission(SparkException ex) {
+        assertNotNull(ex.getCause(), "Unexpected exception with no cause: " + ex.getClass() + "; " + ex.getMessage());
         assertTrue(ex.getCause() instanceof IOException, "Unexpected cause: " + ex.getCause().getClass());
         assertTrue(ex.getCause().getMessage().contains("Server Message: You do not have permission to this method and URL"),
             "Unexpected cause message: " + ex.getCause().getMessage());

--- a/src/test/ml-schemas/tde/no-authors.json
+++ b/src/test/ml-schemas/tde/no-authors.json
@@ -8,6 +8,11 @@
         "viewName": "NoAuthors",
         "columns": [
           {
+            "name": "CitationID",
+            "scalarType": "long",
+            "val": "ID"
+          },
+          {
             "name": "LastName",
             "scalarType": "string",
             "val": "LastName"


### PR DESCRIPTION
Need to do this in the ScanBuilder so we can return "false" to Spark to let it know that we did not push down the operation. 

Also added an assertion to WriteRowsTest to help debug what seems like an intermittent failure on Jenkins.