### PR TITLE
MLE-11841 Can now write document rows to MarkLogic

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/document/DocumentTable.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentTable.java
@@ -1,21 +1,28 @@
 package com.marklogic.spark.reader.document;
 
 import org.apache.spark.sql.connector.catalog.SupportsRead;
+import org.apache.spark.sql.connector.catalog.SupportsWrite;
 import org.apache.spark.sql.connector.catalog.TableCapability;
 import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 import java.util.HashSet;
 import java.util.Set;
 
-public class DocumentTable implements SupportsRead {
+/**
+ * For reading and writing rows conforming to {@code DocumentRowSchema}.
+ */
+public class DocumentTable implements SupportsRead, SupportsWrite {
 
     private static Set<TableCapability> capabilities;
 
     static {
         capabilities = new HashSet<>();
         capabilities.add(TableCapability.BATCH_READ);
+        capabilities.add(TableCapability.BATCH_WRITE);
     }
 
     @Override
@@ -24,8 +31,13 @@ public class DocumentTable implements SupportsRead {
     }
 
     @Override
+    public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
+        return null;
+    }
+
+    @Override
     public String name() {
-        return "MarkLogicDocumentsTable";
+        return "MarkLogicDocumentTable";
     }
 
     @Override

--- a/src/main/java/com/marklogic/spark/writer/ArbitraryRowFunction.java
+++ b/src/main/java/com/marklogic/spark/writer/ArbitraryRowFunction.java
@@ -1,0 +1,57 @@
+package com.marklogic.spark.writer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Options;
+import com.marklogic.spark.Util;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.json.JacksonGenerator;
+
+import java.io.StringWriter;
+import java.util.function.Function;
+
+/**
+ * Handles building a document from an "arbitrary" row - i.e. one with an unknown schema, where the row will be
+ * serialized by Spark to a JSON object.
+ */
+class ArbitraryRowFunction implements Function<InternalRow, DocBuilder.DocumentInputs> {
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+    private WriteContext writeContext;
+
+    ArbitraryRowFunction(WriteContext writeContext) {
+        this.writeContext = writeContext;
+    }
+
+    @Override
+    public DocBuilder.DocumentInputs apply(InternalRow row) {
+        String json = convertRowToJSONString(row);
+        StringHandle content = new StringHandle(json).withFormat(Format.JSON);
+        ObjectNode columnValues = null;
+        if (writeContext.hasOption(Options.WRITE_URI_TEMPLATE)) {
+            try {
+                columnValues = (ObjectNode) objectMapper.readTree(json);
+            } catch (JsonProcessingException e) {
+                throw new ConnectorException(String.format("Unable to read JSON row: %s", e.getMessage()), e);
+            }
+        }
+        return new DocBuilder.DocumentInputs(null, content, columnValues, null);
+    }
+
+    private String convertRowToJSONString(InternalRow row) {
+        StringWriter jsonObjectWriter = new StringWriter();
+        JacksonGenerator jacksonGenerator = new JacksonGenerator(
+            this.writeContext.getSchema(),
+            jsonObjectWriter,
+            Util.DEFAULT_JSON_OPTIONS
+        );
+        jacksonGenerator.write(row);
+        jacksonGenerator.flush();
+        return jsonObjectWriter.toString();
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/DocumentRowFunction.java
+++ b/src/main/java/com/marklogic/spark/writer/DocumentRowFunction.java
@@ -1,0 +1,95 @@
+package com.marklogic.spark.writer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.io.BytesHandle;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.util.ArrayData;
+import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.sql.types.DataTypes;
+
+import javax.xml.namespace.QName;
+import java.util.function.Function;
+
+/**
+ * Knows how to build a document from a row corresponding to our {@code DocumentRowSchema}.
+ */
+class DocumentRowFunction implements Function<InternalRow, DocBuilder.DocumentInputs> {
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public DocBuilder.DocumentInputs apply(InternalRow row) {
+        String uri = row.getString(0);
+        BytesHandle content = new BytesHandle(row.getBinary(1));
+
+        ObjectNode columnValues = objectMapper.createObjectNode();
+        columnValues.put("URI", uri);
+        columnValues.put("format", row.getString(2));
+
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        addCollectionsToMetadata(row, metadata);
+        addPermissionsToMetadata(row, metadata);
+        if (!row.isNullAt(5)) {
+            metadata.setQuality(row.getInt(5));
+        }
+        addPropertiesToMetadata(row, metadata);
+        addMetadataValuesToMetadata(row, metadata);
+        return new DocBuilder.DocumentInputs(uri, content, columnValues, metadata);
+    }
+
+    private void addCollectionsToMetadata(InternalRow row, DocumentMetadataHandle metadata) {
+        if (!row.isNullAt(3)) {
+            ArrayData collections = row.getArray(3);
+            for (int i = 0; i < collections.numElements(); i++) {
+                String value = collections.get(i, DataTypes.StringType).toString();
+                metadata.getCollections().add(value);
+            }
+        }
+    }
+
+    private void addPermissionsToMetadata(InternalRow row, DocumentMetadataHandle metadata) {
+        if (!row.isNullAt(4)) {
+            MapData permissions = row.getMap(4);
+            ArrayData roles = permissions.keyArray();
+            ArrayData capabilities = permissions.valueArray();
+            for (int i = 0; i < roles.numElements(); i++) {
+                String role = roles.get(i, DataTypes.StringType).toString();
+                ArrayData caps = capabilities.getArray(i);
+                DocumentMetadataHandle.Capability[] capArray = new DocumentMetadataHandle.Capability[caps.numElements()];
+                for (int j = 0; j < caps.numElements(); j++) {
+                    String value = caps.get(j, DataTypes.StringType).toString();
+                    capArray[j] = DocumentMetadataHandle.Capability.valueOf(value.toUpperCase());
+                }
+                metadata.getPermissions().add(role, capArray);
+            }
+        }
+    }
+
+    private void addPropertiesToMetadata(InternalRow row, DocumentMetadataHandle metadata) {
+        if (!row.isNullAt(6)) {
+            MapData properties = row.getMap(6);
+            ArrayData qnames = properties.keyArray();
+            ArrayData values = properties.valueArray();
+            for (int i = 0; i < qnames.numElements(); i++) {
+                String qname = qnames.get(i, DataTypes.StringType).toString();
+                String value = values.get(i, DataTypes.StringType).toString();
+                metadata.getProperties().put(QName.valueOf(qname), value);
+            }
+        }
+    }
+
+    private void addMetadataValuesToMetadata(InternalRow row, DocumentMetadataHandle metadata) {
+        if (!row.isNullAt(7)) {
+            MapData properties = row.getMap(7);
+            ArrayData keys = properties.keyArray();
+            ArrayData values = properties.valueArray();
+            for (int i = 0; i < keys.numElements(); i++) {
+                String key = keys.get(i, DataTypes.StringType).toString();
+                String value = values.get(i, DataTypes.StringType).toString();
+                metadata.getMetadataValues().put(key, value);
+            }
+        }
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/FileRowFunction.java
+++ b/src/main/java/com/marklogic/spark/writer/FileRowFunction.java
@@ -1,0 +1,57 @@
+package com.marklogic.spark.writer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.io.BytesHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.DataTypes;
+
+import java.util.function.Function;
+
+/**
+ * Knows how to build a document from a row corresponding to our {@code FileRowSchema}.
+ */
+class FileRowFunction implements Function<InternalRow, DocBuilder.DocumentInputs> {
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+    private WriteContext writeContext;
+
+    FileRowFunction(WriteContext writeContext) {
+        this.writeContext = writeContext;
+    }
+
+    @Override
+    public DocBuilder.DocumentInputs apply(InternalRow row) {
+        String initialUri = row.getString(writeContext.getFileSchemaPathPosition());
+        BytesHandle content = new BytesHandle(row.getBinary(writeContext.getFileSchemaContentPosition()));
+        forceFormatIfNecessary(content);
+        ObjectNode columnValues = null;
+        if (writeContext.hasOption(Options.WRITE_URI_TEMPLATE)) {
+            columnValues = objectMapper.createObjectNode();
+            columnValues.put("path", initialUri);
+            Object modificationTime = row.get(1, DataTypes.LongType);
+            if (modificationTime != null) {
+                columnValues.put("modificationTime", modificationTime.toString());
+            }
+            columnValues.put("length", row.getLong(2));
+            // Not including content as it's a byte array that is not expected to be helpful for making a URI.
+        }
+        return new DocBuilder.DocumentInputs(initialUri, content, columnValues, null);
+    }
+
+    private void forceFormatIfNecessary(BytesHandle content) {
+        if (writeContext.hasOption(Options.WRITE_FILES_DOCUMENT_TYPE)) {
+            String value = writeContext.getProperties().get(Options.WRITE_FILES_DOCUMENT_TYPE);
+            try {
+                content.withFormat(Format.valueOf(value.toUpperCase()));
+            } catch (IllegalArgumentException e) {
+                String message = "Invalid value for option %s: %s; must be one of 'JSON', 'XML', or 'TEXT'.";
+                throw new ConnectorException(String.format(message, Options.WRITE_FILES_DOCUMENT_TYPE, value));
+            }
+        }
+    }
+}

--- a/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
+++ b/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package com.marklogic.spark;
 
+import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.junit5.spring.AbstractSpringMarkLogicTest;
 import com.marklogic.junit5.spring.SimpleTestConfig;
 import org.apache.spark.SparkException;
@@ -166,5 +167,10 @@ public abstract class AbstractIntegrationTest extends AbstractSpringMarkLogicTes
             "Expect the Spark-thrown SparkException to wrap our ConnectorException, which is an exception that we " +
                 "intentionally throw when an error condition is detected.");
         return (ConnectorException) ex.getCause();
+    }
+
+    protected final DocumentMetadataHandle readMetadata(String uri) {
+        // This should really be in marklogic-unit-test.
+        return getDatabaseClient().newDocumentManager().readMetadata(uri, new DocumentMetadataHandle());
     }
 }

--- a/src/test/java/com/marklogic/spark/TestUtil.java
+++ b/src/test/java/com/marklogic/spark/TestUtil.java
@@ -1,0 +1,33 @@
+package com.marklogic.spark;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.document.DocumentWriteSet;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.StringHandle;
+
+import javax.xml.namespace.QName;
+
+public interface TestUtil {
+
+    static void insertTwoDocumentsWithAllMetadata(DatabaseClient client) {
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        metadata.setQuality(10);
+
+        metadata.getCollections().addAll("collection1", "collection2");
+
+        metadata.getPermissions().add("spark-user-role", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE);
+        metadata.getPermissions().add("qconsole-user", DocumentMetadataHandle.Capability.READ);
+
+        metadata.getProperties().put(new QName("org:example", "key1"), "value1");
+        metadata.getProperties().put(QName.valueOf("key2"), "value2");
+
+        metadata.getMetadataValues().put("meta1", "value1");
+        metadata.getMetadataValues().put("meta2", "value2");
+
+        DocumentWriteSet writeSet = client.newDocumentManager().newWriteSet();
+        for (int i = 1; i <= 2; i++) {
+            writeSet.add("/test/" + i + ".xml", metadata, new StringHandle("<hello>world</hello>"));
+        }
+        client.newDocumentManager().write(writeSet);
+    }
+}

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsWithMetadataTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsWithMetadataTest.java
@@ -1,17 +1,14 @@
 package com.marklogic.spark.reader.document;
 
-import com.marklogic.client.document.DocumentWriteSet;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.io.StringHandle;
 import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.Options;
+import com.marklogic.spark.TestUtil;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import scala.collection.JavaConverters;
 import scala.collection.mutable.WrappedArray;
 
-import javax.xml.namespace.QName;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -19,22 +16,8 @@ import static org.junit.jupiter.api.Assertions.*;
 class ReadDocumentRowsWithMetadataTest extends AbstractIntegrationTest {
 
     @BeforeEach
-    void setupTestDocuments() {
-        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
-        metadata.setQuality(10);
-        metadata.getCollections().addAll("collection1", "collection2");
-        metadata.getPermissions().add("spark-user-role", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE);
-        metadata.getPermissions().add("qconsole-user", DocumentMetadataHandle.Capability.READ);
-        metadata.getProperties().put(new QName("org:example", "key1"), "value1");
-        metadata.getProperties().put(QName.valueOf("key2"), "value2");
-        metadata.getMetadataValues().put("meta1", "value1");
-        metadata.getMetadataValues().put("meta2", "value2");
-        DocumentWriteSet writeSet = getDatabaseClient().newDocumentManager().newWriteSet();
-        for (int i = 1; i <= 2; i++) {
-            writeSet.add("/metadata-test/" + i + ".xml", metadata,
-                new StringHandle("<content>doesn't matter for this test</content>"));
-        }
-        getDatabaseClient().newDocumentManager().write(writeSet);
+    void setup() {
+        TestUtil.insertTwoDocumentsWithAllMetadata(getDatabaseClient());
     }
 
     @Test
@@ -110,7 +93,7 @@ class ReadDocumentRowsWithMetadataTest extends AbstractIntegrationTest {
 
     private void verifyUriColumn(Row row) {
         String uri = row.getString(0);
-        assertTrue(uri.startsWith("/metadata-test/"), "Unexpected URI: " + uri);
+        assertTrue(uri.startsWith("/test/"), "Unexpected URI: " + uri);
     }
 
     private void verifyContentAndFormatColumnsArePopulated(Row row) {

--- a/src/test/java/com/marklogic/spark/writer/document/WriteDocumentRowsToMarkLogicTest.java
+++ b/src/test/java/com/marklogic/spark/writer/document/WriteDocumentRowsToMarkLogicTest.java
@@ -1,0 +1,119 @@
+package com.marklogic.spark.writer.document;
+
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.junit5.PermissionsTester;
+import com.marklogic.junit5.XmlNode;
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import com.marklogic.spark.TestUtil;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.namespace.QName;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WriteDocumentRowsToMarkLogicTest extends AbstractIntegrationTest {
+
+    @BeforeEach
+    void setup() {
+        TestUtil.insertTwoDocumentsWithAllMetadata(getDatabaseClient());
+    }
+
+    @Test
+    void retainMetadataFromCopiedDocuments() {
+        readTheTwoTestDocuments()
+            .write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.WRITE_URI_TEMPLATE, "/new{URI}")
+            .mode(SaveMode.Append)
+            .save();
+
+        assertCollectionSize("collection1", 4);
+        assertCollectionSize("collection2", 4);
+
+        Stream.of("/new/test/1.xml", "/new/test/2.xml").forEach(uri -> {
+            XmlNode doc = readXmlDocument(uri);
+            doc.assertElementValue("/hello", "world");
+
+            DocumentMetadataHandle metadata = readMetadata(uri);
+            verifyCollections(metadata, "collection1", "collection2");
+            verifyPropertiesAndMetadataValuesWereCopied(metadata);
+
+            PermissionsTester tester = new PermissionsTester(metadata.getPermissions());
+            assertEquals(2, tester.getDocumentPermissions().size());
+            tester.assertReadPermissionExists("spark-user-role");
+            tester.assertUpdatePermissionExists("spark-user-role");
+            tester.assertReadPermissionExists("qconsole-user");
+            assertEquals(2, tester.getDocumentPermissions().get("spark-user-role").size());
+            assertEquals(1, tester.getDocumentPermissions().get("qconsole-user").size());
+        });
+    }
+
+    @Test
+    void overrideMetadataFromCopiedDocuments() {
+        readTheTwoTestDocuments()
+            .write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.WRITE_URI_TEMPLATE, "/override{URI}")
+            // Hmm... could we do metadata values like this:
+            // .option(Options.WRITE_METADATA_VALUES, "meta1,value1,meta2,value2")
+            // .option(Options.WRITE_DOCUMENT_PROPERTIES, "{org:example}key1,value1")
+            .option(Options.WRITE_COLLECTIONS, "new1,new2")
+            .option(Options.WRITE_PERMISSIONS, "spark-user-role,read,qconsole-user,update")
+            .mode(SaveMode.Append)
+            .save();
+
+        // Make sure new docs weren't added to the test collections.
+        assertCollectionSize("collection1", 2);
+        assertCollectionSize("collection2", 2);
+
+        Stream.of("/override/test/1.xml", "/override/test/2.xml").forEach(uri -> {
+            XmlNode doc = readXmlDocument(uri);
+            doc.assertElementValue("/hello", "world");
+
+            DocumentMetadataHandle metadata = readMetadata(uri);
+            verifyCollections(metadata, "new1", "new2");
+            verifyPropertiesAndMetadataValuesWereCopied(metadata);
+
+            PermissionsTester tester = new PermissionsTester(metadata.getPermissions());
+            assertEquals(2, tester.getDocumentPermissions().size());
+            tester.assertReadPermissionExists("spark-user-role");
+            tester.assertUpdatePermissionExists("qconsole-user");
+            assertEquals(1, tester.getDocumentPermissions().get("spark-user-role").size());
+            assertEquals(1, tester.getDocumentPermissions().get("qconsole-user").size());
+        });
+    }
+
+    private Dataset<Row> readTheTwoTestDocuments() {
+        return newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_DOCUMENTS_COLLECTIONS, "collection1")
+            .option(Options.READ_DOCUMENTS_CATEGORIES, "content,metadata")
+            .load();
+    }
+
+    private void verifyCollections(DocumentMetadataHandle metadata, String... collections) {
+        assertEquals(collections.length, metadata.getCollections().size());
+        for (String c : collections) {
+            assertTrue(metadata.getCollections().contains(c),
+                String.format("Did not find collection %s in %s", c, metadata.getCollections()));
+        }
+    }
+
+    private void verifyPropertiesAndMetadataValuesWereCopied(DocumentMetadataHandle metadata) {
+        assertEquals(2, metadata.getProperties().size());
+        assertEquals("value1", metadata.getProperties().get(QName.valueOf("{org:example}key1"), String.class));
+        assertEquals("value2", metadata.getProperties().get(QName.valueOf("key2"), String.class));
+
+        assertEquals(2, metadata.getMetadataValues().size());
+        assertEquals("value1", metadata.getMetadataValues().get("meta1"));
+        assertEquals("value2", metadata.getMetadataValues().get("meta2"));
+    }
+}


### PR DESCRIPTION
Moved some things around too:

1. The logic in `WriteBatcherDataWriter` for building a document from a row is now spread across 3 classes, each responsible for a different type of row.
2. Created `TestUtil` for holding the logic for creating test documents with all types of metadata. 