### PR TITLE
DEVEXP-627 Can now read via user-defined partitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ gradle-local.properties
 logs
 .ipynb_checkpoints
 venv
+.venv

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,13 +111,13 @@ The following options control how the connector reads rows from MarkLogic via cu
 | spark.marklogic.read.vars. | Prefix for user-defined variables to be sent to the custom code. |
 
 If you are using Spark's streaming support with custom code, the following options can also be used to control how
-batch identifiers are defined:
+partitions are defined:
 
 | Option | Description | 
 | --- | --- |
-| spark.marklogic.read.batchIds.invoke | The path to a module to invoke; the module must be in your application's modules database. |
-| spark.marklogic.read.batchIds.javascript | JavaScript code to execute. |
-| spark.marklogic.read.batchIds.xquery | XQuery code to execute. |
+| spark.marklogic.read.partitions.invoke | The path to a module to invoke; the module must be in your application's modules database. |
+| spark.marklogic.read.partitions.javascript | JavaScript code to execute. |
+| spark.marklogic.read.partitions.xquery | XQuery code to execute. |
 
 ## Write options
 

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -329,8 +329,8 @@ import tempfile
 stream = spark.readStream \
     .format("com.marklogic.spark") \
     .option("spark.marklogic.client.uri", "spark-example-user:password@localhost:8003") \
