### PR TITLE
Rehnamed "MarkLogic" prefix to "Optic" prefix where appropriate

### DIFF
--- a/src/main/java/com/marklogic/spark/MarkLogicTable.java
+++ b/src/main/java/com/marklogic/spark/MarkLogicTable.java
@@ -16,7 +16,7 @@
 package com.marklogic.spark;
 
 import com.marklogic.spark.reader.CustomCodeScanBuilder;
-import com.marklogic.spark.reader.MarkLogicScanBuilder;
+import com.marklogic.spark.reader.OpticScanBuilder;
 import com.marklogic.spark.reader.ReadContext;
 import com.marklogic.spark.writer.MarkLogicWriteBuilder;
 import com.marklogic.spark.writer.WriteContext;
@@ -86,7 +86,7 @@ public class MarkLogicTable implements SupportsRead, SupportsWrite {
         if (logger.isDebugEnabled()) {
             logger.debug("Will read rows via Optic query");
         }
-        return new MarkLogicScanBuilder(new ReadContext(readProperties, readSchema));
+        return new OpticScanBuilder(new ReadContext(readProperties, readSchema));
     }
 
     @Override

--- a/src/main/java/com/marklogic/spark/reader/OpticMicroBatchStream.java
+++ b/src/main/java/com/marklogic/spark/reader/OpticMicroBatchStream.java
@@ -34,15 +34,15 @@ import java.util.List;
  * we simply need to know the index of the bucket in the list of all buckets. And thus, an offset is simply the index of
  * a bucket in that list.
  */
