### PR TITLE
Tweaked logging in MarkLogicWrite

### DIFF
--- a/src/main/java/com/marklogic/spark/writer/MarkLogicWrite.java
+++ b/src/main/java/com/marklogic/spark/writer/MarkLogicWrite.java
@@ -57,15 +57,15 @@ class MarkLogicWrite implements BatchWrite, StreamingWrite {
 
     @Override
     public void commit(WriterCommitMessage[] messages) {
-        if (messages != null && messages.length > 0) {
-            logger.info("Commit messages received: {}", Arrays.asList(messages));
+        if (messages != null && messages.length > 0 && logger.isDebugEnabled()) {
+            logger.debug("Commit messages received: {}", Arrays.asList(messages));
         }
     }
 
     @Override
     public void abort(WriterCommitMessage[] messages) {
         if (messages != null && messages.length > 0) {
-            logger.error("Abort messages received: {}", Arrays.asList(messages));
+            logger.warn("Abort messages received: {}", Arrays.asList(messages));
         }
     }
 
@@ -76,12 +76,15 @@ class MarkLogicWrite implements BatchWrite, StreamingWrite {
 
     @Override
     public void commit(long epochId, WriterCommitMessage[] messages) {
-        // TODO Look into if this is really a good idea when there are lots of messages.
-        logger.info("Commit messages received for epochId {}: {}", epochId, Arrays.asList(messages));
+        if (messages != null && messages.length > 0 && logger.isDebugEnabled()) {
+            logger.debug("Commit messages received for epochId {}: {}", epochId, Arrays.asList(messages));
+        }
     }
 
     @Override
     public void abort(long epochId, WriterCommitMessage[] messages) {
-        logger.info("Abort messages received for epochId {}: {}", epochId, Arrays.asList(messages));
+        if (messages != null && messages.length > 0) {
+            logger.warn("Abort messages received for epochId {}: {}", epochId, Arrays.asList(messages));
+        }
     }
 }


### PR DESCRIPTION
Via some testing, I realized that with large numbers of partitions, logging all the commit messages isn't a great idea. So bumped that to debug, and made the abort messages at the "warn" level (as if the job was aborted, it was either intentional, or an error occurred which will already have copius logging). 