### PR TITLE
Fixing issue with multiple orderBy/sort clauses

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/ReadContext.java
+++ b/src/main/java/com/marklogic/spark/reader/ReadContext.java
@@ -155,9 +155,7 @@ public class ReadContext extends ContextSupport {
     }
 
     void pushDownTopN(SortOrder[] orders, int limit) {
-        for (SortOrder sortOrder : orders) {
-            addOperatorToPlan(PlanUtil.buildOrderBy(sortOrder));
-        }
+        addOperatorToPlan(PlanUtil.buildOrderBy(orders));
         pushDownLimit(limit);
     }
 

--- a/src/test/java/com/marklogic/spark/reader/PushDownOrderByAndLimitTest.java
+++ b/src/test/java/com/marklogic/spark/reader/PushDownOrderByAndLimitTest.java
@@ -192,6 +192,9 @@ public class PushDownOrderByAndLimitTest extends AbstractPushDownTest {
     void sortByMultiple() {
         List<Row> rows = newDefaultReader()
             .option(Options.READ_OPTIC_QUERY, QUERY_WITH_NO_QUALIFIER)
+            // Force a single request to ensure the orderBy is constructed correctly.
+            .option(Options.READ_NUM_PARTITIONS, 1)
+            .option(Options.READ_BATCH_SIZE, 0)
             .load()
             .sort("CitationID", "LastName")
             .limit(8)


### PR DESCRIPTION
Was creating multiple orderBy functions in Optic; need to create a single one