-    .option("spark.marklogic.read.batchIds.javascript", "xdmp.databaseForests(xdmp.database('spark-example-content'))") \
-    .option("spark.marklogic.read.javascript", "cts.uris(null, ['limit=10'], cts.collectionQuery('employee'), null, [BATCH_ID]);") \
+    .option("spark.marklogic.read.partitions.javascript", "xdmp.databaseForests(xdmp.database('spark-example-content'))") \
+    .option("spark.marklogic.read.javascript", "cts.uris(null, ['limit=10'], cts.collectionQuery('employee'), null, [PARTITION]);") \
     .load() \
     .writeStream \
     .format("com.marklogic.spark") \

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -25,9 +25,9 @@ public interface Options {
     String READ_XQUERY = "spark.marklogic.read.xquery";
     String READ_VARS_PREFIX = "spark.marklogic.read.vars.";
 
-    String READ_BATCH_IDS_INVOKE = "spark.marklogic.read.batchIds.invoke";
-    String READ_BATCH_IDS_JAVASCRIPT = "spark.marklogic.read.batchIds.javascript";
-    String READ_BATCH_IDS_XQUERY = "spark.marklogic.read.batchIds.xquery";
+    String READ_PARTITIONS_INVOKE = "spark.marklogic.read.partitions.invoke";
+    String READ_PARTITIONS_JAVASCRIPT = "spark.marklogic.read.partitions.javascript";
+    String READ_PARTITIONS_XQUERY = "spark.marklogic.read.partitions.xquery";
 
     String READ_OPTIC_QUERY = "spark.marklogic.read.opticQuery";
     String READ_NUM_PARTITIONS = "spark.marklogic.read.numPartitions";

--- a/src/main/java/com/marklogic/spark/reader/CustomCodeMicroBatchStream.java
+++ b/src/main/java/com/marklogic/spark/reader/CustomCodeMicroBatchStream.java
@@ -1,8 +1,6 @@
 package com.marklogic.spark.reader;
 
-import com.marklogic.client.DatabaseClient;
 import com.marklogic.spark.CustomCodeContext;
-import com.marklogic.spark.Options;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
@@ -11,7 +9,6 @@ import org.apache.spark.sql.execution.streaming.LongOffset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
 
 class CustomCodeMicroBatchStream implements MicroBatchStream {
@@ -19,55 +16,39 @@ class CustomCodeMicroBatchStream implements MicroBatchStream {
     private final static Logger logger = LoggerFactory.getLogger(CustomCodeMicroBatchStream.class);
 
     private final CustomCodeContext customCodeContext;
-    private long batchIndex = 0;
-    private final List<String> batchIds = new ArrayList<>();
+    private final List<String> partitions;
+    private long partitionIndex = 0;
 
-    /**
-     * Invokes the user-defined option for retrieving batch IDs. The list of batch IDs is stored so that it can be
-     * iterated over via the methods in MicroBatchStream.
-     *
-     * @param customCodeContext
-     */
-    CustomCodeMicroBatchStream(CustomCodeContext customCodeContext) {
+    CustomCodeMicroBatchStream(CustomCodeContext customCodeContext, List<String> partitions) {
         this.customCodeContext = customCodeContext;
-        DatabaseClient client = this.customCodeContext.connectToMarkLogic();
-        try {
-            this.customCodeContext
-                .buildCall(client, new CustomCodeContext.CallOptions(
-                    Options.READ_BATCH_IDS_INVOKE, Options.READ_BATCH_IDS_JAVASCRIPT, Options.READ_BATCH_IDS_XQUERY
-                ))
-                .eval()
-                .forEach(result -> batchIds.add(result.getString()));
-        } finally {
-            client.release();
-        }
+        this.partitions = partitions;
     }
 
     /**
      * Invoked by Spark to get the next offset for which it should construct a reader; an offset for this class is
-     * equivalent to a batch ID.
+     * equivalent to a user-defined partition.
      *
      * @return
      */
     @Override
     public Offset latestOffset() {
-        Offset result = batchIndex >= batchIds.size() ? null : new LongOffset(batchIndex);
+        Offset result = partitionIndex >= partitions.size() ? null : new LongOffset(partitionIndex);
         if (logger.isTraceEnabled()) {
-            logger.trace("Returning latest offset: {}", batchIndex);
+            logger.trace("Returning latest offset: {}", partitionIndex);
         }
-        batchIndex++;
+        partitionIndex++;
         return result;
     }
 
     /**
      * @param start
      * @param end
-     * @return a partition associated with the latest batch ID, which is captured by the "end" offset.
+     * @return a partition associated with the latest partition, which is captured by the "end" offset.
      */
     @Override
     public InputPartition[] planInputPartitions(Offset start, Offset end) {
         long index = ((LongOffset) end).offset();
-        return new InputPartition[]{new CustomCodePartition(batchIds.get((int) index))};
+        return new InputPartition[]{new CustomCodePartition(partitions.get((int) index))};
     }
 
     @Override

--- a/src/main/java/com/marklogic/spark/reader/CustomCodePartition.java
+++ b/src/main/java/com/marklogic/spark/reader/CustomCodePartition.java
@@ -8,25 +8,16 @@ class CustomCodePartition implements InputPartition, Serializable {
 
     final static long serialVersionUID = 1;
 
-    private String batchId;
+    private String partition;
 
-    /**
-     * Constructor for normal reading, where all rows will be returned in a single call to MarkLogic by a single reader.
-     */
     public CustomCodePartition() {
     }
 
-    /**
-     * Constructor used for streaming reads, when a call is made to the reader (and thus to MarkLogic) for the given
-     * batch ID.
-     *
-     * @param batchId
-     */
-    public CustomCodePartition(String batchId) {
-        this.batchId = batchId;
+    public CustomCodePartition(String partition) {
+        this.partition = partition;
     }
 
-    public String getBatchId() {
-        return batchId;
+    public String getPartition() {
+        return partition;
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/CustomCodePartitionReader.java
+++ b/src/main/java/com/marklogic/spark/reader/CustomCodePartitionReader.java
@@ -19,16 +19,15 @@ class CustomCodePartitionReader implements PartitionReader {
     private final JsonRowDeserializer jsonRowDeserializer;
     private final DatabaseClient databaseClient;
 
-    public CustomCodePartitionReader(CustomCodeContext customCodeContext, String batchId) {
+    public CustomCodePartitionReader(CustomCodeContext customCodeContext, String partition) {
         this.databaseClient = customCodeContext.connectToMarkLogic();
         this.serverEvaluationCall = customCodeContext.buildCall(
             this.databaseClient,
             new CustomCodeContext.CallOptions(Options.READ_INVOKE, Options.READ_JAVASCRIPT, Options.READ_XQUERY)
         );
 
-        // For streaming support.
-        if (batchId != null && batchId.trim().length() > 0) {
-            this.serverEvaluationCall.addVariable("BATCH_ID", batchId);
+        if (partition != null) {
+            this.serverEvaluationCall.addVariable("PARTITION", partition);
         }
 
         this.isCustomSchema = customCodeContext.isCustomSchema();

--- a/src/main/java/com/marklogic/spark/reader/CustomCodePartitionReaderFactory.java
+++ b/src/main/java/com/marklogic/spark/reader/CustomCodePartitionReaderFactory.java
@@ -16,6 +16,6 @@ class CustomCodePartitionReaderFactory implements PartitionReaderFactory {
 
     @Override
     public PartitionReader<InternalRow> createReader(InputPartition partition) {
-        return new CustomCodePartitionReader(customCodeContext, ((CustomCodePartition) partition).getBatchId());
+        return new CustomCodePartitionReader(customCodeContext, ((CustomCodePartition) partition).getPartition());
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/CustomCodeScan.java
+++ b/src/main/java/com/marklogic/spark/reader/CustomCodeScan.java
@@ -1,17 +1,40 @@
 package com.marklogic.spark.reader;
 
+import com.marklogic.client.DatabaseClient;
 import com.marklogic.spark.CustomCodeContext;
+import com.marklogic.spark.Options;
 import org.apache.spark.sql.connector.read.Batch;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
 import org.apache.spark.sql.types.StructType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 class CustomCodeScan implements Scan {
 
     private CustomCodeContext customCodeContext;
+    private final List<String> partitions;
 
     public CustomCodeScan(CustomCodeContext customCodeContext) {
         this.customCodeContext = customCodeContext;
+        this.partitions = new ArrayList<>();
+
+        if (this.customCodeContext.hasOption(Options.READ_PARTITIONS_INVOKE, Options.READ_PARTITIONS_JAVASCRIPT, Options.READ_PARTITIONS_XQUERY)) {
+            DatabaseClient client = this.customCodeContext.connectToMarkLogic();
+            try {
+                this.customCodeContext
+                    .buildCall(client, new CustomCodeContext.CallOptions(
+                        Options.READ_PARTITIONS_INVOKE, Options.READ_PARTITIONS_JAVASCRIPT, Options.READ_PARTITIONS_XQUERY
+                    ))
+                    .eval()
+                    .forEach(result -> this.partitions.add(result.getString()));
+            } catch (Exception ex) {
+                throw new RuntimeException("Unable to retrieve partitions", ex);
+            } finally {
+                client.release();
+            }
+        }
     }
 
     @Override
@@ -21,11 +44,11 @@ class CustomCodeScan implements Scan {
 
     @Override
     public Batch toBatch() {
-        return new CustomCodeBatch(customCodeContext);
+        return new CustomCodeBatch(customCodeContext, partitions);
     }
 
     @Override
     public MicroBatchStream toMicroBatchStream(String checkpointLocation) {
-        return new CustomCodeMicroBatchStream(customCodeContext);
+        return new CustomCodeMicroBatchStream(customCodeContext, partitions);
     }
 }

--- a/src/test/java/com/marklogic/spark/writer/ProcessStreamWithCustomCodeTest.java
+++ b/src/test/java/com/marklogic/spark/writer/ProcessStreamWithCustomCodeTest.java
@@ -18,8 +18,8 @@ public class ProcessStreamWithCustomCodeTest extends AbstractIntegrationTest {
             .readStream()
             .format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.READ_BATCH_IDS_JAVASCRIPT, "Sequence.from([1, 2, 3])")
-            .option(Options.READ_JAVASCRIPT, "Sequence.from([BATCH_ID])")
+            .option(Options.READ_PARTITIONS_JAVASCRIPT, "Sequence.from([1, 2, 3])")
+            .option(Options.READ_JAVASCRIPT, "Sequence.from([PARTITION])")
             .load()
             .writeStream()
             .format(CONNECTOR_IDENTIFIER)
@@ -34,7 +34,7 @@ public class ProcessStreamWithCustomCodeTest extends AbstractIntegrationTest {
 
         assertCollectionSize("process-stream-test", 3);
 
-        // Verify 3 docs were written, one for each batch identifier.
+        // Verify 3 docs were written, one for each partition.
         for (int i = 1; i <= 3; i++) {
             JsonNode doc = readJsonDocument("/process-stream-test" + i + ".json");
             assertEquals("world", doc.get("hello").asText());

--- a/src/test/ml-modules/root/getForests.sjs
+++ b/src/test/ml-modules/root/getForests.sjs
@@ -1,0 +1,1 @@
+xdmp.databaseForests(xdmp.database())


### PR DESCRIPTION
This replaces the "get batch ids" concept used for streaming, such that both regular reads and streaming reads now use the optional "get partitions" feature.

Did some doc updates, but some sections need to be rewritten now. Will do that in a follow up PR. 