### PR TITLE
Can now write documents as files

### DIFF
--- a/src/main/java/com/marklogic/spark/DefaultSource.java
+++ b/src/main/java/com/marklogic/spark/DefaultSource.java
@@ -22,7 +22,6 @@ import com.marklogic.spark.reader.SchemaInferrer;
 import com.marklogic.spark.reader.document.DocumentRowSchema;
 import com.marklogic.spark.reader.document.DocumentTable;
 import com.marklogic.spark.reader.file.FileRowSchema;
-import com.marklogic.spark.reader.file.MarkLogicFileTable;
 import com.marklogic.spark.writer.WriteContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Table;
@@ -63,7 +62,7 @@ public class DefaultSource implements TableProvider, DataSourceRegister {
     @Override
     public StructType inferSchema(CaseInsensitiveStringMap options) {
         final Map<String, String> properties = options.asCaseSensitiveMap();
-        if (isReadFilesOperation(properties)) {
+        if (isFileOperation(properties)) {
             return FileRowSchema.SCHEMA;
         }
         // We will likely check for any read.documents option in the near future.
@@ -78,10 +77,10 @@ public class DefaultSource implements TableProvider, DataSourceRegister {
 
     @Override
     public Table getTable(StructType schema, Transform[] partitioning, Map<String, String> properties) {
-        if (isReadFilesOperation(properties)) {
+        if (isFileOperation(properties)) {
             return new MarkLogicFileTable(SparkSession.active(),
                 new CaseInsensitiveStringMap(properties),
-                JavaConverters.asScalaBuffer(getPaths(properties))
+                JavaConverters.asScalaBuffer(getPaths(properties)), schema
             );
         }
 
@@ -112,7 +111,7 @@ public class DefaultSource implements TableProvider, DataSourceRegister {
         return true;
     }
 
-    private boolean isReadFilesOperation(Map<String, String> properties) {
+    private boolean isFileOperation(Map<String, String> properties) {
         return properties.containsKey("path") || properties.containsKey("paths");
     }
 

--- a/src/main/java/com/marklogic/spark/MarkLogicTable.java
+++ b/src/main/java/com/marklogic/spark/MarkLogicTable.java
@@ -36,7 +36,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-public class MarkLogicTable implements SupportsRead, SupportsWrite {
+class MarkLogicTable implements SupportsRead, SupportsWrite {
 
     private static final Logger logger = LoggerFactory.getLogger(MarkLogicTable.class);
 

--- a/src/main/java/com/marklogic/spark/reader/file/FileScanBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FileScanBuilder.java
@@ -4,11 +4,11 @@ import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex;
 
-class FileScanBuilder implements ScanBuilder {
+public class FileScanBuilder implements ScanBuilder {
 
     private PartitioningAwareFileIndex fileIndex;
 
-    FileScanBuilder(PartitioningAwareFileIndex fileIndex) {
+    public FileScanBuilder(PartitioningAwareFileIndex fileIndex) {
         this.fileIndex = fileIndex;
     }
 

--- a/src/main/java/com/marklogic/spark/writer/file/DocumentFileBatch.java
+++ b/src/main/java/com/marklogic/spark/writer/file/DocumentFileBatch.java
@@ -1,0 +1,38 @@
+package com.marklogic.spark.writer.file;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.write.BatchWrite;
+import org.apache.spark.sql.connector.write.DataWriterFactory;
+import org.apache.spark.sql.connector.write.PhysicalWriteInfo;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.util.SerializableConfiguration;
+
+import java.util.Map;
+
+class DocumentFileBatch implements BatchWrite {
+
+    private final Map<String, String> properties;
+
+    DocumentFileBatch(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public DataWriterFactory createBatchWriterFactory(PhysicalWriteInfo info) {
+        // This is the last chance we have for accessing the hadoop config, which is needed by the writer.
+        // SerializableConfiguration allows for it to be sent to the factory.
+        Configuration config = SparkSession.active().sparkContext().hadoopConfiguration();
+        return new DocumentFileWriterFactory(properties, new SerializableConfiguration(config));
+    }
+
+    @Override
+    public void commit(WriterCommitMessage[] messages) {
+        // No messages expected yet.
+    }
+
+    @Override
+    public void abort(WriterCommitMessage[] messages) {
+        // No messages expected yet.
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriteBuilder.java
+++ b/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriteBuilder.java
@@ -1,0 +1,26 @@
+package com.marklogic.spark.writer.file;
+
+import org.apache.spark.sql.connector.write.BatchWrite;
+import org.apache.spark.sql.connector.write.Write;
+import org.apache.spark.sql.connector.write.WriteBuilder;
+
+import java.util.Map;
+
+public class DocumentFileWriteBuilder implements WriteBuilder {
+
+    private final Map<String, String> properties;
+
+    public DocumentFileWriteBuilder(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public Write build() {
+        return new Write() {
+            @Override
+            public BatchWrite toBatch() {
+                return new DocumentFileBatch(properties);
+            }
+        };
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriter.java
@@ -1,0 +1,101 @@
+package com.marklogic.spark.writer.file;
+
+import com.marklogic.spark.ConnectorException;
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.write.DataWriter;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.util.SerializableConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+/**
+ * Writes each row, which is expected to represent a document, as a single file.
+ */
+class DocumentFileWriter implements DataWriter<InternalRow> {
+
+    private static final Logger logger = LoggerFactory.getLogger(DocumentFileWriter.class);
+
+    private final Map<String, String> properties;
+    private final SerializableConfiguration hadoopConfiguration;
+
+    DocumentFileWriter(Map<String, String> properties, SerializableConfiguration hadoopConfiguration) {
+        this.properties = properties;
+        this.hadoopConfiguration = hadoopConfiguration;
+    }
+
+    @Override
+    public void write(InternalRow row) throws IOException {
+        final Path path = makePath(row);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Will write to: {}", path);
+        }
+        BufferedOutputStream outputStream = makeOutputStream(path);
+        try {
+            outputStream.write(row.getBinary(1));
+        } finally {
+            IOUtils.closeQuietly(outputStream);
+        }
+    }
+
+    @Override
+    public WriterCommitMessage commit() {
+        return null;
+    }
+
+    @Override
+    public void abort() {
+        // No action to take.
+    }
+
+    @Override
+    public void close() {
+        // Nothing to close.
+    }
+
+    private Path makePath(InternalRow row) {
+        String dir = properties.get("path");
+        final String uri = row.getString(0);
+        String path = makePathFromDocumentURI(uri);
+        return path.charAt(0) == '/' ? new Path(dir + path) : new Path(dir, path);
+    }
+
+    private static String makePathFromDocumentURI(String documentURI) {
+        // Copied from MLCP
+        URI uri;
+        try {
+            uri = new URI(documentURI);
+        } catch (URISyntaxException e) {
+            throw new ConnectorException(String.format("Unable to construct URI from: %s", documentURI), e);
+        }
+        // The isOpaque check is made because an opaque URI will not have a path.
+        return uri.isOpaque() ? uri.getSchemeSpecificPart() : uri.getPath();
+    }
+
+    private BufferedOutputStream makeOutputStream(Path path) throws IOException {
+        FileSystem fileSystem = path.getFileSystem(this.hadoopConfiguration.value());
+        // MLCP doesn't write .crc files, not sure yet if we want to default this to true or false.
+        fileSystem.setWriteChecksum(false);
+        // Copied from MLCP; testing shows an enormous improvement in performance when writing to local files by
+        // using this approach.
+        if (fileSystem instanceof LocalFileSystem) {
+            File file = new File(path.toUri().getPath());
+            if (!file.exists() && file.getParentFile() != null) {
+                file.getParentFile().mkdirs();
+            }
+            return new BufferedOutputStream(new FileOutputStream(file, false));
+        }
+        return new BufferedOutputStream(fileSystem.create(path, false));
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriterFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriterFactory.java
@@ -1,0 +1,26 @@
+package com.marklogic.spark.writer.file;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.write.DataWriter;
+import org.apache.spark.sql.connector.write.DataWriterFactory;
+import org.apache.spark.util.SerializableConfiguration;
+
+import java.util.Map;
+
+class DocumentFileWriterFactory implements DataWriterFactory {
+
+    static final long serialVersionUID = 1;
+
+    private final Map<String, String> properties;
+    private final SerializableConfiguration hadoopConfiguration;
+
+    DocumentFileWriterFactory(Map<String, String> properties, SerializableConfiguration hadoopConfiguration) {
+        this.properties = properties;
+        this.hadoopConfiguration = hadoopConfiguration;
+    }
+
+    @Override
+    public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
+        return new DocumentFileWriter(properties, hadoopConfiguration);
+    }
+}

--- a/src/test/java/com/marklogic/spark/writer/file/WriteDocumentFilesTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteDocumentFilesTest.java
@@ -1,0 +1,89 @@
+package com.marklogic.spark.writer.file;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marklogic.client.document.DocumentWriteSet;
+import com.marklogic.client.document.TextDocumentManager;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.SaveMode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.util.FileCopyUtils;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WriteDocumentFilesTest extends AbstractIntegrationTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void writeFifteenAuthorFiles(@TempDir Path tempDir) throws Exception {
+        newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_DOCUMENTS_COLLECTIONS, "author")
+            .load()
+            .write()
+            .format(CONNECTOR_IDENTIFIER)
+            .mode(SaveMode.Append)
+            .save(tempDir.toFile().getAbsolutePath());
+
+        for (int i = 1; i <= 15; i++) {
+            File expectedFile = Paths.get(
+                tempDir.toFile().getAbsolutePath(),
+                "author", "author" + i + ".json"
+            ).toFile();
+            assertTrue(expectedFile.exists(), "Expected file at: " + expectedFile);
+
+            // Verify the JSON is valid.
+            JsonNode doc = objectMapper.readTree(expectedFile);
+            assertTrue(doc.has("CitationID"));
+            assertTrue(doc.has("LastName"));
+        }
+    }
+
+    @Test
+    void variousURIs(@TempDir Path tempDir) throws Exception {
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle().withCollections("uri-examples")
+            .withPermission("spark-user-role", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE);
+        TextDocumentManager mgr = getDatabaseClient().newTextDocumentManager();
+        DocumentWriteSet writeSet = mgr.newWriteSet();
+        writeSet.add("example.txt", metadata, new StringHandle("URI without leading slash"));
+        writeSet.add("org:example2.txt", metadata, new StringHandle("Opaque URI"));
+        mgr.write(writeSet);
+
+        newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_DOCUMENTS_COLLECTIONS, "uri-examples")
+            .load()
+            .write()
+            .format(CONNECTOR_IDENTIFIER)
+            .mode(SaveMode.Append)
+            .save(tempDir.toFile().getAbsolutePath());
+
+        File[] files = tempDir.toFile().listFiles();
+        List<String> filenames = Arrays.stream(files).map(f -> f.getName()).collect(Collectors.toList());
+        assertEquals(2, filenames.size());
+        assertTrue(filenames.contains("example.txt"), "Unexpected filenames: " + filenames);
+        assertTrue(filenames.contains("example2.txt"), "MLCP has a check for an 'opaque' URI, of which org:example2.txt " +
+            "is an example. An opaque URI does not have a path, so its 'scheme-specific' part is expected to be used " +
+            "as the filename; actual filenames: " + filenames);
+
+        String content = new String(FileCopyUtils.copyToByteArray(files[filenames.indexOf("example.txt")]));
+        assertEquals("URI without leading slash", content);
+        content = new String(FileCopyUtils.copyToByteArray(files[filenames.indexOf("example2.txt")]));
+        assertEquals("Opaque URI", content);
+    }
+}


### PR DESCRIPTION
Moved `MarkLogicFileTable` to base package so it can be reused for both reading and writing. 

`DocumentFileWriter` is the main code; the rest is Spark plumbing. It borrows chunks of code from MLCP for writing a file. 

We'll be updating the Factory here with additional writers very soon - e.g. a compressed file writer, an archive file writer, etc. 