### PR TITLE
DEVEXP-599 Refactored use of Spark's JacksonParser

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/CustomCodePartitionReader.java
+++ b/src/main/java/com/marklogic/spark/reader/CustomCodePartitionReader.java
@@ -1,27 +1,13 @@
 package com.marklogic.spark.reader;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
 import com.marklogic.client.eval.EvalResultIterator;
 import com.marklogic.client.eval.ServerEvaluationCall;
 import com.marklogic.spark.CustomCodeContext;
 import com.marklogic.spark.Options;
-import com.marklogic.spark.Util;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
-import org.apache.spark.sql.catalyst.json.CreateJacksonParser;
-import org.apache.spark.sql.catalyst.json.JacksonParser;
 import org.apache.spark.sql.connector.read.PartitionReader;
-import org.apache.spark.sql.sources.Filter;
-import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
-import scala.Function1;
-import scala.Function2;
-import scala.collection.JavaConverters;
-import scala.collection.Seq;
-import scala.compat.java8.JFunction;
-
-import java.util.ArrayList;
 
 class CustomCodePartitionReader implements PartitionReader {
 
@@ -29,29 +15,14 @@ class CustomCodePartitionReader implements PartitionReader {
     private final boolean isCustomSchema;
 
     private EvalResultIterator evalResultIterator;
-
-    private final JacksonParser jacksonParser;
-    private final Function2<JsonFactory, String, JsonParser> jsonParserCreator;
-    private final Function1<String, UTF8String> utf8StringCreator;
-
+    private final JsonRowDeserializer jsonRowDeserializer;
 
     public CustomCodePartitionReader(CustomCodeContext customCodeContext) {
         this.serverEvaluationCall = customCodeContext.buildCall(
             Options.READ_INVOKE, Options.READ_JAVASCRIPT, Options.READ_XQUERY
         );
         this.isCustomSchema = customCodeContext.isCustomSchema();
-
-        // TODO Big pile of duplication here. Will refactor this in a follow-up PR.
-        this.jacksonParser = newJacksonParser(customCodeContext.getSchema());
-        this.jsonParserCreator = JFunction.func((jsonFactory, someString) -> CreateJacksonParser.string(jsonFactory, someString));
-        this.utf8StringCreator = JFunction.func((someString) -> UTF8String.fromString(someString));
-    }
-
-    private JacksonParser newJacksonParser(StructType schema) {
-        // TODO More duplication here to refactor in a follow-up PR.
-        final boolean allowArraysAsStructs = true;
-        final Seq<Filter> filters = JavaConverters.asScalaIterator(new ArrayList().iterator()).toSeq();
-        return new JacksonParser(schema, Util.DEFAULT_JSON_OPTIONS, allowArraysAsStructs, filters);
+        this.jsonRowDeserializer = new JsonRowDeserializer(customCodeContext.getSchema());
     }
 
     @Override
@@ -66,7 +37,7 @@ class CustomCodePartitionReader implements PartitionReader {
     public InternalRow get() {
         String val = this.evalResultIterator.next().getString();
         if (this.isCustomSchema) {
-            return this.jacksonParser.parse(val, this.jsonParserCreator, this.utf8StringCreator).head();
+            return this.jsonRowDeserializer.deserializeJson(val);
         }
         return new GenericInternalRow(new Object[]{UTF8String.fromString(val)});
     }

--- a/src/main/java/com/marklogic/spark/reader/JsonRowDeserializer.java
+++ b/src/main/java/com/marklogic/spark/reader/JsonRowDeserializer.java
@@ -1,0 +1,57 @@
+package com.marklogic.spark.reader;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.marklogic.spark.Util;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.json.CreateJacksonParser;
+import org.apache.spark.sql.catalyst.json.JacksonParser;
+import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
+import scala.Function1;
+import scala.Function2;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+import scala.compat.java8.JFunction;
+
+import java.util.ArrayList;
+
+/**
+ * Handles deserializing a JSON object into a Spark InternalRow. This is accomplished via Spark's JacksonParser.
+ * This class is critical to our connector, though unfortunately there doesn't seem to be much in the way of public
+ * docs for it. Source code for it can be found at:
+ * https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+ * <p>
+ * As noted in the code, JacksonParser can translate a string of JSON into a Spark InternalRow based on a schema.
+ * That's exactly what we want, so we don't need to have any knowledge of how to convert to Spark's set of data
+ * types.
+ */
+class JsonRowDeserializer {
+
+    private final JacksonParser jacksonParser;
+    private final Function2<JsonFactory, String, JsonParser> jsonParserCreator;
+    private final Function1<String, UTF8String> utf8StringCreator;
+
+    JsonRowDeserializer(StructType schema) {
+        this.jacksonParser = newJacksonParser(schema);
+
+        // Used https://github.com/scala/scala-java8-compat in the DHF Spark 2 connector. Per the README for
+        // scala-java8-compat, we should be able to use scala.jdk.FunctionConverters since those are part of Scala
+        // 2.13. However, that is not yet working within PySpark. So sticking with this "legacy" appraoch as it seems
+        // to work fine in both vanilla Spark (i.e. JUnit tests) and PySpark.
+        this.jsonParserCreator = JFunction.func((jsonFactory, someString) -> CreateJacksonParser.string(jsonFactory, someString));
+
+        this.utf8StringCreator = JFunction.func((someString) -> UTF8String.fromString(someString));
+    }
+
+    InternalRow deserializeJson(String json) {
+        return this.jacksonParser.parse(json, this.jsonParserCreator, this.utf8StringCreator).head();
+    }
+    
+    private JacksonParser newJacksonParser(StructType schema) {
+        final boolean allowArraysAsStructs = true;
+        final Seq<Filter> filters = JavaConverters.asScalaIterator(new ArrayList().iterator()).toSeq();
+        return new JacksonParser(schema, Util.DEFAULT_JSON_OPTIONS, allowArraysAsStructs, filters);
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/MarkLogicPartitionReader.java
+++ b/src/main/java/com/marklogic/spark/reader/MarkLogicPartitionReader.java
@@ -16,29 +16,15 @@
 
 package com.marklogic.spark.reader;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.row.RowManager;
-import com.marklogic.spark.Util;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.catalyst.json.CreateJacksonParser;
-import org.apache.spark.sql.catalyst.json.JacksonParser;
 import org.apache.spark.sql.connector.read.PartitionReader;
-import org.apache.spark.sql.sources.Filter;
-import org.apache.spark.sql.types.StructType;
-import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Function1;
-import scala.Function2;
-import scala.collection.JavaConverters;
-import scala.collection.Seq;
-import scala.compat.java8.JFunction;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.function.Consumer;
 
@@ -50,9 +36,7 @@ class MarkLogicPartitionReader implements PartitionReader {
     private final PlanAnalysis.Partition partition;
     private final RowManager rowManager;
 
-    private final JacksonParser jacksonParser;
-    private final Function2<JsonFactory, String, JsonParser> jsonParserCreator;
-    private final Function1<String, UTF8String> utf8StringCreator;
+    private JsonRowDeserializer jsonRowDeserializer;
 
     private Iterator<JsonNode> rowIterator;
     private int nextBucketIndex;
@@ -71,17 +55,10 @@ class MarkLogicPartitionReader implements PartitionReader {
         this.readContext = readContext;
         this.partition = partition;
         this.rowManager = readContext.connectToMarkLogic().newRowManager();
-        // Nested values won't work with JacksonParser, so we ask for type info to not be in the rows.
+        // Nested values won't work with the JacksonParser used by JsonRowDeserializer, so we ask for type info to not
+        // be in the rows.
         this.rowManager.setDatatypeStyle(RowManager.RowSetPart.HEADER);
-
-        this.jacksonParser = newJacksonParser(readContext.getSchema());
-
-        // Used https://github.com/scala/scala-java8-compat in the DHF Spark 2 connector. Per the README for
-        // scala-java8-compat, we should be able to use scala.jdk.FunctionConverters since those are part of Scala
-        // 2.13. However, that is not yet working within PySpark. So sticking with this "legacy" appraoch as it seems
-        // to work fine in both vanilla Spark (i.e. JUnit tests) and PySpark.
-        this.jsonParserCreator = JFunction.func((jsonFactory, someString) -> CreateJacksonParser.string(jsonFactory, someString));
-        this.utf8StringCreator = JFunction.func((someString) -> UTF8String.fromString(someString));
+        this.jsonRowDeserializer = new JsonRowDeserializer(readContext.getSchema());
     }
 
     @Override
@@ -124,7 +101,7 @@ class MarkLogicPartitionReader implements PartitionReader {
         this.currentBucketRowCount++;
         this.totalRowCount++;
         JsonNode row = rowIterator.next();
-        return this.jacksonParser.parse(row.toString(), this.jsonParserCreator, this.utf8StringCreator).head();
+        return this.jsonRowDeserializer.deserializeJson(row.toString());
     }
 
     @Override
@@ -135,27 +112,6 @@ class MarkLogicPartitionReader implements PartitionReader {
 
         // Not yet certain how to make use of CustomTaskMetric, so just logging metrics of interest for now.
         logMetrics();
-    }
-
-    /**
-     * Spark's JacksonParser class is a critical part of our connector, though there doesn't seem to be much in the
-     * way of public docs for it. Source code for it can be found at:
-     * https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
-     * <p>
-     * As noted in the code, JacksonParser can translate a string of JSON into a Spark InternalRow based on a schema.
-     * That's exactly what we want, so we don't need to have any knowledge of how to convert to Spark's set of data
-     * types.
-     *
-     * @param schema
-     */
-    private JacksonParser newJacksonParser(StructType schema) {
-        // Have not yet found documentation on this parameter for JacksonParser, but it does not seem relevant as a
-        // column value in TDE will be a single value and not an array.
-        final boolean allowArraysAsStructs = true;
-
-        // No use cases for filters so far.
-        final Seq<Filter> filters = JavaConverters.asScalaIterator(new ArrayList().iterator()).toSeq();
-        return new JacksonParser(schema, Util.DEFAULT_JSON_OPTIONS, allowArraysAsStructs, filters);
     }
 
     private void logMetrics() {

--- a/src/main/java/com/marklogic/spark/writer/DocBuilderFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/DocBuilderFactory.java
@@ -44,29 +44,7 @@ class DocBuilderFactory {
     }
 
     DocBuilderFactory withPermissions(String permissionsString) {
-        DocumentMetadataHandle.DocumentPermissions permissions = metadata.getPermissions();
-        // TODO Copied from ml-javaclient-util. Should be in java-client-api.
-        if (permissionsString != null && permissionsString.trim().length() > 0) {
-            String[] tokens = permissionsString.split(",");
-            for (int i = 0; i < tokens.length; i += 2) {
-                String role = tokens[i];
-                if (i + 1 >= tokens.length) {
-                    throw new IllegalArgumentException("Unable to parse permissions string, which must be a comma-separated " +
-                        "list of role names and capabilities - i.e. role1,read,role2,update,role3,execute; string: " + permissionsString);
-                }
-                DocumentMetadataHandle.Capability c;
-                try {
-                    c = DocumentMetadataHandle.Capability.getValueOf(tokens[i + 1]);
-                } catch (Exception e) {
-                    throw new IllegalArgumentException("Unable to parse permissions string: " + permissionsString + "; cause: " + e.getMessage());
-                }
-                if (permissions.containsKey(role)) {
-                    permissions.get(role).add(c);
-                } else {
-                    permissions.add(role, c);
-                }
-            }
-        }
+        metadata.getPermissions().addFromDelimitedString(permissionsString);
         return this;
     }
 

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
@@ -177,7 +177,7 @@ public class WriteRowsTest extends AbstractWriteTest {
 
         Throwable cause = getCauseFromWriterException(ex);
         assertTrue(cause instanceof IllegalArgumentException);
-        assertEquals("Unable to parse permissions string, which must be a comma-separated list of role names and " +
+        assertEquals("Unable to parse permissions string, which must be a comma-delimited list of role names and " +
             "capabilities - i.e. role1,read,role2,update,role3,execute; " +
             "string: rest-reader,read,rest-writer", cause.getMessage());
     }


### PR DESCRIPTION
Had it duplicated in two places; hoping that the new `JsonRowDeserializer` also sheds light on the important task of converting a JSON string into a Spark row. 

Also addressed another TODO in DocBuilderFactory. 

All refactoring, no functional changes. 