### PR TITLE
Renaming "opticDsl" to "opticQuery"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ df = spark.read.format("com.marklogic.spark")\
     .option("spark.marklogic.client.username", "admin")\
     .option("spark.marklogic.client.password", "admin")\
     .option("spark.marklogic.client.authType", "digest")\
-    .option("spark.marklogic.read.opticDsl", "op.fromView('Medical', 'Authors')")\
+    .option("spark.marklogic.read.opticQuery", "op.fromView('Medical', 'Authors')")\
     .load()
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ Using this convenience can provide a much more succinct set of options - for exa
 ```
 df = spark.read.format("com.marklogic.spark")\
     .option("spark.marklogic.client.uri", "spark-example-user:password@localhost:8020")\
-    .option("spark.marklogic.read.opticDsl", "op.fromView('example', 'employee')")\
+    .option("spark.marklogic.read.opticQuery", "op.fromView('example', 'employee')")\
     .load()
 ```
 
@@ -66,7 +66,7 @@ information on how data is read from MarkLogic.
 
 | Option | Description                                                                                       | 
 | --- |---------------------------------------------------------------------------------------------------|
-| spark.marklogic.read.opticDsl | Required; the Optic DSL query to run for retrieving rows; must use `op.fromView` as the accessor. |
+| spark.marklogic.read.opticQuery | Required; the Optic DSL query to run for retrieving rows; must use `op.fromView` as the accessor. |
 | spark.marklogic.read.numPartitions | The number of Spark partitions to create; defaults to `spark.default.parallelism` .               |
 | spark.marklogic.read.batchSize | Approximate number of rows to retrieve in each call to MarkLogic; defaults to 10000.              |
 

--- a/docs/getting-started/pyspark.md
+++ b/docs/getting-started/pyspark.md
@@ -57,7 +57,7 @@ df = spark.read.format("com.marklogic.spark") \
     .option("spark.marklogic.client.port", "8020") \
     .option("spark.marklogic.client.username", "spark-example-user") \
     .option("spark.marklogic.client.password", "password") \
-    .option("spark.marklogic.read.opticDsl", "op.fromView('example', 'employee')") \
+    .option("spark.marklogic.read.opticQuery", "op.fromView('example', 'employee')") \
     .load()
 ```
 
@@ -67,7 +67,7 @@ client options in one option:
 ```
 df = spark.read.format("com.marklogic.spark") \
     .option("spark.marklogic.client.uri", "spark-example-user:password@localhost:8020") \
-    .option("spark.marklogic.read.opticDsl", "op.fromView('example', 'employee')") \
+    .option("spark.marklogic.read.opticQuery", "op.fromView('example', 'employee')") \
     .load()
 ```
 

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -31,7 +31,7 @@ from pyspark.sql.types import StructField, StructType, StringType
 df = spark.read.format("com.marklogic.spark") \
     .schema(StructType([StructField("example.employee.GivenName", StringType()), StructField("example.employee.Surname", StringType())])) \
     .option("spark.marklogic.client.uri", "spark-example-user:password@localhost:8020") \
-    .option("spark.marklogic.read.opticDsl", "op.fromView('example', 'employee')") \
+    .option("spark.marklogic.read.opticQuery", "op.fromView('example', 'employee')") \
     .load()
 ```
 
@@ -51,7 +51,7 @@ op.fromView('example', 'employee', '', joinCol) \
 
 df = spark.read.format("com.marklogic.spark") \
     .option("spark.marklogic.client.uri", "spark-example-user:password@localhost:8020") \
