### PR TITLE
Added docs for reading via custom queries

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -253,6 +253,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/docs/getting-started/pyspark.md
+++ b/docs/getting-started/pyspark.md
@@ -80,7 +80,8 @@ information on how a Spark DataFrame works along with more commands that you can
 
 The instructions above can be applied to your own MarkLogic application. You can use the same Spark command above,
 simply adjusting the connection details and the Optic query. Please see 
-[the guide on reading data](../reading.md) for more information on how data can be read from MarkLogic.
+[the guide on reading data](../reading.md) for more information on how data can be read from MarkLogic, including via custom 
+JavaScript and XQuery code.
 
 ### Writing data to the connector
 

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -4,14 +4,21 @@ title: Reading Data
 nav_order: 3
 ---
 
-The MarkLogic connector allows for data to be retrieved from MarkLogic as rows via an 
-[Optic query](https://docs.marklogic.com/guide/app-dev/OpticAPI#id_46710). The 
-sections below provide more detail on configuring how data is retrieved and converted into a Spark DataFrame.
 
-## Basic read operation
+The MarkLogic connector allows for data to be retrieved from MarkLogic as rows either via an  
+[Optic query](https://docs.marklogic.com/guide/app-dev/OpticAPI#id_46710) or via custom code written in JavaScript or XQuery.
 
-As shown in the [Getting Started with PySpark guide](getting-started/pyspark.md), a basic read operation will define
-how the connector should connect to MarkLogic, the MarkLogic Optic query to run, and zero or more other options:
+## Table of contents
+{: .no_toc .text-delta }
+
+- TOC
+{:toc}
+
+## Reading rows via Optic
+
+As shown in the [Getting Started with PySpark guide](getting-started/pyspark.md), a read operation will define
+how the connector should connect to MarkLogic, the MarkLogic Optic query to run (or a custom JavaScript or XQuery query; 
+see the next section for more information), and zero or more other options:
 
 ```
 df = spark.read.format("com.marklogic.spark") \
@@ -46,7 +53,7 @@ The `where` clause in the example above can include any of the query features su
 query expansion via [a thesaurus](https://docs.marklogic.com/guide/search-dev/thesaurus) or 
 [spelling correction](https://docs.marklogic.com/guide/search-dev/spelling).
 
-## Optic query requirements
+### Optic query requirements
 
 As of the 2.0.0 release of the connector, the Optic query must use the 
 [op.fromView](https://docs.marklogic.com/op.fromView) accessor function. Future releases of both the connector and 
@@ -64,7 +71,7 @@ Finally, the query must adhere to the handful of limitations imposed by the
 query is to run it in your [MarkLogic server's qconsole tool](https://docs.marklogic.com/guide/qconsole) in a buffer 
 with a query type of "Optic DSL". 
 
-## Schema inference
+### Schema inference
 
 The connector will infer a Spark schema automatically based on the view identified by `op.fromView` in
 the Optic query. Each column returned by your Optic query will be mapped to a Spark schema column with the 
@@ -83,7 +90,7 @@ df = spark.read.format("com.marklogic.spark") \
     .load()
 ```
 
-## Accessing documents 
+### Accessing documents 
 
 While the connector requires that an Optic query use `op.fromView` as its accessor function, documents can still be
 retrieved via the [Optic functions for joining documents](https://docs.marklogic.com/guide/app-dev/OpticAPI#id_78437). 
@@ -107,7 +114,7 @@ Calling `df.show()` will then show the URI and JSON contents of the document ass
 [from_json](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.from_json.html)
 function can then be used to parse the contents of each `doc` column into a JSON object as needed. 
 
-## Streaming support
+### Streaming support
 
 The connector supports
 [streaming reads](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html) from MarkLogic
@@ -142,21 +149,7 @@ The number of micro-batches can be determined by enabling info-level logging and
 
     Partition count: 2; number of requests that will be made to MarkLogic: 2
 
-## Error handling
-
-When reading data with the connector, any error that occurs - whether it is before any data is read or during a request
-to MarkLogic to read data - is immediately thrown to the user and the read operation ends without any result being 
-returned. This is consistent with the design of Spark connectors, where a partition reader is allowed to throw 
-exceptions and is not given any mechanism for reporting an error and continuing to read data. The connector will strive 
-to provide meaningful context when an error occurs to assist with debugging the cause of the error. 
-
-In practice, it is expected that most errors will be a result of a misconfiguration. For example, the connection and 
-authentication options may be incorrect, or the Optic query may have a syntax error. Any errors that cannot be 
-fixed via changes to the options passed to the connector should be 
-[reported as new issues](https://github.com/marklogic/marklogic-spark-connector/issues) in the connector's GitHub
-repository.
-
-## Pushing down operations
+### Pushing down operations
 
 The Spark connector framework supports pushing down multiple operations to the connector data source. This can
 often provide a significant performance boost by allowing the data source to perform the operation, which can result in
@@ -216,67 +209,154 @@ If you run into any issues with aggregates being pushed down to MarkLogic, you c
 `spark.marklogic.read.pushDownAggregates` option to `false`. If doing so results in what appears to be a different and 
 correct result, please [file an issue with this project](https://github.com/marklogic/marklogic-spark-connector/issues).
 
+### Tuning performance
 
-## Tuning performance
+The primary factor affecting connector performance when reading rows is how many requests are made to MarkLogic. In
+general, performance will be best when minimizing the number of requests to MarkLogic while ensuring that no single
+request attempts to return or process too much data.
 
-The primary factor affecting connector performance when reading rows is how many requests are made to MarkLogic. In 
-general, performance will be best when minimizing the number of requests to MarkLogic while ensuring that no single 
-request attempts to return or process too much data. 
+Two [configuration options](configuration.md) control how many requests are made. First, the
+`spark.marklogic.read.numPartitions` option controls how many partitions are created. For each partition, Spark
+will use a separate task to send requests to MarkLogic to retrieve rows matching your Optic DSL query. Second, the
+`spark.marklogic.read.batchSize` option controls approximately how many rows will be retrieved in each call to
+MarkLogic.
 
-Two [configuration options](configuration.md) control how many requests are made. First, the 
-`spark.marklogic.read.numPartitions` option controls how many partitions are created. For each partition, Spark 
-will use a separate task to send requests to MarkLogic to retrieve rows matching your Optic DSL query. Second, the 
-`spark.marklogic.read.batchSize` option controls approximately how many rows will be retrieved in each call to 
+To understand how these options control the number of requests to MarkLogic,
+consider an Optic query that matches 10 million rows in MarkLogic, a partition count of 10, and a batch size of
+100,000 rows (the default value). This configuration will result in the connector creating 10 Spark partition readers,
+each of which will retrieve approximately 1,000,000 unique rows. And with a batch size of 100,000, each partition
+reader will make approximately 10 calls to MarkLogic to retrieve these rows, for a total of 100 calls across all
+partitions.
+
+Performance should be tested by varying the number of partitions and the batch size. In general, increasing the
+number of partitions should help performance as the number of rows to return increases. Determining the optimal batch
+size depends both on the number of columns in each returned row and what kind of Spark operations are being invoked.
+The next section describes both how the connector tries to optimize performance when an aggregation is performed
+and when the same kind of optimization should be made when not many rows need to be returned.
+
+#### Optimizing for smaller result sets
+
+If your Optic query matches a set of rows whose count is a small percentage of the total number of rows in
+the view that the query runs against, you should find improved performance by setting `spark.marklogic.read.batchSize`
+to zero. This setting ensures that for each partition, a single request is sent to MarkLogic.
+
+If your Spark program includes an aggregation that the connector can push down to MarkLogic, then the connector will
+automatically use a batch size of zero unless you specify a different value for `spark.marklogic.read.batchSize`. This
+optimization should typically be desirable when calculating an aggregation, as MarkLogic will return far fewer rows
+per request depending on the type of aggregation.
+
+If the result set matching your query is particularly small - such as tens of thousands of rows or less, or possibly
+hundreds of thousands of rows or less - you may find optimal performance by setting
+`spark.marklogic.read.numPartitions` to one. This will result in the connector sending a single request to MarkLogic.
+The effectiveness of this approach can be evaluated by executing the Optic query via
+[MarkLogic's qconsole application](https://docs.marklogic.com/guide/qconsole/intro), which will execute the query in
+a single request as well.
+
+#### More detail on partitions
+
+This section is solely informational and is not required understanding for using the connector
+successfully.
+
+For MarkLogic users familiar with the [Data Movement SDK](https://docs.marklogic.com/guide/java/data-movement), the
+concept of a "partition" may suggest that the number and location of forests in a database play a role. But due to
+the ability of an Optic query to perform joins across documents, the goal of running a query against a single forest
+is not meaningful, as constructing a row may require data from documents in many forests across many hosts.
+
+Instead of referring to forests, a "partition" in the scope of the connector refers to a set of
+internal row identifiers that are generated at a particular server timestamp. Each row matching an Optic query is
+assigned a random identifier, which can be any number in the range from zero to the max unsigned long value. A
+partition is a slice of numbers within that range. Because row identifiers are generated randomly, matching rows
+can be expected to be fairly evenly distributed across each partition, but the number of rows in each partition will
+most likely not be equal.
+
+Because row identifiers are specific to a MarkLogic server timestamp, all requests sent to MarkLogic for a given
+query will use the same server timestamp, thus ensuring consistent results. This behavior is analogous to the use of a
+[consistent snapshot](https://docs.marklogic.com/guide/java/data-movement#id_18227) when using the Data Movement SDK.
+
+
+## Reading rows via custom code
+
+Rows can be retrieved via custom code executed by MarkLogic and written in either JavaScript or XQuery. This can be
+useful when you need to retrieve data that cannot be easily accessed via Optic, or you are looking for behavior similar 
+to that of [MarkLogic's CoRB tool](https://github.com/marklogic-community/corb2) for processing data already in 
 MarkLogic. 
 
-To understand how these options control the number of requests to MarkLogic, 
-consider an Optic query that matches 10 million rows in MarkLogic, a partition count of 10, and a batch size of 
-100,000 rows (the default value). This configuration will result in the connector creating 10 Spark partition readers,
-each of which will retrieve approximately 1,000,000 unique rows. And with a batch size of 100,000, each partition 
-reader will make approximately 10 calls to MarkLogic to retrieve these rows, for a total of 100 calls across all 
-partitions.  
+Custom code can be written in [JavaScript](https://docs.marklogic.com/guide/getting-started/javascript) by 
+configuring the `spark.marklogic.read.javascript` option:
 
-Performance should be tested by varying the number of partitions and the batch size. In general, increasing the 
-number of partitions should help performance as the number of rows to return increases. Determining the optimal batch 
-size depends both on the number of columns in each returned row and what kind of Spark operations are being invoked. 
-The next section describes both how the connector tries to optimize performance when an aggregation is performed
-and when the same kind of optimization should be made when not many rows need to be returned. 
+```
+df = spark.read.format("com.marklogic.spark") \
+    .option("spark.marklogic.client.uri", "spark-example-user:password@localhost:8020") \
+    .option("spark.marklogic.read.javascript", "cts.uris([], [], cts.collectionQuery('example'))") \
+    .load()
+```
 
-### Optimizing for smaller result sets
+Or in [XQuery](https://docs.marklogic.com/guide/getting-started/XQueryTutorial) by configuring the 
+`spark.marklogic.read.xquery` option:
 
-If your Optic query matches a set of rows whose count is a small percentage of the total number of rows in 
-the view that the query runs against, you should find improved performance by setting `spark.marklogic.read.batchSize` 
-to zero. This setting ensures that for each partition, a single request is sent to MarkLogic. 
+```
+df = spark.read.format("com.marklogic.spark") \
+    .option("spark.marklogic.client.uri", "spark-example-user:password@localhost:8020") \
+    .option("spark.marklogic.read.xquery", "cts:uris((), (), cts:collection-query('example')") \
+    .load()
+```
 
-If your Spark program includes an aggregation that the connector can push down to MarkLogic, then the connector will 
-automatically use a batch size of zero unless you specify a different value for `spark.marklogic.read.batchSize`. This
-optimization should typically be desirable when calculating an aggregation, as MarkLogic will return far fewer rows 
-per request depending on the type of aggregation. 
+You can also invoke a JavaScript or XQuery module in your application's modules database via the 
+`spark.marklogic.read.invoke` option:
 
-If the result set matching your query is particularly small - such as tens of thousands of rows or less, or possibly 
-hundreds of thousands of rows or less - you may find optimal performance by setting 
-`spark.marklogic.read.numPartitions` to one. This will result in the connector sending a single request to MarkLogic.
-The effectiveness of this approach can be evaluated by executing the Optic query via 
-[MarkLogic's qconsole application](https://docs.marklogic.com/guide/qconsole/intro), which will execute the query in
-a single request as well. 
+```
+df = spark.read.format("com.marklogic.spark") \
+    .option("spark.marklogic.client.uri", "spark-example-user:password@localhost:8020") \
+    .option("spark.marklogic.read.invoke", "/path/to/module.sjs") \
+    .load()
+```
 
-### More detail on partitions
+### Custom code schemas
 
-This section is solely informational and is not required understanding for using the connector 
-successfully. 
+While the connector can infer a schema when executing an Optic query, it does not have any way to do so with custom 
+code, which can return any kind of data. As a sensible default - particularly since the most common use case for 
+executing custom code is to return one or more documents URIs - the connector will assume a schema with a single 
+column named "URI" and of type string. The custom code is thus expected to return a sequence of zero or more values,
+each of which will become a string value in a row with a single column named "URI". 
 
-For MarkLogic users familiar with the [Data Movement SDK](https://docs.marklogic.com/guide/java/data-movement), the 
-concept of a "partition" may suggest that the number and location of forests in a database play a role. But due to 
-the ability of an Optic query to perform joins across documents, the goal of running a query against a single forest 
-is not meaningful, as constructing a row may require data from documents in many forests across many hosts. 
+If your custom code needs to return a different sequence of values, you can specify the schema in your Spark program 
+and the connector will use it instead. For example, the following expects that the `/path/to/module.sjs` will return
+JSON objects with columns that conform to the given schema:
 
-Instead of referring to forests, a "partition" in the scope of the connector refers to a set of 
-internal row identifiers that are generated at a particular server timestamp. Each row matching an Optic query is 
-assigned a random identifier, which can be any number in the range from zero to the max unsigned long value. A 
-partition is a slice of numbers within that range. Because row identifiers are generated randomly, matching rows 
-can be expected to be fairly evenly distributed across each partition, but the number of rows in each partition will 
-most likely not be equal.  
+(TODO Assumption is that we can use the technique currently in use for converting a JSON object into a Spark row via
+Spark's JacksonParser.)
 
-Because row identifiers are specific to a MarkLogic server timestamp, all requests sent to MarkLogic for a given 
-query will use the same server timestamp, thus ensuring consistent results. This behavior is analogous to the use of a 
-[consistent snapshot](https://docs.marklogic.com/guide/java/data-movement#id_18227) when using the Data Movement SDK.
+```
+df = spark.read.format("com.marklogic.spark") \
+    .option("spark.marklogic.client.uri", "spark-example-user:password@localhost:8020") \
+    .option("spark.marklogic.read.invoke", "/path/to/module.sjs") \
+    .schema(new StructType() \
+        .add("MyValue", DataTypes.StringType) \
+        .add("MyTimestamp", DataTypes.TimestampType) \
+    ) \
+    .load()
+```
+
+### Tuning performance
+
+A key difference with reading via custom code is that a single call will be made to MarkLogic to execute the custom 
+code. Therefore, the options `spark.marklogic.read.batchSize` and `spark.marklogic.read.numPartitions` will not have 
+any impact on the performance of executing custom code. This behavior matches that of both MarkLogic's CoRB tool and 
+[MarkLogic's Data Hub](https://docs.marklogic.com/datahub/6.0/). You must ensure that you are executing custom code query that can be expected to 
+complete in a single call to MarkLogic without timing out.
+
+## Error handling
+
+When reading data with the connector, any error that occurs - whether it is before any data is read or during a request
+to MarkLogic to read data - is immediately thrown to the user and the read operation ends without any result being
+returned. This is consistent with the design of Spark connectors, where a partition reader is allowed to throw
+exceptions and is not given any mechanism for reporting an error and continuing to read data. The connector will strive
+to provide meaningful context when an error occurs to assist with debugging the cause of the error.
+
+In practice, it is expected that most errors will be a result of a misconfiguration. For example, the connection and
+authentication options may be incorrect, or the Optic query may have a syntax error. Any errors that cannot be
+fixed via changes to the options passed to the connector should be
+[reported as new issues](https://github.com/marklogic/marklogic-spark-connector/issues) in the connector's GitHub
+repository.
+
+


### PR DESCRIPTION
- Added a TOC
- Moved all the Optic-specific sections under the overall "Reading via Optic" section
- Bumped "Error Handling" to the bottom since it'll be the same for both Optic and custom queries

There are some whitespace changes in terms of newline symbols, so be sure to ignore those when reviewing in GH. 