### PR TITLE
Added tests to verify that serializable objects are serializable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,8 @@ def runtests(String mlVersionType, String mlVersion, String javaVersion){
     cd marklogic-spark-connector
     echo "mlPassword=admin" > gradle-local.properties
    ./gradlew -i mlDeploy
+   echo "Loading data a second time to try to avoid Optic bug with duplicate rows being returned."
+   ./gradlew -i mlLoadData
    ./gradlew test || true
   '''
   junit '**/build/**/*.xml'

--- a/src/main/java/com/marklogic/spark/MarkLogicTable.java
+++ b/src/main/java/com/marklogic/spark/MarkLogicTable.java
@@ -15,11 +15,12 @@
  */
 package com.marklogic.spark;
 
-import com.marklogic.spark.reader.customcode.CustomCodeScanBuilder;
 import com.marklogic.spark.reader.OpticScanBuilder;
 import com.marklogic.spark.reader.ReadContext;
+import com.marklogic.spark.reader.customcode.CustomCodeScanBuilder;
 import com.marklogic.spark.writer.MarkLogicWriteBuilder;
 import com.marklogic.spark.writer.WriteContext;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.SupportsRead;
 import org.apache.spark.sql.connector.catalog.SupportsWrite;
 import org.apache.spark.sql.connector.catalog.TableCapability;
@@ -86,7 +87,11 @@ public class MarkLogicTable implements SupportsRead, SupportsWrite {
         if (logger.isDebugEnabled()) {
             logger.debug("Will read rows via Optic query");
         }
-        return new OpticScanBuilder(new ReadContext(readProperties, readSchema));
+
+        // This is needed by the Optic partition reader; capturing it in the ReadContext so that the reader does not
+        // have a dependency on an active Spark session, which makes certain kinds of tests easier.
+        int defaultMinPartitions = SparkSession.active().sparkContext().defaultMinPartitions();
+        return new OpticScanBuilder(new ReadContext(readProperties, readSchema, defaultMinPartitions));
     }
 
     @Override

--- a/src/test/java/com/marklogic/spark/SerializeUtil.java
+++ b/src/test/java/com/marklogic/spark/SerializeUtil.java
@@ -1,0 +1,32 @@
+package com.marklogic.spark;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.springframework.test.util.AssertionErrors.fail;
+
+public interface SerializeUtil {
+
+    /**
+     * Used by tests that verify that objects that need to be serializable are in fact serializable.
+     */
+    static Object serialize(Object o) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(o);
+            oos.close();
+
+            ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+            ObjectInputStream ois = new ObjectInputStream(bais);
+            o = ois.readObject();
+            ois.close();
+            return o;
+        } catch (Exception e) {
+            fail("Could not serialize object: " + e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/marklogic/spark/reader/SerializeOpticReaderObjectsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/SerializeOpticReaderObjectsTest.java
@@ -1,0 +1,50 @@
+package com.marklogic.spark.reader;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import com.marklogic.spark.SerializeUtil;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SerializeOpticReaderObjectsTest extends AbstractIntegrationTest {
+
+    @Test
+    void planAnalysis() {
+        PlanAnalysis.Bucket bucket = new PlanAnalysis.Bucket("1", "2");
+        PlanAnalysis.Partition partition = new PlanAnalysis.Partition("id", bucket);
+        ObjectNode plan = new ObjectMapper().createObjectNode();
+        plan.put("hello", "world");
+        PlanAnalysis planAnalysis = new PlanAnalysis(plan, Arrays.asList(partition));
+
+        planAnalysis = (PlanAnalysis) SerializeUtil.serialize(planAnalysis);
+        assertEquals("world", planAnalysis.getBoundedPlan().get("hello").asText());
+        bucket = planAnalysis.getPartitions().get(0).getBuckets().get(0);
+        assertEquals("1", bucket.lowerBound);
+        assertEquals("2", bucket.upperBound);
+    }
+
+    @Test
+    void factory() {
+        Map<String, String> props = new HashMap<>();
+        props.put(Options.CLIENT_URI, makeClientUri());
+        props.put(Options.READ_OPTIC_QUERY, NO_AUTHORS_QUERY);
+        ReadContext context = new ReadContext(props, new StructType().add("myType", DataTypes.StringType), 1);
+        OpticPartitionReaderFactory factory = new OpticPartitionReaderFactory(context);
+
+        factory = (OpticPartitionReaderFactory) SerializeUtil.serialize(factory);
+        PlanAnalysis.Bucket bucket = new PlanAnalysis.Bucket("0", "1");
+        PlanAnalysis.Partition partition = new PlanAnalysis.Partition("bucket-id", bucket);
+        OpticPartitionReader reader = (OpticPartitionReader) factory.createReader(partition);
+        assertNotNull(reader, "Creating the reader without error means the factory serialized correctly.");
+    }
+}

--- a/src/test/java/com/marklogic/spark/reader/customcode/SerializeCustomCodeReaderTest.java
+++ b/src/test/java/com/marklogic/spark/reader/customcode/SerializeCustomCodeReaderTest.java
@@ -1,0 +1,31 @@
+package com.marklogic.spark.reader.customcode;
+
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import com.marklogic.spark.SerializeUtil;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SerializeCustomCodeReaderTest extends AbstractIntegrationTest {
+
+    @Test
+    void test() {
+        Map<String, String> options = new HashMap<>();
+        options.put(Options.READ_JAVASCRIPT, "console.log()");
+        options.put(Options.CLIENT_URI, makeClientUri());
+        CustomCodeContext context = new CustomCodeContext(options, new StructType().add("myType", DataTypes.StringType), "prefix");
+        CustomCodePartitionReaderFactory factory = new CustomCodePartitionReaderFactory(context);
+
+        factory = (CustomCodePartitionReaderFactory) SerializeUtil.serialize(factory);
+        CustomCodePartition partition = new CustomCodePartition("p1");
+        CustomCodePartitionReader reader = (CustomCodePartitionReader) factory.createReader(partition);
+        assertNotNull(reader, "Creating the reader without error means the factory serialized correctly.");
+    }
+
+}

--- a/src/test/java/com/marklogic/spark/writer/SerializeWriterObjectsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/SerializeWriterObjectsTest.java
@@ -1,0 +1,28 @@
+package com.marklogic.spark.writer;
+
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import com.marklogic.spark.SerializeUtil;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SerializeWriterObjectsTest extends AbstractIntegrationTest {
+
+    @Test
+    void test() {
+        Map<String, String> props = new HashMap<>();
+        props.put(Options.CLIENT_URI, makeClientUri());
+        WriteContext writeContext = new WriteContext(new StructType().add("myType", DataTypes.StringType), props);
+        WriteBatcherDataWriterFactory factory = new WriteBatcherDataWriterFactory(writeContext);
+
+        factory = (WriteBatcherDataWriterFactory) SerializeUtil.serialize(factory);
+        WriteBatcherDataWriter writer = (WriteBatcherDataWriter) factory.createWriter(1, 1l);
+        assertNotNull(writer, "Creating the writer without error means the factory serialized correctly.");
+    }
+}

--- a/src/test/java/com/marklogic/spark/writer/customcode/SerializeCustomCodeWriterTest.java
+++ b/src/test/java/com/marklogic/spark/writer/customcode/SerializeCustomCodeWriterTest.java
@@ -1,0 +1,29 @@
+package com.marklogic.spark.writer.customcode;
+
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import com.marklogic.spark.SerializeUtil;
+import com.marklogic.spark.reader.customcode.CustomCodeContext;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SerializeCustomCodeWriterTest extends AbstractIntegrationTest {
+
+    @Test
+    void test() {
+        Map<String, String> options = new HashMap<>();
+        options.put(Options.CLIENT_URI, makeClientUri());
+        CustomCodeContext context = new CustomCodeContext(options, new StructType().add("myType", DataTypes.StringType), "prefix");
+        CustomCodeWriterFactory factory = new CustomCodeWriterFactory(context);
+
+        factory = (CustomCodeWriterFactory) SerializeUtil.serialize(factory);
+        CustomCodeWriter writer = (CustomCodeWriter) factory.createWriter(1, 1l);
+        assertNotNull(writer, "Creating the writer without error means the factory serialized correctly.");
+    }
+}


### PR DESCRIPTION
Turns out that they are serializable, but I wasn't certain as I thought no-arg constructors were required - but that doesn't appear to be the case based on what `SerializedUtil` does, and Spark does the same thing for its default serialization strategy. 

I made one impl change, though it has no functional impact - I modified ReadContext so that it's not trying to access an active SparkSession, which was making testing more difficult. 

