### PR TITLE
Quieting down some logging

### DIFF
--- a/src/main/java/com/marklogic/spark/writer/WriteContext.java
+++ b/src/main/java/com/marklogic/spark/writer/WriteContext.java
@@ -71,7 +71,8 @@ public class WriteContext extends ContextSupport {
         if (uriTemplate != null && uriTemplate.trim().length() > 0) {
             factory.withUriMaker(new SparkRowUriMaker(uriTemplate));
             Stream.of(Options.WRITE_URI_PREFIX, Options.WRITE_URI_SUFFIX).forEach(option -> {
-                if (getProperties().containsKey(option)) {
+                String value = getProperties().get(option);
+                if (value != null && value.trim().length() > 0) {
                     logger.warn("Option {} will be ignored since option {} was specified.", option, Options.WRITE_URI_TEMPLATE);
                 }
             });


### PR DESCRIPTION
The logged warning was showing up even if the value for the URI prefix/suffix was null. No automated test included as we don't have a way to verify logging. So just did some quick manual testing. 