### PR TITLE
Extracted constant for permissions

### DIFF
--- a/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
+++ b/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
@@ -45,6 +45,7 @@ public abstract class AbstractIntegrationTest extends AbstractSpringMarkLogicTes
     protected static final String TEST_PASSWORD = "spark";
     protected static final String CONNECTOR_IDENTIFIER = "marklogic";
     protected static final String NO_AUTHORS_QUERY = "op.fromView('Medical', 'NoAuthors', '')";
+    protected static final String DEFAULT_PERMISSIONS = "spark-user-role,read,spark-user-role,update";
 
     private static MarkLogicVersion markLogicVersion;
 

--- a/src/test/java/com/marklogic/spark/reader/ReadStreamOfRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/ReadStreamOfRowsTest.java
@@ -44,7 +44,7 @@ class ReadStreamOfRowsTest extends AbstractIntegrationTest {
             .format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.WRITE_COLLECTIONS, "output")
-            .option(Options.WRITE_PERMISSIONS, "spark-user-role,read,spark-user-role,update")
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
             .option(Options.WRITE_URI_PREFIX, "/output/")
             .option("checkpointLocation", tempDir.toFile().getAbsolutePath())
             .start()

--- a/src/test/java/com/marklogic/spark/reader/customcode/ReadStreamWithCustomCodeTest.java
+++ b/src/test/java/com/marklogic/spark/reader/customcode/ReadStreamWithCustomCodeTest.java
@@ -63,7 +63,7 @@ class ReadStreamWithCustomCodeTest extends AbstractIntegrationTest {
             .format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.WRITE_COLLECTIONS, "read-stream")
-            .option(Options.WRITE_PERMISSIONS, "spark-user-role,read,spark-user-role,update")
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
             .option(Options.WRITE_URI_TEMPLATE, "/read-stream/{partition}.json")
             .option(Options.WRITE_URI_PREFIX, "/")
 
@@ -108,7 +108,7 @@ class ReadStreamWithCustomCodeTest extends AbstractIntegrationTest {
             .format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.WRITE_COLLECTIONS, "read-stream")
-            .option(Options.WRITE_PERMISSIONS, "spark-user-role,read,spark-user-role,update")
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
             .option(Options.WRITE_URI_TEMPLATE, "/read-stream/{partition}.json")
             .option(Options.WRITE_URI_PREFIX, "/")
             .option("checkpointLocation", tempDir.toFile().getAbsolutePath())
@@ -137,7 +137,7 @@ class ReadStreamWithCustomCodeTest extends AbstractIntegrationTest {
             .format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.WRITE_COLLECTIONS, "single-partition-test")
-            .option(Options.WRITE_PERMISSIONS, "spark-user-role,read,spark-user-role,update")
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
             .option("checkpointLocation", tempDir.toFile().getAbsolutePath())
             .start()
             .processAllAvailable();

--- a/src/test/java/com/marklogic/spark/writer/AbstractWriteTest.java
+++ b/src/test/java/com/marklogic/spark/writer/AbstractWriteTest.java
@@ -39,7 +39,7 @@ public abstract class AbstractWriteTest extends AbstractIntegrationTest {
     protected DataFrameWriter newWriterWithDefaultConfig(String csvFilename, int partitionCount) {
         return newWriterWithoutDocumentConfig(csvFilename, partitionCount)
             .option(Options.WRITE_COLLECTIONS, COLLECTION)
-            .option(Options.WRITE_PERMISSIONS, "spark-user-role,read,spark-user-role,update")
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
             .option(Options.WRITE_URI_PREFIX, "/test/")
             .option(Options.WRITE_URI_SUFFIX, ".json");
     }

--- a/src/test/java/com/marklogic/spark/writer/WriteStreamOfRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteStreamOfRowsTest.java
@@ -81,7 +81,7 @@ class WriteStreamOfRowsTest extends AbstractWriteTest {
             .format(CONNECTOR_IDENTIFIER)
             .option("checkpointLocation", tempDir.toFile().getAbsolutePath())
             .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_PERMISSIONS, "rest-extension-user,read,rest-writer,update");
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS);
     }
 
 }


### PR DESCRIPTION
Just avoiding duplication of a long-ish string. 