### PR TITLE
Ignoring allTypes test on MarkLogic 10

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/SchemaInferrer.java
+++ b/src/main/java/com/marklogic/spark/reader/SchemaInferrer.java
@@ -63,6 +63,7 @@ public abstract class SchemaInferrer {
         put("unsignedInt", DataTypes.IntegerType);
         put("iri", DataTypes.StringType);
         put("time", DataTypes.StringType);
+        put("unknown", DataTypes.StringType);
     }};
 
     /**


### PR DESCRIPTION
Also added "unknown" -> String since we're certain of that mapping now and it avoids several warning log messages.