-    .option("spark.marklogic.read.opticDsl", query) \
+    .option("spark.marklogic.read.opticQuery", query) \
     .load()
 ```
 
@@ -75,7 +75,7 @@ stream = spark.readStream \
     .format("com.marklogic.spark") \
     .option("spark.marklogic.client.uri", "spark-example-user:password@localhost:8020") \
     .option("spark.marklogic.read.numPartitions", 2) \
-    .option("spark.marklogic.read.opticDsl", "op.fromView('example', 'employee')") \
+    .option("spark.marklogic.read.opticQuery", "op.fromView('example', 'employee')") \
     .load() \
     .writeStream \
     .format("console") \

--- a/examples/java-dependency/src/main/java/org/example/App.java
+++ b/examples/java-dependency/src/main/java/org/example/App.java
@@ -17,7 +17,7 @@ public class App {
                 .read()
                 .format("com.marklogic.spark")
                 .option("spark.marklogic.client.uri", "spark-example-user:password@localhost:8020")
-                .option("spark.marklogic.read.opticDsl", "op.fromView('example', 'employee', '')")
+                .option("spark.marklogic.read.opticQuery", "op.fromView('example', 'employee', '')")
                 .load()
                 .filter("City == 'San Diego'")
                 .collectAsList();

--- a/src/main/java/com/marklogic/spark/DefaultSource.java
+++ b/src/main/java/com/marklogic/spark/DefaultSource.java
@@ -47,9 +47,9 @@ public class DefaultSource implements TableProvider {
     @Override
     public StructType inferSchema(CaseInsensitiveStringMap options) {
         final Map<String, String> caseSensitiveOptions = options.asCaseSensitiveMap();
-        final String query = caseSensitiveOptions.get(Options.READ_OPTIC_DSL);
+        final String query = caseSensitiveOptions.get(Options.READ_OPTIC_QUERY);
         if (query == null || query.trim().length() < 1) {
-            throw new IllegalArgumentException(String.format("No Optic query found; must define %s", Options.READ_OPTIC_DSL));
+            throw new IllegalArgumentException(String.format("No Optic query found; must define %s", Options.READ_OPTIC_QUERY));
         }
         RowManager rowManager = new ContextSupport(caseSensitiveOptions).connectToMarkLogic().newRowManager();
         RawQueryDSLPlan dslPlan = rowManager.newRawQueryDSLPlan(new StringHandle(query));
@@ -88,6 +88,6 @@ public class DefaultSource implements TableProvider {
     }
 
     private boolean isReadOperation(Map<String, String> properties) {
-        return properties.containsKey(Options.READ_OPTIC_DSL);
+        return properties.containsKey(Options.READ_OPTIC_QUERY);
     }
 }

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -19,7 +19,7 @@ public interface Options {
 
     String CLIENT_URI = "spark.marklogic.client.uri";
 
-    String READ_OPTIC_DSL = "spark.marklogic.read.opticDsl";
+    String READ_OPTIC_QUERY = "spark.marklogic.read.opticQuery";
     String READ_NUM_PARTITIONS = "spark.marklogic.read.numPartitions";
     String READ_BATCH_SIZE = "spark.marklogic.read.batchSize";
 

--- a/src/main/java/com/marklogic/spark/reader/ReadContext.java
+++ b/src/main/java/com/marklogic/spark/reader/ReadContext.java
@@ -67,9 +67,9 @@ public class ReadContext extends ContextSupport {
         final long partitionCount = getNumericOption(Options.READ_NUM_PARTITIONS,
             SparkSession.active().sparkContext().defaultMinPartitions(), 1);
         final long batchSize = getNumericOption(Options.READ_BATCH_SIZE, DEFAULT_BATCH_SIZE, 0);
-        final String dslQuery = properties.get(Options.READ_OPTIC_DSL);
+        final String dslQuery = properties.get(Options.READ_OPTIC_QUERY);
         if (dslQuery == null || dslQuery.trim().length() < 1) {
-            throw new IllegalArgumentException(String.format("No Optic query found; must define %s", Options.READ_OPTIC_DSL));
+            throw new IllegalArgumentException(String.format("No Optic query found; must define %s", Options.READ_OPTIC_QUERY));
         }
         DatabaseClient client = connectToMarkLogic();
         RawQueryDSLPlan dslPlan = client.newRowManager().newRawQueryDSLPlan(new StringHandle(dslQuery));

--- a/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
+++ b/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
@@ -97,7 +97,7 @@ public class AbstractIntegrationTest extends AbstractSpringMarkLogicTest {
             .option("spark.marklogic.client.port", testConfig.getRestPort())
             .option("spark.marklogic.client.username", TEST_USERNAME)
             .option("spark.marklogic.client.password", TEST_PASSWORD)
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical','Authors')");
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical','Authors')");
     }
 
     protected String readClasspathFile(String path) {

--- a/src/test/java/com/marklogic/spark/reader/AbstractPushDownTest.java
+++ b/src/test/java/com/marklogic/spark/reader/AbstractPushDownTest.java
@@ -43,7 +43,7 @@ abstract class AbstractPushDownTest extends AbstractIntegrationTest {
 
     protected Dataset<Row> newDatasetOrderedByCitationIDWithOneBucket() {
         return newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, QUERY_ORDERED_BY_CITATION_ID)
+            .option(Options.READ_OPTIC_QUERY, QUERY_ORDERED_BY_CITATION_ID)
             .option(Options.READ_NUM_PARTITIONS, 1)
             .option(Options.READ_BATCH_SIZE, 0)
             .load();

--- a/src/test/java/com/marklogic/spark/reader/PerformanceTester.java
+++ b/src/test/java/com/marklogic/spark/reader/PerformanceTester.java
@@ -50,7 +50,7 @@ public class PerformanceTester {
             .option("spark.marklogic.client.port", 8009)
             .option("spark.marklogic.client.username", "admin")
             .option("spark.marklogic.client.password", "admin")
-            .option(Options.READ_OPTIC_DSL, query)
+            .option(Options.READ_OPTIC_QUERY, query)
             .option(Options.READ_NUM_PARTITIONS, partitionCount)
             .option(Options.READ_BATCH_SIZE, batchSize)
             .load();

--- a/src/test/java/com/marklogic/spark/reader/PushDownCountTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownCountTest.java
@@ -42,7 +42,7 @@ public class PushDownCountTest extends AbstractPushDownTest {
     @Test
     void noRowsFound() {
         long count = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, NO_AUTHORS_QUERY)
+            .option(Options.READ_OPTIC_QUERY, NO_AUTHORS_QUERY)
             .load()
             .count();
 

--- a/src/test/java/com/marklogic/spark/reader/PushDownFilterTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownFilterTest.java
@@ -50,7 +50,7 @@ public class PushDownFilterTest extends AbstractPushDownTest {
     @Test
     void equalToWithViewQualifier() {
         assertEquals(4, newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors', 'myView')")
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'Authors', 'myView')")
             .load()
             .filter("`myView.CitationID` == 1")
             .collectAsList()
@@ -61,7 +61,7 @@ public class PushDownFilterTest extends AbstractPushDownTest {
     @Test
     void noRowsFound() {
         assertEquals(0, newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, NO_AUTHORS_QUERY)
+            .option(Options.READ_OPTIC_QUERY, NO_AUTHORS_QUERY)
             .load()
             .filter("CitationID == 1")
             .collectAsList()
@@ -249,7 +249,7 @@ public class PushDownFilterTest extends AbstractPushDownTest {
 
     private Dataset<Row> newDataset() {
         return newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
+            .option(Options.READ_OPTIC_QUERY, QUERY_WITH_NO_QUALIFIER)
             // Use a single call to MarkLogic so it's easier to verify from the logging
             // that only N rows were returned.
             .option(Options.READ_NUM_PARTITIONS, 1)

--- a/src/test/java/com/marklogic/spark/reader/PushDownFilterValueTypesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownFilterValueTypesTest.java
@@ -87,7 +87,7 @@ public class PushDownFilterValueTypesTest extends AbstractIntegrationTest {
 
     private Dataset<Row> newDataset() {
         return newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('sparkTest', 'allTypes', '')")
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('sparkTest', 'allTypes', '')")
             .option(Options.READ_NUM_PARTITIONS, 1)
             .option(Options.READ_BATCH_SIZE, 0)
             .load();

--- a/src/test/java/com/marklogic/spark/reader/PushDownGroupByCountTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownGroupByCountTest.java
@@ -28,7 +28,7 @@ public class PushDownGroupByCountTest extends AbstractPushDownTest {
     @Test
     void groupByWithNoQualifier() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
+            .option(Options.READ_OPTIC_QUERY, QUERY_WITH_NO_QUALIFIER)
             .load()
             .groupBy("CitationID")
             .count()
@@ -42,7 +42,7 @@ public class PushDownGroupByCountTest extends AbstractPushDownTest {
     @Test
     void noRowsFound() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, NO_AUTHORS_QUERY)
+            .option(Options.READ_OPTIC_QUERY, NO_AUTHORS_QUERY)
             .load()
             .groupBy("CitationID")
             .count()
@@ -56,7 +56,7 @@ public class PushDownGroupByCountTest extends AbstractPushDownTest {
     @Test
     void groupByWithView() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors', 'example')")
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'Authors', 'example')")
             .load()
             .groupBy("`example.CitationID`")
             .count()
@@ -83,7 +83,7 @@ public class PushDownGroupByCountTest extends AbstractPushDownTest {
     @Test
     void groupByCountLimitOrderBy() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
+            .option(Options.READ_OPTIC_QUERY, QUERY_WITH_NO_QUALIFIER)
             .load()
             .groupBy("CitationID")
             .count()
@@ -102,7 +102,7 @@ public class PushDownGroupByCountTest extends AbstractPushDownTest {
     @Test
     void groupByCountOrderByLimit() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
+            .option(Options.READ_OPTIC_QUERY, QUERY_WITH_NO_QUALIFIER)
             .load()
             .groupBy("CitationID")
             .count()

--- a/src/test/java/com/marklogic/spark/reader/PushDownOffsetTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownOffsetTest.java
@@ -40,7 +40,7 @@ public class PushDownOffsetTest extends AbstractPushDownTest {
     @Test
     void noRowsFound() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, NO_AUTHORS_QUERY)
+            .option(Options.READ_OPTIC_QUERY, NO_AUTHORS_QUERY)
             .load()
             .offset(1)
             .collectAsList();

--- a/src/test/java/com/marklogic/spark/reader/PushDownOrderByAndLimitTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownOrderByAndLimitTest.java
@@ -40,7 +40,7 @@ public class PushDownOrderByAndLimitTest extends AbstractPushDownTest {
     @Test
     void orderByWithTwoPartitions() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, QUERY_ORDERED_BY_CITATION_ID)
+            .option(Options.READ_OPTIC_QUERY, QUERY_ORDERED_BY_CITATION_ID)
             .option(Options.READ_NUM_PARTITIONS, 2)
             .option(Options.READ_BATCH_SIZE, 0)
             .load()
@@ -110,7 +110,7 @@ public class PushDownOrderByAndLimitTest extends AbstractPushDownTest {
     @Test
     void limitWithTwoPartitionsAndOrderBy() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
+            .option(Options.READ_OPTIC_QUERY, QUERY_WITH_NO_QUALIFIER)
             .option(Options.READ_NUM_PARTITIONS, 2)
             .option(Options.READ_BATCH_SIZE, 0)
             .load()
@@ -131,7 +131,7 @@ public class PushDownOrderByAndLimitTest extends AbstractPushDownTest {
     @Test
     void limitWithTwoPartitionsAndOrderByLastNameDescending() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors', '')")
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'Authors', '')")
             .option(Options.READ_NUM_PARTITIONS, 2)
             .option(Options.READ_BATCH_SIZE, 0)
             .load()
@@ -165,7 +165,7 @@ public class PushDownOrderByAndLimitTest extends AbstractPushDownTest {
     @Test
     void orderByWithView() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors', 'myQualifier')")
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'Authors', 'myQualifier')")
             .load()
             .orderBy("`myQualifier.CitationID`")
             .limit(8)
@@ -178,7 +178,7 @@ public class PushDownOrderByAndLimitTest extends AbstractPushDownTest {
     @Test
     void sort() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
+            .option(Options.READ_OPTIC_QUERY, QUERY_WITH_NO_QUALIFIER)
             .load()
             .sort("CitationID")
             .limit(8)

--- a/src/test/java/com/marklogic/spark/reader/PushDownRequiredColumnsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownRequiredColumnsTest.java
@@ -37,7 +37,7 @@ public class PushDownRequiredColumnsTest extends AbstractPushDownTest {
     @Test
     void withNoQualifier() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
+            .option(Options.READ_OPTIC_QUERY, QUERY_WITH_NO_QUALIFIER)
             .load()
             .orderBy("ForeName")
             .select("ForeName", "LastName")
@@ -51,7 +51,7 @@ public class PushDownRequiredColumnsTest extends AbstractPushDownTest {
     @Test
     void noRowsFound() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, NO_AUTHORS_QUERY)
+            .option(Options.READ_OPTIC_QUERY, NO_AUTHORS_QUERY)
             .load()
             .select("CitationID")
             .collectAsList();
@@ -76,7 +76,7 @@ public class PushDownRequiredColumnsTest extends AbstractPushDownTest {
     @Test
     void withViewQualifier() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors', 'hey')")
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'Authors', 'hey')")
             .load()
             .orderBy("`hey.ForeName`")
             .select("`hey.ForeName`", "`hey.LastName`")
@@ -90,7 +90,7 @@ public class PushDownRequiredColumnsTest extends AbstractPushDownTest {
     @Test
     void dropColumns() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, QUERY_WITH_NO_QUALIFIER)
+            .option(Options.READ_OPTIC_QUERY, QUERY_WITH_NO_QUALIFIER)
             .load()
             .orderBy("ForeName")
             .drop("CitationID", "LastName")

--- a/src/test/java/com/marklogic/spark/reader/ReadRowsMultipleTimesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/ReadRowsMultipleTimesTest.java
@@ -36,7 +36,7 @@ public class ReadRowsMultipleTimesTest extends AbstractIntegrationTest {
     void twoReadsWithInsertInBetween() throws Exception {
         logger.info("Creating reader");
         Dataset<Row> dataset = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('sparkTest', 'allTypes')")
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('sparkTest', 'allTypes')")
             .option(Options.READ_NUM_PARTITIONS, 1)
             .option(Options.READ_BATCH_SIZE, 0)
             .load();

--- a/src/test/java/com/marklogic/spark/reader/ReadRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/ReadRowsTest.java
@@ -55,7 +55,7 @@ public class ReadRowsTest extends AbstractIntegrationTest {
     @Test
     void emptyQualifier() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical','Authors', '')")
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical','Authors', '')")
             .load()
             .collectAsList();
 
@@ -71,7 +71,7 @@ public class ReadRowsTest extends AbstractIntegrationTest {
     @Test
     void queryReturnsZeroRows() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, NO_AUTHORS_QUERY)
+            .option(Options.READ_OPTIC_QUERY, NO_AUTHORS_QUERY)
             .load()
             .collectAsList();
 
@@ -83,7 +83,7 @@ public class ReadRowsTest extends AbstractIntegrationTest {
     @Test
     void invalidQuery() {
         RuntimeException ex = assertThrows(RuntimeException.class, () -> newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'ViewNotFound')")
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'ViewNotFound')")
             .load()
             .count());
 

--- a/src/test/java/com/marklogic/spark/reader/ReadRowsWithAllSparkDataTypesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/ReadRowsWithAllSparkDataTypesTest.java
@@ -107,7 +107,7 @@ public class ReadRowsWithAllSparkDataTypesTest extends AbstractIntegrationTest {
     @Test
     void binaryType() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors').where(op.sqlCondition(\"ForeName = 'Pen'\"))")
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'Authors').where(op.sqlCondition(\"ForeName = 'Pen'\"))")
             .schema(new StructType()
                 .add("Medical.Authors.Base64Value", DataTypes.BinaryType)
             )
@@ -123,7 +123,7 @@ public class ReadRowsWithAllSparkDataTypesTest extends AbstractIntegrationTest {
     @Test
     void trueBooleanValue() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors').where(op.sqlCondition(\"ForeName = 'Pen'\"))")
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'Authors').where(op.sqlCondition(\"ForeName = 'Pen'\"))")
             .schema(new StructType()
                 .add("Medical.Authors.BooleanValue", DataTypes.BooleanType)
             )
@@ -137,7 +137,7 @@ public class ReadRowsWithAllSparkDataTypesTest extends AbstractIntegrationTest {
     @Test
     void falseBooleanValue() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors')" +
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'Authors')" +
                 ".where(op.sqlCondition(\"ForeName = 'Cherianne'\"))")
             .schema(new StructType()
                 .add("Medical.Authors.BooleanValue", DataTypes.BooleanType)
@@ -152,7 +152,7 @@ public class ReadRowsWithAllSparkDataTypesTest extends AbstractIntegrationTest {
     @Test
     void dateType() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors')" +
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'Authors')" +
                 ".where(op.sqlCondition(\"ForeName = 'Finlay'\"))")
             .schema(new StructType()
                 .add("Medical.Authors.Date", DataTypes.DateType)
@@ -189,7 +189,7 @@ public class ReadRowsWithAllSparkDataTypesTest extends AbstractIntegrationTest {
     @Test
     void calendarIntervalType() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors')" +
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'Authors')" +
                 ".where(op.sqlCondition(\"ForeName = 'Pen'\"))")
             .schema(new StructType()
                 .add("Medical.Authors.LastName", DataTypes.StringType)
@@ -211,7 +211,7 @@ public class ReadRowsWithAllSparkDataTypesTest extends AbstractIntegrationTest {
     private Row readFinlayRowWithTimeZone(String timeZone) {
         TimeZone.setDefault(TimeZone.getTimeZone(timeZone));
         List<Row> rows = newDefaultReader(newSparkSession(timeZone))
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical', 'Authors')" +
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'Authors')" +
                 ".where(op.sqlCondition(\"ForeName = 'Finlay'\"))")
             .schema(new StructType()
                 .add("Medical.Authors.DateTime", DataTypes.TimestampType)

--- a/src/test/java/com/marklogic/spark/reader/ReadRowsWithInferredSchemaTest.java
+++ b/src/test/java/com/marklogic/spark/reader/ReadRowsWithInferredSchemaTest.java
@@ -36,7 +36,7 @@ public class ReadRowsWithInferredSchemaTest extends AbstractIntegrationTest {
     @Test
     void allTypes() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL,
+            .option(Options.READ_OPTIC_QUERY,
                 "op.fromView('sparkTest', 'allTypes').where(op.sqlCondition('intValue = 1'))")
             .load()
             .collectAsList();
@@ -91,7 +91,7 @@ public class ReadRowsWithInferredSchemaTest extends AbstractIntegrationTest {
     @Test
     void allColumnsNullExceptRequiredOne() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL,
+            .option(Options.READ_OPTIC_QUERY,
                 "op.fromView('sparkTest', 'allTypes').where(op.sqlCondition('intValue = 2'))")
             .load()
             .collectAsList();
@@ -109,7 +109,7 @@ public class ReadRowsWithInferredSchemaTest extends AbstractIntegrationTest {
     @Test
     void rowWithInvalidLongValueThatShouldBeIgnored() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL,
+            .option(Options.READ_OPTIC_QUERY,
                 "op.fromView('sparkTest', 'allTypes').where(op.sqlCondition('intValue = 3'))")
             .load()
             .collectAsList();
@@ -124,7 +124,7 @@ public class ReadRowsWithInferredSchemaTest extends AbstractIntegrationTest {
     @Test
     void selectSubsetOfColumns() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL,
+            .option(Options.READ_OPTIC_QUERY,
                 "op.fromView('sparkTest', 'allTypes')" +
                     ".select(['intValue', 'timeValue'])")
             .option(Options.READ_NUM_PARTITIONS, "1")

--- a/src/test/java/com/marklogic/spark/reader/ReadStreamOfRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/ReadStreamOfRowsTest.java
@@ -37,7 +37,7 @@ public class ReadStreamOfRowsTest extends AbstractIntegrationTest {
             .option(Options.CLIENT_URI, makeClientUri())
             // With 3 partitions, the logging will show 3 queries to MarkLogic with a "write" occurring after each one.
             .option(Options.READ_NUM_PARTITIONS, 3)
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical','Authors')")
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical','Authors')")
             .load()
             .writeStream()
             .format(CONNECTOR_IDENTIFIER)
@@ -62,7 +62,7 @@ public class ReadStreamOfRowsTest extends AbstractIntegrationTest {
             .format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.READ_NUM_PARTITIONS, 2)
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical','Authors')")
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical','Authors')")
             .load()
             .writeStream()
             .format("memory")
@@ -91,6 +91,6 @@ public class ReadStreamOfRowsTest extends AbstractIntegrationTest {
                 .load()
         );
 
-        assertEquals("No Optic query found; must define spark.marklogic.read.opticDsl", ex.getMessage());
+        assertEquals("No Optic query found; must define spark.marklogic.read.opticQuery", ex.getMessage());
     }
 }

--- a/src/test/java/com/marklogic/spark/reader/ReadWithClientUriTest.java
+++ b/src/test/java/com/marklogic/spark/reader/ReadWithClientUriTest.java
@@ -103,7 +103,7 @@ public class ReadWithClientUriTest extends AbstractIntegrationTest {
             .read()
             .format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, clientUri)
-            .option(Options.READ_OPTIC_DSL, "op.fromView('Medical','Authors')")
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical','Authors')")
             .load()
             .collectAsList();
     }

--- a/src/test/java/com/marklogic/spark/reader/ReadWithJoinDocTest.java
+++ b/src/test/java/com/marklogic/spark/reader/ReadWithJoinDocTest.java
@@ -31,7 +31,7 @@ public class ReadWithJoinDocTest extends AbstractIntegrationTest {
     @Test
     void jsonDocuments() throws Exception {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_OPTIC_DSL,
+            .option(Options.READ_OPTIC_QUERY,
                 "const idCol = op.fragmentIdCol('id'); " +
                     "op.fromView('sparkTest', 'allTypes', '', idCol)" +
                     ".where(op.sqlCondition('intValue = 1'))" +


### PR DESCRIPTION
This is in line with our use of the term "Optic Query" in the Optic Getting Started docs. 

If we need support for a serialized query in the future, we'll do "opticSerializedQuery".