### PR TITLE
Improving groupBy pushdown to work for multiple column names

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/PlanUtil.java
+++ b/src/main/java/com/marklogic/spark/reader/PlanUtil.java
@@ -48,9 +48,10 @@ public abstract class PlanUtil {
         });
     }
 
-    static ObjectNode buildGroupByCount(String columnName) {
+    static ObjectNode buildGroupByCount(List<String> columnNames) {
         return newOperation("group-by", args -> {
-            populateSchemaCol(args.addObject(), columnName);
+            ArrayNode columns = args.addArray();
+            columnNames.forEach(columnName -> populateSchemaCol(columns.addObject(), columnName));
             addCountArg(args);
         });
     }


### PR DESCRIPTION
Turns out this was a simple enhancement since `op.groupBy` already supports multiple column names being passed in.