### PR TITLE
Can now read document rows by collection

### DIFF
--- a/src/main/java/com/marklogic/spark/DefaultSource.java
+++ b/src/main/java/com/marklogic/spark/DefaultSource.java
@@ -19,6 +19,8 @@ import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RawQueryDSLPlan;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.spark.reader.SchemaInferrer;
+import com.marklogic.spark.reader.document.DocumentRowSchema;
+import com.marklogic.spark.reader.document.DocumentTable;
 import com.marklogic.spark.reader.file.FileRowSchema;
 import com.marklogic.spark.reader.file.MarkLogicFileTable;
 import com.marklogic.spark.writer.WriteContext;
@@ -64,6 +66,10 @@ public class DefaultSource implements TableProvider, DataSourceRegister {
         if (isReadFilesOperation(properties)) {
             return FileRowSchema.SCHEMA;
         }
+        // We will likely check for any read.documents option in the near future.
+        if (options.containsKey(Options.READ_DOCUMENTS_COLLECTIONS)) {
+            return DocumentRowSchema.SCHEMA;
+        }
         if (isReadWithCustomCodeOperation(properties)) {
             return new StructType().add("URI", DataTypes.StringType);
         }
@@ -77,6 +83,10 @@ public class DefaultSource implements TableProvider, DataSourceRegister {
                 new CaseInsensitiveStringMap(properties),
                 JavaConverters.asScalaBuffer(getPaths(properties))
             );
+        }
+
+        if (properties.containsKey(Options.READ_DOCUMENTS_COLLECTIONS)) {
+            return new DocumentTable();
         }
 
         if (isReadOperation(properties)) {

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -41,6 +41,8 @@ public abstract class Options {
     public static final String READ_BATCH_SIZE = "spark.marklogic.read.batchSize";
     public static final String READ_PUSH_DOWN_AGGREGATES = "spark.marklogic.read.pushDownAggregates";
 
+    public static final String READ_DOCUMENTS_COLLECTIONS = "spark.marklogic.read.documents.collections";
+
     public static final String WRITE_BATCH_SIZE = "spark.marklogic.write.batchSize";
     public static final String WRITE_THREAD_COUNT = "spark.marklogic.write.threadCount";
     public static final String WRITE_ABORT_ON_FAILURE = "spark.marklogic.write.abortOnFailure";

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentBatch.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentBatch.java
@@ -1,0 +1,39 @@
+package com.marklogic.spark.reader.document;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.datamovement.Forest;
+import org.apache.spark.sql.connector.read.Batch;
+import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+class DocumentBatch implements Batch {
+
+    private DocumentContext context;
+
+    DocumentBatch(CaseInsensitiveStringMap options) {
+        this.context = new DocumentContext(options);
+    }
+
+    /**
+     * Reuses the DMSDK support for obtaining a list of all eligible forests. A partition reader will then be
+     * created for each partition/forest.
+     *
+     * @return
+     */
+    @Override
+    public InputPartition[] planInputPartitions() {
+        DatabaseClient client = this.context.connectToMarkLogic();
+        Forest[] forests = client.newDataMovementManager().readForestConfig().listForests();
+        InputPartition[] partitions = new InputPartition[forests.length];
+        for (int i = 0; i < forests.length; i++) {
+            partitions[i] = new ForestPartition(forests[i].getForestName());
+        }
+        return partitions;
+    }
+
+    @Override
+    public PartitionReaderFactory createReaderFactory() {
+        return new ForestReaderFactory(this.context);
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
@@ -1,0 +1,12 @@
+package com.marklogic.spark.reader.document;
+
+import com.marklogic.spark.ContextSupport;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+class DocumentContext extends ContextSupport {
+
+    DocumentContext(CaseInsensitiveStringMap options) {
+        super(options.asCaseSensitiveMap());
+    }
+
+}

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentRowSchema.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentRowSchema.java
@@ -1,0 +1,15 @@
+package com.marklogic.spark.reader.document;
+
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+
+public abstract class DocumentRowSchema {
+
+    public static final StructType SCHEMA = new StructType()
+        .add("URI", DataTypes.StringType)
+        .add("content", DataTypes.BinaryType)
+        .add("format", DataTypes.StringType);
+
+    private DocumentRowSchema() {
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentScan.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentScan.java
@@ -1,0 +1,25 @@
+package com.marklogic.spark.reader.document;
+
+import org.apache.spark.sql.connector.read.Batch;
+import org.apache.spark.sql.connector.read.Scan;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+class DocumentScan implements Scan {
+
+    private CaseInsensitiveStringMap options;
+
+    DocumentScan(CaseInsensitiveStringMap options) {
+        this.options = options;
+    }
+
+    @Override
+    public StructType readSchema() {
+        return DocumentRowSchema.SCHEMA;
+    }
+
+    @Override
+    public Batch toBatch() {
+        return new DocumentBatch(options);
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentScanBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentScanBuilder.java
@@ -1,0 +1,19 @@
+package com.marklogic.spark.reader.document;
+
+import org.apache.spark.sql.connector.read.Scan;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+class DocumentScanBuilder implements ScanBuilder {
+
+    private CaseInsensitiveStringMap options;
+
+    DocumentScanBuilder(CaseInsensitiveStringMap options) {
+        this.options = options;
+    }
+
+    @Override
+    public Scan build() {
+        return new DocumentScan(options);
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentTable.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentTable.java
@@ -1,0 +1,40 @@
+package com.marklogic.spark.reader.document;
+
+import org.apache.spark.sql.connector.catalog.SupportsRead;
+import org.apache.spark.sql.connector.catalog.TableCapability;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class DocumentTable implements SupportsRead {
+
+    private static Set<TableCapability> capabilities;
+
+    static {
+        capabilities = new HashSet<>();
+        capabilities.add(TableCapability.BATCH_READ);
+    }
+
+    @Override
+    public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
+        return new DocumentScanBuilder(options);
+    }
+
+    @Override
+    public String name() {
+        return "MarkLogicDocumentsTable";
+    }
+
+    @Override
+    public StructType schema() {
+        return DocumentRowSchema.SCHEMA;
+    }
+
+    @Override
+    public Set<TableCapability> capabilities() {
+        return capabilities;
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/document/ForestPartition.java
+++ b/src/main/java/com/marklogic/spark/reader/document/ForestPartition.java
@@ -1,0 +1,18 @@
+package com.marklogic.spark.reader.document;
+
+import org.apache.spark.sql.connector.read.InputPartition;
+
+class ForestPartition implements InputPartition {
+
+    static final long serialVersionUID = 1;
+
+    private String forestName;
+
+    ForestPartition(String forestName) {
+        this.forestName = forestName;
+    }
+
+    public String getForestName() {
+        return forestName;
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/document/ForestReader.java
+++ b/src/main/java/com/marklogic/spark/reader/document/ForestReader.java
@@ -1,0 +1,83 @@
+package com.marklogic.spark.reader.document;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.document.DocumentPage;
+import com.marklogic.client.document.DocumentRecord;
+import com.marklogic.client.document.ServerTransform;
+import com.marklogic.client.io.BytesHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.connector.read.PartitionReader;
+import org.apache.spark.unsafe.types.ByteArray;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * This uses the same technique as QueryBatcher in getting back an ordered list of URIs without having to paginate.
+ * It does involve 2x calls for each batch - one to get the URIs, and then one to get the documents for those URIs.
+ * Will performance test this later to determine if just using documentManager.search with pagination is generally
+ * faster. That's just 1 call, but it incurs the cost of finding page N.
+ */
+class ForestReader implements PartitionReader<InternalRow> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ForestReader.class);
+    private final DatabaseClient databaseClient;
+    private final UriBatcher uriBatcher;
+
+    // Only used for logging.
+    private final String forestName;
+
+    private DocumentPage currentDocumentPage;
+
+    ForestReader(ForestPartition forestPartition, DocumentContext documentContext) {
+        this.forestName = forestPartition.getForestName();
+        if (logger.isInfoEnabled()) {
+            logger.info("Will read from forest: {}", this.forestName);
+        }
+
+        this.databaseClient = documentContext.connectToMarkLogic();
+        String[] collections = documentContext.getProperties().get(Options.READ_DOCUMENTS_COLLECTIONS).split(",");
+        StructuredQueryDefinition query = databaseClient.newQueryManager()
+            .newStructuredQueryBuilder()
+            .collection(collections);
+        this.uriBatcher = new UriBatcher(databaseClient, query, forestPartition.getForestName());
+    }
+
+    @Override
+    public boolean next() {
+        if (currentDocumentPage == null || !currentDocumentPage.hasNext()) {
+            List<String> uris = uriBatcher.nextBatchOfUris();
+            if (uris.isEmpty()) {
+                return false;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("Read {} URIs from forest {}", uris.size(), this.forestName);
+            }
+            // Copied from ExportListener. Will add transform support later.
+            this.currentDocumentPage = this.databaseClient.newDocumentManager()
+                .read((ServerTransform) null, uris.toArray(new String[]{}));
+        }
+        return currentDocumentPage.hasNext();
+    }
+
+    @Override
+    public InternalRow get() {
+        DocumentRecord record = this.currentDocumentPage.next();
+        String format = record.getFormat() != null ? record.getFormat().toString() : Format.UNKNOWN.toString();
+        return new GenericInternalRow(new Object[]{
+            UTF8String.fromString(record.getUri()),
+            ByteArray.concat(record.getContent(new BytesHandle()).get()),
+            UTF8String.fromString(format)
+        });
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/document/ForestReaderFactory.java
+++ b/src/main/java/com/marklogic/spark/reader/document/ForestReaderFactory.java
@@ -1,0 +1,22 @@
+package com.marklogic.spark.reader.document;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.connector.read.PartitionReader;
+import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+
+class ForestReaderFactory implements PartitionReaderFactory {
+
+    static final long serialVersionUID = 1;
+    
+    private DocumentContext documentContext;
+
+    ForestReaderFactory(DocumentContext documentContext) {
+        this.documentContext = documentContext;
+    }
+
+    @Override
+    public PartitionReader<InternalRow> createReader(InputPartition partition) {
+        return new ForestReader((ForestPartition) partition, documentContext);
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/document/UriBatcher.java
+++ b/src/main/java/com/marklogic/spark/reader/document/UriBatcher.java
@@ -1,0 +1,70 @@
+package com.marklogic.spark.reader.document;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.ResourceNotFoundException;
+import com.marklogic.client.impl.QueryManagerImpl;
+import com.marklogic.client.impl.UrisHandle;
+import com.marklogic.client.query.SearchQueryDefinition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Retrieves batches of URIs in the same manner as {@code QueryBatcher} in the Java Client, without resorting to
+ * pagination. May eventually want this to be in the Java Client for reuse, as the need to get back a distinct set of
+ * URIs without resorting to pagination is common.
+ */
+class UriBatcher {
+
+    private final DatabaseClient client;
+    private final SearchQueryDefinition query;
+    private final boolean filtered;
+    private final String forestName;
+    private final int pageLength;
+
+    private long serverTimestamp = -1;
+    private String lastUri;
+    private long start = 1;
+
+    UriBatcher(DatabaseClient client, SearchQueryDefinition query, String forestName) {
+        this(client, query, forestName, 500, false);
+    }
+
+    UriBatcher(DatabaseClient client, SearchQueryDefinition query, String forestName, int pageLength, boolean filtered) {
+        this.client = client;
+        this.query = query;
+        this.filtered = filtered;
+        this.forestName = forestName;
+        this.pageLength = pageLength;
+    }
+
+    /**
+     * @return the next batch of matching URIs, where "next" = URIs after "lastUri", if it's not null. The
+     * {@code queryManager.uris} method will order the URIs so that we are guaranteed to get URIs we have not seen yet
+     * without resorting to pagination.
+     */
+    List<String> nextBatchOfUris() {
+        QueryManagerImpl queryManager = (QueryManagerImpl) client.newQueryManager();
+        queryManager.setPageLength(this.pageLength);
+        UrisHandle urisHandle = new UrisHandle();
+        if (this.serverTimestamp > -1) {
+            urisHandle.setPointInTimeQueryTimestamp(this.serverTimestamp);
+        }
+
+        try (UrisHandle results = queryManager.uris("POST", query, filtered, urisHandle, start, lastUri, forestName)) {
+            if (serverTimestamp == -1) {
+                this.serverTimestamp = results.getServerTimestamp();
+            }
+            List<String> uris = new ArrayList<>();
+            results.iterator().forEachRemaining(uri -> uris.add(uri));
+            if (!uris.isEmpty()) {
+                this.lastUri = uris.get(uris.size() - 1);
+            }
+            this.start = this.start + uris.size();
+            return uris;
+        } catch (ResourceNotFoundException ex) {
+            // QueryBatcherImpl notes that this is how internal/uris informs us that there are no results left.
+            return new ArrayList<>();
+        }
+    }
+}

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
@@ -1,0 +1,33 @@
+package com.marklogic.spark.reader.document;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ReadDocumentRowsTest extends AbstractIntegrationTest {
+
+    @Test
+    void readByCollection() throws Exception {
+        Dataset<Row> rows = newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_DOCUMENTS_COLLECTIONS, "author")
+            .load();
+
+        assertEquals(15, rows.count());
+
+        Row row = rows.filter("URI = '/author/author1.json'").collectAsList().get(0);
+        assertEquals("/author/author1.json", row.getString(0));
+        assertEquals("JSON", row.getString(2));
+        JsonNode doc = new ObjectMapper().readTree((byte[]) row.get(1));
+        // Verify just a couple fields to ensure the JSON object is correct.
+        assertEquals(4, doc.get("CitationID").asInt());
+        assertEquals("Vivianne", doc.get("ForeName").asText());
+    }
+}


### PR DESCRIPTION
The critical part here is `UrisBatcher`. I'm going to do some scalability testing with that outside of this PR. 

Most everything else is just Spark-required boilerplate. 