### PR TITLE
MLE-11895 Can now use any of the 4 query types for reading documents

### DIFF
--- a/src/main/java/com/marklogic/spark/DefaultSource.java
+++ b/src/main/java/com/marklogic/spark/DefaultSource.java
@@ -18,10 +18,10 @@ package com.marklogic.spark;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RawQueryDSLPlan;
 import com.marklogic.client.row.RowManager;
-import com.marklogic.spark.reader.optic.SchemaInferrer;
 import com.marklogic.spark.reader.document.DocumentRowSchema;
 import com.marklogic.spark.reader.document.DocumentTable;
 import com.marklogic.spark.reader.file.FileRowSchema;
+import com.marklogic.spark.reader.optic.SchemaInferrer;
 import com.marklogic.spark.writer.WriteContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Table;
@@ -65,8 +65,7 @@ public class DefaultSource implements TableProvider, DataSourceRegister {
         if (isFileOperation(properties)) {
             return FileRowSchema.SCHEMA;
         }
-        // We will likely check for any read.documents option in the near future.
-        if (options.containsKey(Options.READ_DOCUMENTS_COLLECTIONS)) {
+        if (isReadDocumentsOperation(properties)) {
             return DocumentRowSchema.SCHEMA;
         }
         if (isReadWithCustomCodeOperation(properties)) {
@@ -84,11 +83,10 @@ public class DefaultSource implements TableProvider, DataSourceRegister {
             );
         }
 
-        if (properties.containsKey(Options.READ_DOCUMENTS_COLLECTIONS)) {
+        if (isReadDocumentsOperation(properties)) {
             return new DocumentTable();
         }
-
-        if (isReadOperation(properties)) {
+        else if (isReadOperation(properties)) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Creating new table for reading");
             }
@@ -117,6 +115,10 @@ public class DefaultSource implements TableProvider, DataSourceRegister {
 
     private boolean isReadOperation(Map<String, String> properties) {
         return properties.get(Options.READ_OPTIC_QUERY) != null || isReadWithCustomCodeOperation(properties);
+    }
+
+    private boolean isReadDocumentsOperation(Map<String, String> properties) {
+        return properties.containsKey(Options.READ_DOCUMENTS_QUERY) || properties.containsKey(Options.READ_DOCUMENTS_COLLECTIONS);
     }
 
     private boolean isReadWithCustomCodeOperation(Map<String, String> properties) {

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -44,6 +44,9 @@ public abstract class Options {
     // "categories" as defined by https://docs.marklogic.com/REST/GET/v1/documents .
     public static final String READ_DOCUMENTS_CATEGORIES = "spark.marklogic.read.documents.categories";
     public static final String READ_DOCUMENTS_COLLECTIONS = "spark.marklogic.read.documents.collections";
+    public static final String READ_DOCUMENTS_QUERY = "spark.marklogic.read.documents.query";
+    public static final String READ_DOCUMENTS_QUERY_TYPE = "spark.marklogic.read.documents.queryType";
+    public static final String READ_DOCUMENTS_QUERY_FORMAT = "spark.marklogic.read.documents.queryFormat";
 
     public static final String READ_FILES_COMPRESSION = "spark.marklogic.read.files.compression";
 

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
@@ -1,6 +1,8 @@
 package com.marklogic.spark.reader.document;
 
+import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.document.DocumentManager;
+import com.marklogic.client.query.SearchQueryDefinition;
 import com.marklogic.spark.ContextSupport;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
@@ -41,5 +43,13 @@ class DocumentContext extends ContextSupport {
             }
         }
         return false;
+    }
+
+    SearchQueryDefinition buildSearchQuery(DatabaseClient client) {
+        return new SearchQueryBuilder()
+            .withQuery(getProperties().get(Options.READ_DOCUMENTS_QUERY))
+            .withQueryType(getProperties().get(Options.READ_DOCUMENTS_QUERY_TYPE))
+            .withCollections(getProperties().get(Options.READ_DOCUMENTS_COLLECTIONS))
+            .buildQuery(client);
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/document/ForestReader.java
+++ b/src/main/java/com/marklogic/spark/reader/document/ForestReader.java
@@ -5,7 +5,7 @@ import com.marklogic.client.document.*;
 import com.marklogic.client.io.BytesHandle;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
-import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.client.query.SearchQueryDefinition;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
@@ -49,12 +49,7 @@ class ForestReader implements PartitionReader<InternalRow> {
         }
 
         DatabaseClient client = documentContext.connectToMarkLogic();
-
-        // Can break out query construction into a new private method as we add more query features.
-        String[] collections = documentContext.getProperties().get(Options.READ_DOCUMENTS_COLLECTIONS).split(",");
-        StructuredQueryDefinition query = client.newQueryManager()
-            .newStructuredQueryBuilder()
-            .collection(collections);
+        SearchQueryDefinition query = documentContext.buildSearchQuery(client);
         this.uriBatcher = new UriBatcher(client, query, forestPartition.getForestName());
 
         this.documentManager = client.newDocumentManager();

--- a/src/main/java/com/marklogic/spark/reader/document/SearchQueryBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/document/SearchQueryBuilder.java
@@ -1,0 +1,65 @@
+package com.marklogic.spark.reader.document;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.query.QueryDefinition;
+import com.marklogic.client.query.QueryManager;
+import com.marklogic.client.query.SearchQueryDefinition;
+
+/**
+ * Potentially reusable class for the Java Client that handles constructing a query based on a common
+ * set of user-defined inputs.
+ */
+class SearchQueryBuilder {
+
+    public enum QueryType {
+        STRING,
+        STRUCTURED,
+        SERIALIZED_CTS,
+        COMBINED;
+    }
+
+    private String query;
+    private QueryType queryType;
+    private String[] collections;
+
+    SearchQueryDefinition buildQuery(DatabaseClient client) {
+        final QueryManager queryManager = client.newQueryManager();
+        if (query != null) {
+            QueryDefinition queryDefinition;
+            if (QueryType.STRUCTURED.equals(queryType)) {
+                queryDefinition = queryManager.newRawStructuredQueryDefinition(new StringHandle(query));
+            } else if (QueryType.SERIALIZED_CTS.equals(queryType)) {
+                queryDefinition = queryManager.newRawCtsQueryDefinition(new StringHandle(query));
+            } else if (QueryType.COMBINED.equals(queryType)) {
+                queryDefinition = queryManager.newRawCombinedQueryDefinition(new StringHandle(query));
+            } else {
+                queryDefinition = client.newQueryManager().newStringDefinition().withCriteria(this.query);
+            }
+            if (collections != null) {
+                queryDefinition.setCollections(this.collections);
+            }
+            return queryDefinition;
+        }
+        return queryManager.newStructuredQueryBuilder().collection(collections);
+    }
+
+    public SearchQueryBuilder withQuery(String query) {
+        this.query = query;
+        return this;
+    }
+
+    public SearchQueryBuilder withQueryType(String queryType) {
+        if (queryType != null) {
+            this.queryType = QueryType.valueOf(queryType.toUpperCase());
+        }
+        return this;
+    }
+
+    public SearchQueryBuilder withCollections(String value) {
+        if (value != null) {
+            this.collections = value.split(",");
+        }
+        return this;
+    }
+}

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
@@ -4,19 +4,22 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.Options;
+import org.apache.spark.sql.DataFrameReader;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ReadDocumentRowsTest extends AbstractIntegrationTest {
 
     @Test
     void readByCollection() throws Exception {
-        Dataset<Row> rows = newSparkSession().read()
-            .format(CONNECTOR_IDENTIFIER)
-            .option(Options.CLIENT_URI, makeClientUri())
+        Dataset<Row> rows = startRead()
             .option(Options.READ_DOCUMENTS_COLLECTIONS, "author")
             .load();
 
@@ -33,13 +36,140 @@ class ReadDocumentRowsTest extends AbstractIntegrationTest {
 
     @Test
     void noDocsInCollection() {
-        long count = newSparkSession().read()
-            .format(CONNECTOR_IDENTIFIER)
-            .option(Options.CLIENT_URI, makeClientUri())
+        long count = startRead()
             .option(Options.READ_DOCUMENTS_COLLECTIONS, "some-collection-with-no-documents")
             .load()
             .count();
         assertEquals(0, count);
     }
 
+    @Test
+    void stringQuery() {
+        Dataset<Row> rows = startRead()
+            // Query type defaults to "string", so no need to specify it.
+            .option(Options.READ_DOCUMENTS_QUERY, "Vivianne OR Moria")
+            .load();
+
+        List<String> uris = rows.collectAsList().stream().map(row -> row.getString(0)).collect(Collectors.toList());
+        assertEquals(2, uris.size());
+        assertTrue(uris.contains("/author/author1.json"));
+        assertTrue(uris.contains("/author/author11.json"));
+    }
+
+    @Test
+    void structuredQueryXML() {
+        String query = "<query xmlns='http://marklogic.com/appservices/search'>" +
+            "<term-query><text>Vivianne</text></term-query></query>";
+        List<Row> rows = startRead()
+            .option(Options.READ_DOCUMENTS_QUERY, query)
+            .option(Options.READ_DOCUMENTS_QUERY_TYPE, "strucTURED")
+            .load()
+            .collectAsList();
+
+        assertEquals(1, rows.size());
+        assertEquals("/author/author1.json", rows.get(0).getString(0));
+    }
+
+    @Test
+    void structuredQueryWithCollection() {
+        String query = "<query xmlns='http://marklogic.com/appservices/search'>" +
+            "<term-query><text>Vivianne</text></term-query></query>";
+        List<Row> rows = startRead()
+            .option(Options.READ_DOCUMENTS_QUERY, query)
+            .option(Options.READ_DOCUMENTS_QUERY_TYPE, "structured")
+            .option(Options.READ_DOCUMENTS_COLLECTIONS, "author")
+            .load()
+            .collectAsList();
+
+        assertEquals(1, rows.size());
+    }
+
+    @Test
+    void structuredQueryWithNonMatchingCollection() {
+        String query = "<query xmlns='http://marklogic.com/appservices/search'>" +
+            "<term-query><text>Vivianne</text></term-query></query>";
+        List<Row> rows = startRead()
+            .option(Options.READ_DOCUMENTS_QUERY, query)
+            .option(Options.READ_DOCUMENTS_QUERY_TYPE, "STRUCTURED")
+            .option(Options.READ_DOCUMENTS_COLLECTIONS, "some-other-collection")
+            .load()
+            .collectAsList();
+
+        assertEquals(0, rows.size());
+    }
+
+    @Test
+    void structuredQueryJSON() {
+        String query = "{ \"query\": { \"queries\": [{ \"term-query\": { \"text\": [ \"Moria\" ] } }] } }";
+        List<Row> rows = startRead()
+            .option(Options.READ_DOCUMENTS_QUERY, query)
+            .option(Options.READ_DOCUMENTS_QUERY_TYPE, "STRUCTured")
+            .load()
+            .collectAsList();
+
+        assertEquals(1, rows.size());
+        assertEquals("/author/author11.json", rows.get(0).getString(0));
+    }
+
+    @Test
+    void serializedCTSQueryXML() {
+        String query = "<cts:word-query xmlns:cts='http://marklogic.com/cts'>" +
+            "<cts:text xml:lang='en'>Vivianne</cts:text>" +
+            "</cts:word-query>";
+
+        List<Row> rows = startRead()
+            .option(Options.READ_DOCUMENTS_QUERY, query)
+            .option(Options.READ_DOCUMENTS_QUERY_TYPE, "serialized_cts")
+            .load()
+            .collectAsList();
+
+        assertEquals(1, rows.size());
+    }
+
+    @Test
+    void serializedCTSQueryJSON() {
+        String query = "{ \"query\": { \"queries\": [{ \"term-query\": { \"text\": [ \"Vivianne\" ] } }] } }";
+
+        List<Row> rows = startRead()
+            .option(Options.READ_DOCUMENTS_QUERY, query)
+            .option(Options.READ_DOCUMENTS_QUERY_TYPE, "serialized_cts")
+            .load()
+            .collectAsList();
+
+        assertEquals(1, rows.size());
+    }
+
+    @Test
+    void combinedQueryXML() {
+        String query = "<search xmlns='http://marklogic.com/appservices/search'>" +
+            "<cts:word-query xmlns:cts='http://marklogic.com/cts'><cts:text xml:lang='en'>Vivianne</cts:text></cts:word-query>" +
+            "<options/></search>";
+
+        List<Row> rows = startRead()
+            .option(Options.READ_DOCUMENTS_QUERY, query)
+            .option(Options.READ_DOCUMENTS_QUERY_TYPE, "combined")
+            .load()
+            .collectAsList();
+
+        assertEquals(1, rows.size());
+    }
+
+    @Test
+    void combinedQueryJSON() {
+        String query = "{ \"search\": { \"query\": { \"query\": { \"queries\": [{\"term-query\":{\"text\":[\"Vivianne\"]}}] } } } }";
+
+        List<Row> rows = startRead()
+            .option(Options.READ_DOCUMENTS_QUERY, query)
+            .option(Options.READ_DOCUMENTS_QUERY_TYPE, "combined")
+            .load()
+            .collectAsList();
+
+        assertEquals(1, rows.size());
+    }
+
+    private DataFrameReader startRead() {
+        return newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri());
+    }
 }


### PR DESCRIPTION
Turns out we don't need queryFormat - the REST API seems to figure out whether it's a JSON or XML query without having to configure it on the handle. 