### PR TITLE
MLE-11842 Can now read metadata columns when reading documents

### DIFF
--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -41,6 +41,8 @@ public abstract class Options {
     public static final String READ_BATCH_SIZE = "spark.marklogic.read.batchSize";
     public static final String READ_PUSH_DOWN_AGGREGATES = "spark.marklogic.read.pushDownAggregates";
 
+    // "categories" as defined by https://docs.marklogic.com/REST/GET/v1/documents .
+    public static final String READ_DOCUMENTS_CATEGORIES = "spark.marklogic.read.documents.categories";
     public static final String READ_DOCUMENTS_COLLECTIONS = "spark.marklogic.read.documents.collections";
 
     public static final String READ_FILES_COMPRESSION = "spark.marklogic.read.files.compression";

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
@@ -1,7 +1,12 @@
 package com.marklogic.spark.reader.document;
 
+import com.marklogic.client.document.DocumentManager;
 import com.marklogic.spark.ContextSupport;
+import com.marklogic.spark.Options;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+import java.util.HashSet;
+import java.util.Set;
 
 class DocumentContext extends ContextSupport {
 
@@ -9,4 +14,32 @@ class DocumentContext extends ContextSupport {
         super(options.asCaseSensitiveMap());
     }
 
+    Set<DocumentManager.Metadata> getRequestedMetadata() {
+        Set<DocumentManager.Metadata> set = new HashSet<>();
+        if (hasOption(Options.READ_DOCUMENTS_CATEGORIES)) {
+            for (String category : getProperties().get(Options.READ_DOCUMENTS_CATEGORIES).split(",")) {
+                if ("content".equalsIgnoreCase(category)) {
+                    continue;
+                }
+                if ("metadata".equalsIgnoreCase(category)) {
+                    set.add(DocumentManager.Metadata.ALL);
+                } else {
+                    set.add(DocumentManager.Metadata.valueOf(category.toUpperCase()));
+                }
+            }
+        }
+        return set;
+    }
+
+    boolean contentWasRequested() {
+        if (!hasOption(Options.READ_DOCUMENTS_CATEGORIES)) {
+            return true;
+        }
+        for (String value : getProperties().get(Options.READ_DOCUMENTS_CATEGORIES).split(",")) {
+            if ("content".equalsIgnoreCase(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentRowSchema.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentRowSchema.java
@@ -8,7 +8,15 @@ public abstract class DocumentRowSchema {
     public static final StructType SCHEMA = new StructType()
         .add("URI", DataTypes.StringType)
         .add("content", DataTypes.BinaryType)
-        .add("format", DataTypes.StringType);
+        .add("format", DataTypes.StringType)
+        .add("collections", DataTypes.createArrayType(DataTypes.StringType))
+        .add("permissions", DataTypes.createMapType(
+            DataTypes.StringType,
+            DataTypes.createArrayType(DataTypes.StringType))
+        )
+        .add("quality", DataTypes.IntegerType)
+        .add("properties", DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType))
+        .add("metadataValues", DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType));
 
     private DocumentRowSchema() {
     }

--- a/src/main/java/com/marklogic/spark/reader/document/ForestReader.java
+++ b/src/main/java/com/marklogic/spark/reader/document/ForestReader.java
@@ -1,22 +1,27 @@
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.document.DocumentPage;
-import com.marklogic.client.document.DocumentRecord;
-import com.marklogic.client.document.ServerTransform;
+import com.marklogic.client.document.*;
 import com.marklogic.client.io.BytesHandle;
+import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
+import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.unsafe.types.ByteArray;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.xml.namespace.QName;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * This uses the same technique as QueryBatcher in getting back an ordered list of URIs without having to paginate.
@@ -27,8 +32,10 @@ import java.util.List;
 class ForestReader implements PartitionReader<InternalRow> {
 
     private static final Logger logger = LoggerFactory.getLogger(ForestReader.class);
-    private final DatabaseClient databaseClient;
     private final UriBatcher uriBatcher;
+    private final GenericDocumentManager documentManager;
+    private final Set<DocumentManager.Metadata> requestedMetadata;
+    private final boolean contentWasRequested;
 
     // Only used for logging.
     private final String forestName;
@@ -41,34 +48,30 @@ class ForestReader implements PartitionReader<InternalRow> {
             logger.debug("Will read from forest: {}", this.forestName);
         }
 
-        this.databaseClient = documentContext.connectToMarkLogic();
+        DatabaseClient client = documentContext.connectToMarkLogic();
+
+        // Can break out query construction into a new private method as we add more query features.
         String[] collections = documentContext.getProperties().get(Options.READ_DOCUMENTS_COLLECTIONS).split(",");
-        StructuredQueryDefinition query = databaseClient.newQueryManager()
+        StructuredQueryDefinition query = client.newQueryManager()
             .newStructuredQueryBuilder()
             .collection(collections);
-        this.uriBatcher = new UriBatcher(databaseClient, query, forestPartition.getForestName());
+        this.uriBatcher = new UriBatcher(client, query, forestPartition.getForestName());
+
+        this.documentManager = client.newDocumentManager();
+        this.contentWasRequested = documentContext.contentWasRequested();
+        this.requestedMetadata = documentContext.getRequestedMetadata();
+        this.documentManager.setMetadataCategories(this.requestedMetadata);
     }
 
     @Override
     public boolean next() {
         if (currentDocumentPage == null || !currentDocumentPage.hasNext()) {
-            closeCurrentDocumentPageIfNecessary();
-            long start = System.currentTimeMillis();
-            List<String> uris = uriBatcher.nextBatchOfUris();
-            if (logger.isTraceEnabled()) {
-                logger.trace("Retrieved {} URIs in {}ms from forest {}", uris.size(),
-                    (System.currentTimeMillis() - start), this.forestName);
-            }
+            closeCurrentDocumentPage();
+            List<String> uris = getNextBatchOfUris();
             if (uris.isEmpty()) {
                 return false;
             }
-            // Copied from ExportListener. Will add transform support later.
-            start = System.currentTimeMillis();
-            this.currentDocumentPage = this.databaseClient.newDocumentManager()
-                .read((ServerTransform) null, uris.toArray(new String[]{}));
-            if (logger.isTraceEnabled()) {
-                logger.trace("Retrieved page of documents in {}ms from forest {}", (System.currentTimeMillis() - start), this.forestName);
-            }
+            this.currentDocumentPage = readPage(uris);
         }
         return currentDocumentPage.hasNext();
     }
@@ -76,20 +79,125 @@ class ForestReader implements PartitionReader<InternalRow> {
     @Override
     public InternalRow get() {
         DocumentRecord document = this.currentDocumentPage.next();
-        String format = document.getFormat() != null ? document.getFormat().toString() : Format.UNKNOWN.toString();
-        return new GenericInternalRow(new Object[]{
-            UTF8String.fromString(document.getUri()),
-            ByteArray.concat(document.getContent(new BytesHandle()).get()),
-            UTF8String.fromString(format)
-        });
+
+        Object[] row = new Object[8];
+        row[0] = UTF8String.fromString(document.getUri());
+        if (this.contentWasRequested) {
+            row[1] = ByteArray.concat(document.getContent(new BytesHandle()).get());
+            final String format = document.getFormat() != null ? document.getFormat().toString() : Format.UNKNOWN.toString();
+            row[2] = UTF8String.fromString(format);
+        }
+
+        if (!requestedMetadata.isEmpty()) {
+            DocumentMetadataHandle metadata = document.getMetadata(new DocumentMetadataHandle());
+            populateMetadataColumns(row, metadata);
+        }
+
+        return new GenericInternalRow(row);
+    }
+
+    private List<String> getNextBatchOfUris() {
+        long start = System.currentTimeMillis();
+        List<String> uris = uriBatcher.nextBatchOfUris();
+        if (logger.isTraceEnabled()) {
+            logger.trace("Retrieved {} URIs in {}ms from forest {}", uris.size(),
+                (System.currentTimeMillis() - start), this.forestName);
+        }
+        return uris;
+    }
+
+    private DocumentPage readPage(List<String> uris) {
+        long start = System.currentTimeMillis();
+        String[] uriArray = uris.toArray(new String[]{});
+        // Copied from ExportListener. Will add transform support later.
+        DocumentPage page = this.contentWasRequested ?
+            this.documentManager.read((ServerTransform) null, uriArray) :
+            this.documentManager.readMetadata(uriArray);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Retrieved page of documents in {}ms from forest {}", (System.currentTimeMillis() - start), this.forestName);
+        }
+        return page;
+    }
+
+    private void populateMetadataColumns(Object[] row, DocumentMetadataHandle metadata) {
+        if (requestedMetadataHas(DocumentManager.Metadata.COLLECTIONS)) {
+            populateCollectionsColumn(row, metadata);
+        }
+        if (requestedMetadataHas(DocumentManager.Metadata.PERMISSIONS)) {
+            populatePermissionsColumn(row, metadata);
+        }
+        if (requestedMetadataHas(DocumentManager.Metadata.QUALITY)) {
+            row[5] = metadata.getQuality();
+        }
+        if (requestedMetadataHas(DocumentManager.Metadata.PROPERTIES)) {
+            populatePropertiesColumn(row, metadata);
+        }
+        if (requestedMetadataHas(DocumentManager.Metadata.METADATAVALUES)) {
+            populateMetadataValuesColumn(row, metadata);
+        }
+    }
+
+    private void populateCollectionsColumn(Object[] row, DocumentMetadataHandle metadata) {
+        UTF8String[] collections = new UTF8String[metadata.getCollections().size()];
+        Iterator<String> iterator = metadata.getCollections().iterator();
+        for (int i = 0; i < collections.length; i++) {
+            collections[i] = UTF8String.fromString(iterator.next());
+        }
+        row[3] = ArrayData.toArrayData(collections);
+    }
+
+    private void populatePermissionsColumn(Object[] row, DocumentMetadataHandle metadata) {
+        DocumentMetadataHandle.DocumentPermissions perms = metadata.getPermissions();
+        UTF8String[] roles = new UTF8String[perms.size()];
+        Object[] capabilityArrays = new Object[perms.size()];
+        int i = 0;
+        for (Map.Entry<String, Set<DocumentMetadataHandle.Capability>> entry : perms.entrySet()) {
+            roles[i] = UTF8String.fromString(entry.getKey());
+            UTF8String[] capabilities = new UTF8String[entry.getValue().size()];
+            int j = 0;
+            Iterator<DocumentMetadataHandle.Capability> iterator = entry.getValue().iterator();
+            while (iterator.hasNext()) {
+                capabilities[j++] = UTF8String.fromString(iterator.next().name());
+            }
+            capabilityArrays[i++] = ArrayData.toArrayData(capabilities);
+        }
+        row[4] = ArrayBasedMapData.apply(roles, capabilityArrays);
+    }
+
+    private void populatePropertiesColumn(Object[] row, DocumentMetadataHandle metadata) {
+        DocumentMetadataHandle.DocumentProperties props = metadata.getProperties();
+        UTF8String[] keys = new UTF8String[props.size()];
+        UTF8String[] values = new UTF8String[props.size()];
+        int index = 0;
+        for (QName key : props.keySet()) {
+            keys[index] = UTF8String.fromString(key.toString());
+            values[index++] = UTF8String.fromString(props.get(key, String.class));
+        }
+        row[6] = ArrayBasedMapData.apply(keys, values);
+    }
+
+    private void populateMetadataValuesColumn(Object[] row, DocumentMetadataHandle metadata) {
+        DocumentMetadataHandle.DocumentMetadataValues metadataValues = metadata.getMetadataValues();
+        UTF8String[] keys = new UTF8String[metadataValues.size()];
+        UTF8String[] values = new UTF8String[metadataValues.size()];
+        int index = 0;
+        for (Map.Entry<String, String> entry : metadataValues.entrySet()) {
+            keys[index] = UTF8String.fromString(entry.getKey());
+            values[index++] = UTF8String.fromString(entry.getValue());
+        }
+        row[7] = ArrayBasedMapData.apply(keys, values);
+    }
+
+    private boolean requestedMetadataHas(DocumentManager.Metadata metadata) {
+        return requestedMetadata.contains(metadata) || requestedMetadata.contains(DocumentManager.Metadata.ALL);
     }
 
     @Override
     public void close() {
-        closeCurrentDocumentPageIfNecessary();
+        closeCurrentDocumentPage();
     }
 
-    private void closeCurrentDocumentPageIfNecessary() {
+    private void closeCurrentDocumentPage() {
         if (currentDocumentPage != null) {
             currentDocumentPage.close();
             currentDocumentPage = null;

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsWithMetadataTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsWithMetadataTest.java
@@ -1,0 +1,158 @@
+package com.marklogic.spark.reader.document;
+
+import com.marklogic.client.document.DocumentWriteSet;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import scala.collection.JavaConverters;
+import scala.collection.mutable.WrappedArray;
+
+import javax.xml.namespace.QName;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReadDocumentRowsWithMetadataTest extends AbstractIntegrationTest {
+
+    @BeforeEach
+    void setupTestDocuments() {
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        metadata.setQuality(10);
+        metadata.getCollections().addAll("collection1", "collection2");
+        metadata.getPermissions().add("spark-user-role", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE);
+        metadata.getPermissions().add("qconsole-user", DocumentMetadataHandle.Capability.READ);
+        metadata.getProperties().put(new QName("org:example", "key1"), "value1");
+        metadata.getProperties().put(QName.valueOf("key2"), "value2");
+        metadata.getMetadataValues().put("meta1", "value1");
+        metadata.getMetadataValues().put("meta2", "value2");
+        DocumentWriteSet writeSet = getDatabaseClient().newDocumentManager().newWriteSet();
+        for (int i = 1; i <= 2; i++) {
+            writeSet.add("/metadata-test/" + i + ".xml", metadata,
+                new StringHandle("<content>doesn't matter for this test</content>"));
+        }
+        getDatabaseClient().newDocumentManager().write(writeSet);
+    }
+
+    @Test
+    void contentAndAllMetadata() {
+        newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_DOCUMENTS_COLLECTIONS, "collection1")
+            .option(Options.READ_DOCUMENTS_CATEGORIES, "content,metadata")
+            .load()
+            .collectAsList()
+            .forEach(row -> {
+                verifyUriColumn(row);
+                verifyContentAndFormatColumnsArePopulated(row);
+                verifyAllMetadataColumnsArePopulated(row);
+            });
+    }
+
+    @Test
+    void noMetadata() {
+        newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_DOCUMENTS_COLLECTIONS, "collection1")
+            .load()
+            .collectAsList()
+            .forEach(row -> {
+                verifyUriColumn(row);
+                verifyContentAndFormatColumnsArePopulated(row);
+                for (int i = 3; i <= 7; i++) {
+                    assertNull(row.get(i), "Expected column " + i + " to be null because no metadata was requested.");
+                }
+            });
+    }
+
+    @Test
+    void allMetadataAndNoContent() {
+        newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_DOCUMENTS_COLLECTIONS, "collection1")
+            .option(Options.READ_DOCUMENTS_CATEGORIES, "metadata")
+            .load()
+            .collectAsList()
+            .forEach(row -> {
+                verifyUriColumn(row);
+                verifyAllMetadataColumnsArePopulated(row);
+                assertNull(row.get(1), "The content column should be empty since only metadata was requested.");
+                assertNull(row.get(2), "The format column should be empty since only metadata was requested.");
+            });
+    }
+
+    @Test
+    void someMetadataAndNoContent() {
+        newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_DOCUMENTS_COLLECTIONS, "collection1")
+            .option(Options.READ_DOCUMENTS_CATEGORIES, "collections,permissions")
+            .load()
+            .collectAsList()
+            .forEach(row -> {
+                verifyUriColumn(row);
+                verifyCollectionsColumn(row);
+                verifyPermissionsColumn(row);
+                assertNull(row.get(1));
+                assertNull(row.get(2));
+                assertNull(row.get(5));
+                assertNull(row.get(6));
+                assertNull(row.get(7));
+            });
+    }
+
+    private void verifyUriColumn(Row row) {
+        String uri = row.getString(0);
+        assertTrue(uri.startsWith("/metadata-test/"), "Unexpected URI: " + uri);
+    }
+
+    private void verifyContentAndFormatColumnsArePopulated(Row row) {
+        assertNotNull(row.get(1), "Content column should not be null");
+        assertEquals("XML", row.getString(2));
+    }
+
+    private void verifyAllMetadataColumnsArePopulated(Row row) {
+        verifyCollectionsColumn(row);
+        verifyPermissionsColumn(row);
+
+        assertEquals(10, row.getInt(5));
+
+        Map<String, String> properties = JavaConverters.mapAsJavaMap((scala.collection.immutable.Map) row.get(6));
+        assertEquals(2, properties.size());
+        assertEquals("value1", properties.get("{org:example}key1"));
+        assertEquals("value2", properties.get("key2"));
+
+        Map<String, String> metadataValues = JavaConverters.mapAsJavaMap((scala.collection.immutable.Map) row.get(7));
+        assertEquals(2, metadataValues.size());
+        assertEquals("value1", metadataValues.get("meta1"));
+        assertEquals("value2", metadataValues.get("meta2"));
+    }
+
+    private void verifyCollectionsColumn(Row row) {
+        WrappedArray collections = (WrappedArray) row.get(3);
+        assertEquals("collection1", collections.apply(0));
+        assertEquals("collection2", collections.apply(1));
+    }
+
+    private void verifyPermissionsColumn(Row row) {
+        Map<String, WrappedArray> permissions = JavaConverters.mapAsJavaMap((scala.collection.immutable.Map) row.get(4));
+        assertEquals(2, permissions.size());
+        assertTrue(permissions.containsKey("spark-user-role"));
+        assertTrue(permissions.containsKey("qconsole-user"));
+
+        WrappedArray capabilities = permissions.get("spark-user-role");
+        assertEquals(2, capabilities.length());
+        assertTrue(capabilities.contains("READ"));
+        assertTrue(capabilities.contains("UPDATE"));
+        capabilities = permissions.get("qconsole-user");
+        assertEquals(1, capabilities.length());
+        assertTrue(capabilities.contains("READ"));
+    }
+}


### PR DESCRIPTION
Most of this is just converting data in our `DocumentMetadataHandle` into the appropriate columns in a Spark row. 