### PR TITLE
Fixed issue with Jackson dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,15 @@ repositories {
 
 dependencies {
   compileOnly 'org.apache.spark:spark-sql_2.12:' + sparkVersion
-  implementation "com.marklogic:marklogic-client-api:6.3.0"
+  implementation ("com.marklogic:marklogic-client-api:6.4.0") {
+    // The Java Client uses Jackson 2.15.2; Scala 3.4.x does not yet support that and will throw the following error:
+    // Scala module 2.14.2 requires Jackson Databind version >= 2.14.0 and < 2.15.0 - Found jackson-databind version 2.15.2
+    // So the 4 Jackson modules are excluded to allow for Spark's to be used.
+    exclude module: 'jackson-core'
+    exclude module: 'jackson-databind'
+    exclude module: 'jackson-annotations'
+    exclude module: 'jackson-dataformat-csv'
+  }
 
   // Makes it possible to use lambdas in Java 8 to implement Spark's Function1 and Function2 interfaces
   // See https://github.com/scala/scala-java8-compat for more information
@@ -31,8 +39,18 @@ dependencies {
   }
 
   testImplementation 'org.apache.spark:spark-sql_2.12:' + sparkVersion
-  testImplementation 'com.marklogic:ml-app-deployer:4.6.0'
-  testImplementation 'com.marklogic:marklogic-junit5:1.4.0'
+  testImplementation ('com.marklogic:ml-app-deployer:4.6.0') {
+    exclude module: 'jackson-core'
+    exclude module: 'jackson-databind'
+    exclude module: 'jackson-annotations'
+    exclude module: 'jackson-dataformat-csv'
+  }
+  testImplementation ('com.marklogic:marklogic-junit5:1.4.0') {
+    exclude module: 'jackson-core'
+    exclude module: 'jackson-databind'
+    exclude module: 'jackson-annotations'
+    exclude module: 'jackson-dataformat-csv'
+  }
   testImplementation "ch.qos.logback:logback-classic:1.3.5"
   testImplementation "org.slf4j:jcl-over-slf4j:1.7.36"
   testImplementation "org.skyscreamer:jsonassert:1.5.1"

--- a/examples/java-dependency/build.gradle
+++ b/examples/java-dependency/build.gradle
@@ -8,8 +8,8 @@ repositories {
 }
 
 dependencies {
-  implementation 'org.apache.spark:spark-sql_2.12:3.3.2'
-  implementation 'com.marklogic:marklogic-spark-connector:2.0-SNAPSHOT'
+  implementation 'org.apache.spark:spark-sql_2.12:3.4.1'
+  implementation 'com.marklogic:marklogic-spark-connector:2.1-SNAPSHOT'
 }
 
 task runApp(type: JavaExec) {

--- a/examples/java-dependency/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/java-dependency/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/java-dependency/src/main/java/org/example/App.java
+++ b/examples/java-dependency/src/main/java/org/example/App.java
@@ -16,7 +16,7 @@ public class App {
             List<Row> rows = session
                 .read()
                 .format("com.marklogic.spark")
-                .option("spark.marklogic.client.uri", "spark-example-user:password@localhost:8020")
+                .option("spark.marklogic.client.uri", "spark-example-user:password@localhost:8003")
                 .option("spark.marklogic.read.opticQuery", "op.fromView('example', 'employee', '')")
                 .load()
                 .filter("City == 'San Diego'")


### PR DESCRIPTION
Ran into an issue when testing the java-dependency project, where the Java Client's preferred Jackson version of 2.15.2 was being used, which Spark 3.4 does not like. Made me realize that we don't want our connector to bring any Jackson dependencies with it - it needs to use whatever the user's Spark distribution is using. So updated our build.gradle file to exclude the Jackson dependencies coming from java-client-api, ml-app-deployer, and marklogic-unit-test (the latter two ensure that we don't get any Jackson 2.15.2 dependencies when running the tests, but get Spark 3.4.1's preferred version instead, which is 2.14.2). 

After fixing this, I realized it's perfectly safe to use Java Client 6.4.0, as that was using Jackson 2.15.2 just like Java Client 6.3.0. So made that upgrade. All tests are passing, and verified that all examples in the docs work as well. 