### PR TITLE
Allowing for MarkLogic version to be overridden

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+# Defines environment variables for docker-compose.
+# Can be overridden via e.g. `MARKLOGIC_TAG=latest-10.0 docker-compose up -d --build`.
+MARKLOGIC_TAG=11.1.0-centos-1.1.0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ name: marklogic_spark
 services:
 
   marklogic:
-    image: "marklogicdb/marklogic-db:11.1.0-centos-1.1.0"
+    image: "marklogicdb/marklogic-db:${MARKLOGIC_TAG}"
     platform: linux/amd64
     environment:
       - MARKLOGIC_INIT=true


### PR DESCRIPTION
This is for regression builds in Jenkins. 