-class MarkLogicMicroBatchStream implements MicroBatchStream {
+class OpticMicroBatchStream implements MicroBatchStream {
 
-    private final static Logger logger = LoggerFactory.getLogger(MarkLogicMicroBatchStream.class);
+    private final static Logger logger = LoggerFactory.getLogger(OpticMicroBatchStream.class);
 
     private ReadContext readContext;
     private List<PlanAnalysis.Bucket> allBuckets;
     private int bucketIndex;
 
-    MarkLogicMicroBatchStream(ReadContext readContext) {
+    OpticMicroBatchStream(ReadContext readContext) {
         this.readContext = readContext;
         this.allBuckets = this.readContext.getPlanAnalysis().getAllBuckets();
     }
@@ -76,7 +76,7 @@ class MarkLogicMicroBatchStream implements MicroBatchStream {
 
     @Override
     public PartitionReaderFactory createReaderFactory() {
-        return new MarkLogicPartitionReaderFactory(this.readContext);
+        return new OpticPartitionReaderFactory(this.readContext);
     }
 
     @Override

--- a/src/main/java/com/marklogic/spark/reader/OpticPartitionReader.java
+++ b/src/main/java/com/marklogic/spark/reader/OpticPartitionReader.java
@@ -28,9 +28,9 @@ import org.slf4j.LoggerFactory;
 import java.util.Iterator;
 import java.util.function.Consumer;
 
-class MarkLogicPartitionReader implements PartitionReader {
+class OpticPartitionReader implements PartitionReader {
 
-    private final static Logger logger = LoggerFactory.getLogger(MarkLogicPartitionReader.class);
+    private final static Logger logger = LoggerFactory.getLogger(OpticPartitionReader.class);
 
     private final ReadContext readContext;
     private final PlanAnalysis.Partition partition;
@@ -51,7 +51,7 @@ class MarkLogicPartitionReader implements PartitionReader {
     // are working correctly.
     static Consumer<Long> totalRowCountListener;
 
-    MarkLogicPartitionReader(ReadContext readContext, PlanAnalysis.Partition partition) {
+    OpticPartitionReader(ReadContext readContext, PlanAnalysis.Partition partition) {
         this.readContext = readContext;
         this.partition = partition;
         this.rowManager = readContext.connectToMarkLogic().newRowManager();

--- a/src/main/java/com/marklogic/spark/reader/OpticPartitionReaderFactory.java
+++ b/src/main/java/com/marklogic/spark/reader/OpticPartitionReaderFactory.java
@@ -22,20 +22,20 @@ import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class MarkLogicPartitionReaderFactory implements PartitionReaderFactory {
+class OpticPartitionReaderFactory implements PartitionReaderFactory {
 
     final static long serialVersionUID = 1;
 
-    private final Logger logger = LoggerFactory.getLogger(MarkLogicPartitionReaderFactory.class);
+    private final Logger logger = LoggerFactory.getLogger(OpticPartitionReaderFactory.class);
     private final ReadContext readContext;
 
-    MarkLogicPartitionReaderFactory(ReadContext readContext) {
+    OpticPartitionReaderFactory(ReadContext readContext) {
         this.readContext = readContext;
     }
 
     @Override
     public PartitionReader<InternalRow> createReader(InputPartition partition) {
         logger.info("Creating reader for partition: {}", partition);
-        return new MarkLogicPartitionReader(this.readContext, (PlanAnalysis.Partition) partition);
+        return new OpticPartitionReader(this.readContext, (PlanAnalysis.Partition) partition);
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/OpticScanBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/OpticScanBuilder.java
@@ -46,10 +46,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
-public class MarkLogicScanBuilder implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownLimit,
+public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownLimit,
     SupportsPushDownTopN, SupportsPushDownAggregates, SupportsPushDownRequiredColumns {
 
-    private final static Logger logger = LoggerFactory.getLogger(MarkLogicScanBuilder.class);
+    private final static Logger logger = LoggerFactory.getLogger(OpticScanBuilder.class);
 
     private final ReadContext readContext;
     private List<Filter> pushedFilters;
@@ -63,7 +63,7 @@ public class MarkLogicScanBuilder implements ScanBuilder, SupportsPushDownFilter
         add(Sum.class);
     }};
 
-    public MarkLogicScanBuilder(ReadContext readContext) {
+    public OpticScanBuilder(ReadContext readContext) {
         this.readContext = readContext;
     }
 
@@ -72,7 +72,7 @@ public class MarkLogicScanBuilder implements ScanBuilder, SupportsPushDownFilter
         if (logger.isDebugEnabled()) {
             logger.debug("Creating new scan");
         }
-        return new MarkLogicScan(readContext);
+        return new OpticScan(readContext);
     }
 
     /**

--- a/src/main/java/com/marklogic/spark/writer/MarkLogicWrite.java
+++ b/src/main/java/com/marklogic/spark/writer/MarkLogicWrite.java
@@ -52,7 +52,7 @@ class MarkLogicWrite implements BatchWrite, StreamingWrite {
             );
             return new CustomCodeWriterFactory(context);
         }
-        return new MarkLogicDataWriterFactory(writeContext);
+        return new WriteBatcherDataWriterFactory(writeContext);
     }
 
     @Override
@@ -71,7 +71,7 @@ class MarkLogicWrite implements BatchWrite, StreamingWrite {
 
     @Override
     public StreamingDataWriterFactory createStreamingWriterFactory(PhysicalWriteInfo info) {
-        return new MarkLogicDataWriterFactory(writeContext);
+        return new WriteBatcherDataWriterFactory(writeContext);
     }
 
     @Override

--- a/src/main/java/com/marklogic/spark/writer/SparkRowUriMaker.java
+++ b/src/main/java/com/marklogic/spark/writer/SparkRowUriMaker.java
@@ -35,7 +35,7 @@ class SparkRowUriMaker implements DocumentWriteOperation.DocumentUriMaker {
 
     private String uriTemplate;
 
-    // The matcher can be reused as this class is not expected to be thread-safe, as each MarkLogicDataWriter creates
+    // The matcher can be reused as this class is not expected to be thread-safe, as each WriteBatcherDataWriter creates
     // its own and never has multiple threads trying to access it at the same time.
     private Matcher matcher;
 

--- a/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
@@ -32,9 +32,12 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.concurrent.atomic.AtomicReference;
 
-class MarkLogicDataWriter implements DataWriter<InternalRow> {
+/**
+ * Uses the Java Client's WriteBatcher to handle writing rows as documents to MarkLogic.
+ */
+class WriteBatcherDataWriter implements DataWriter<InternalRow> {
 
-    private final static Logger logger = LoggerFactory.getLogger(MarkLogicDataWriter.class);
+    private final static Logger logger = LoggerFactory.getLogger(WriteBatcherDataWriter.class);
 
     private final WriteContext writeContext;
     private final DatabaseClient databaseClient;
@@ -50,7 +53,7 @@ class MarkLogicDataWriter implements DataWriter<InternalRow> {
 
     private int docCount;
 
-    MarkLogicDataWriter(WriteContext writeContext, int partitionId, long taskId, long epochId) {
+    WriteBatcherDataWriter(WriteContext writeContext, int partitionId, long taskId, long epochId) {
         this.writeContext = writeContext;
         this.partitionId = partitionId;
         this.taskId = taskId;

--- a/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriterFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriterFactory.java
@@ -20,21 +20,21 @@ import org.apache.spark.sql.connector.write.DataWriter;
 import org.apache.spark.sql.connector.write.DataWriterFactory;
 import org.apache.spark.sql.connector.write.streaming.StreamingDataWriterFactory;
 
-class MarkLogicDataWriterFactory implements DataWriterFactory, StreamingDataWriterFactory {
+class WriteBatcherDataWriterFactory implements DataWriterFactory, StreamingDataWriterFactory {
 
     private WriteContext writeContext;
 
-    MarkLogicDataWriterFactory(WriteContext writeContext) {
+    WriteBatcherDataWriterFactory(WriteContext writeContext) {
         this.writeContext = writeContext;
     }
 
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
-        return new MarkLogicDataWriter(writeContext, partitionId, taskId, 0L);
+        return new WriteBatcherDataWriter(writeContext, partitionId, taskId, 0L);
     }
 
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId, long epochId) {
-        return new MarkLogicDataWriter(writeContext, partitionId, taskId, epochId);
+        return new WriteBatcherDataWriter(writeContext, partitionId, taskId, epochId);
     }
 }

--- a/src/test/java/com/marklogic/spark/reader/AbstractPushDownTest.java
+++ b/src/test/java/com/marklogic/spark/reader/AbstractPushDownTest.java
@@ -36,7 +36,7 @@ abstract class AbstractPushDownTest extends AbstractIntegrationTest {
         // correctly pushed down to MarkLogic as opposed to being handled by Spark, which should make operations
         // faster as MarkLogic is returning fewer rows. A synchronized method is used in case the test uses multiple
         // partitions, as each will run on a separate thread.
-        MarkLogicPartitionReader.totalRowCountListener = totalRowCount -> addToRowCount(totalRowCount);
+        OpticPartitionReader.totalRowCountListener = totalRowCount -> addToRowCount(totalRowCount);
     }
 
     protected DataFrameReader newDefaultReader(SparkSession session) {


### PR DESCRIPTION
"MarkLogic" is still the prefix for Spark-required classes that aren't specific to using Optic or custom code. 