### PR TITLE
Small enhancements from testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,25 @@ You now have a Spark dataframe - try some commands out on it:
 Check out the [PySpark docs](https://spark.apache.org/docs/latest/api/python/getting_started/quickstart_df.html) for 
 more commands you can try out. 
 
+You can query for documents as well - the following shows a simple example along with a technique for converting the
+binary content of each document into a string of JSON.
+
+```
+import json
+from pyspark.sql import functions as F
+
+df = spark.read.format("marklogic")\
+    .option("spark.marklogic.client.uri", "spark-test-user:spark@localhost:8016")\
+    .option("spark.marklogic.read.documents.collections", "author")\
+    .load()
+df.show()
+
+df2 = df.select(F.col("content").cast("string"))
+df2.head()
+json.loads(df2.head()['content'])
+```
+
+
 # Testing against a local Spark cluster
 
 When you run PySpark, it will create its own Spark cluster. If you'd like to try against a separate Spark cluster

--- a/src/main/java/com/marklogic/spark/DefaultSource.java
+++ b/src/main/java/com/marklogic/spark/DefaultSource.java
@@ -121,7 +121,7 @@ public class DefaultSource implements TableProvider, DataSourceRegister {
         return properties.containsKey(Options.READ_DOCUMENTS_QUERY) ||
             properties.containsKey(Options.READ_DOCUMENTS_COLLECTIONS) ||
             properties.containsKey(Options.READ_DOCUMENTS_DIRECTORY) ||
-            properties.containsKey(Options.READ_DOCUMENTS_OPTIONS_NAME);
+            properties.containsKey(Options.READ_DOCUMENTS_OPTIONS);
     }
 
     private boolean isReadWithCustomCodeOperation(Map<String, String> properties) {

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -46,7 +46,7 @@ public abstract class Options {
     public static final String READ_DOCUMENTS_COLLECTIONS = "spark.marklogic.read.documents.collections";
     public static final String READ_DOCUMENTS_QUERY = "spark.marklogic.read.documents.query";
     public static final String READ_DOCUMENTS_QUERY_TYPE = "spark.marklogic.read.documents.queryType";
-    public static final String READ_DOCUMENTS_OPTIONS_NAME = "spark.marklogic.read.documents.optionsName";
+    public static final String READ_DOCUMENTS_OPTIONS = "spark.marklogic.read.documents.options";
     public static final String READ_DOCUMENTS_DIRECTORY = "spark.marklogic.read.documents.directory";
     public static final String READ_DOCUMENTS_TRANSFORM = "spark.marklogic.read.documents.transform";
     public static final String READ_DOCUMENTS_TRANSFORM_PARAMS = "spark.marklogic.read.documents.transformParams";
@@ -66,6 +66,7 @@ public abstract class Options {
     public static final String WRITE_THREAD_COUNT = "spark.marklogic.write.threadCount";
     public static final String WRITE_ABORT_ON_FAILURE = "spark.marklogic.write.abortOnFailure";
 
+    // For writing via custom code.
     public static final String WRITE_INVOKE = "spark.marklogic.write.invoke";
     public static final String WRITE_JAVASCRIPT = "spark.marklogic.write.javascript";
     public static final String WRITE_XQUERY = "spark.marklogic.write.xquery";
@@ -73,6 +74,7 @@ public abstract class Options {
     public static final String WRITE_EXTERNAL_VARIABLE_DELIMITER = "spark.marklogic.write.externalVariableDelimiter";
     public static final String WRITE_VARS_PREFIX = "spark.marklogic.write.vars.";
 
+    // For writing documents to MarkLogic.
     public static final String WRITE_COLLECTIONS = "spark.marklogic.write.collections";
     public static final String WRITE_PERMISSIONS = "spark.marklogic.write.permissions";
     public static final String WRITE_TEMPORAL_COLLECTION = "spark.marklogic.write.temporalCollection";
@@ -80,14 +82,14 @@ public abstract class Options {
     public static final String WRITE_URI_REPLACE = "spark.marklogic.write.uriReplace";
     public static final String WRITE_URI_SUFFIX = "spark.marklogic.write.uriSuffix";
     public static final String WRITE_URI_TEMPLATE = "spark.marklogic.write.uriTemplate";
-
     public static final String WRITE_TRANSFORM_NAME = "spark.marklogic.write.transform";
     public static final String WRITE_TRANSFORM_PARAMS = "spark.marklogic.write.transformParams";
     public static final String WRITE_TRANSFORM_PARAMS_DELIMITER = "spark.marklogic.write.transformParamsDelimiter";
 
-    // TBD Need to rename this, probably to WRITE_FILE_ROWS_DOCUMENT_TYPE.
-    public static final String WRITE_FILES_DOCUMENT_TYPE = "spark.marklogic.write.files.documentType";
+    // For writing rows adhering to {@code FileRowSchema} to MarkLogic.
+    public static final String WRITE_FILE_ROWS_DOCUMENT_TYPE = "spark.marklogic.write.fileRows.documentType";
 
+    // For writing rows adhering to {@code DocumentRowSchema} to a filesystem.
     public static final String WRITE_FILES_COMPRESSION = "spark.marklogic.write.files.compression";
 
     private Options() {

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
@@ -53,7 +53,7 @@ class DocumentContext extends ContextSupport {
             .withQueryType(props.get(Options.READ_DOCUMENTS_QUERY_TYPE))
             .withCollections(props.get(Options.READ_DOCUMENTS_COLLECTIONS))
             .withDirectory(props.get(Options.READ_DOCUMENTS_DIRECTORY))
-            .withOptionsName(props.get(Options.READ_DOCUMENTS_OPTIONS_NAME))
+            .withOptionsName(props.get(Options.READ_DOCUMENTS_OPTIONS))
             .withTransformName(props.get(Options.READ_DOCUMENTS_TRANSFORM))
             .withTransformParams(props.get(Options.READ_DOCUMENTS_TRANSFORM_PARAMS))
             .withTransformParamsDelimiter(props.get(Options.READ_DOCUMENTS_TRANSFORM_PARAMS_DELIMITER))

--- a/src/main/java/com/marklogic/spark/reader/document/SearchQueryBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/document/SearchQueryBuilder.java
@@ -13,7 +13,7 @@ import java.util.Arrays;
  * Potentially reusable class for the Java Client that handles constructing a query based on a common
  * set of user-defined inputs.
  */
-class SearchQueryBuilder {
+public class SearchQueryBuilder {
 
     public enum QueryType {
         STRING,

--- a/src/main/java/com/marklogic/spark/writer/FileRowFunction.java
+++ b/src/main/java/com/marklogic/spark/writer/FileRowFunction.java
@@ -44,13 +44,13 @@ class FileRowFunction implements Function<InternalRow, DocBuilder.DocumentInputs
     }
 
     private void forceFormatIfNecessary(BytesHandle content) {
-        if (writeContext.hasOption(Options.WRITE_FILES_DOCUMENT_TYPE)) {
-            String value = writeContext.getProperties().get(Options.WRITE_FILES_DOCUMENT_TYPE);
+        if (writeContext.hasOption(Options.WRITE_FILE_ROWS_DOCUMENT_TYPE)) {
+            String value = writeContext.getProperties().get(Options.WRITE_FILE_ROWS_DOCUMENT_TYPE);
             try {
                 content.withFormat(Format.valueOf(value.toUpperCase()));
             } catch (IllegalArgumentException e) {
                 String message = "Invalid value for option %s: %s; must be one of 'JSON', 'XML', or 'TEXT'.";
-                throw new ConnectorException(String.format(message, Options.WRITE_FILES_DOCUMENT_TYPE, value));
+                throw new ConnectorException(String.format(message, Options.WRITE_FILE_ROWS_DOCUMENT_TYPE, value));
             }
         }
     }

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
@@ -205,7 +205,7 @@ class ReadDocumentRowsTest extends AbstractIntegrationTest {
     void withSearchOptions() {
         List<Row> rows = startRead()
             .option(Options.READ_DOCUMENTS_QUERY, "citation_id:3")
-            .option(Options.READ_DOCUMENTS_OPTIONS_NAME, "test-options")
+            .option(Options.READ_DOCUMENTS_OPTIONS, "test-options")
             .load()
             .collectAsList();
 

--- a/src/test/java/com/marklogic/spark/writer/WriteFileRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteFileRowsTest.java
@@ -123,7 +123,7 @@ class WriteFileRowsTest extends AbstractWriteTest {
             .format(CONNECTOR_IDENTIFIER)
             .options(defaultWriteOptions())
             // Verifies that the value gets capitalized.
-            .option(Options.WRITE_FILES_DOCUMENT_TYPE, "jSoN")
+            .option(Options.WRITE_FILE_ROWS_DOCUMENT_TYPE, "jSoN")
             .option(Options.WRITE_COLLECTIONS, "json-unrecognized-extension")
             .mode(SaveMode.Append)
             .save();
@@ -145,13 +145,13 @@ class WriteFileRowsTest extends AbstractWriteTest {
             .write()
             .format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_FILES_DOCUMENT_TYPE, "not valid")
+            .option(Options.WRITE_FILE_ROWS_DOCUMENT_TYPE, "not valid")
             .mode(SaveMode.Append);
 
         SparkException ex = assertThrows(SparkException.class, () -> writer.save());
         assertTrue(ex.getCause() instanceof ConnectorException);
         ConnectorException ce = (ConnectorException) ex.getCause();
-        assertEquals("Invalid value for option spark.marklogic.write.files.documentType: not valid; " +
+        assertEquals("Invalid value for option " + Options.WRITE_FILE_ROWS_DOCUMENT_TYPE + ": not valid; " +
             "must be one of 'JSON', 'XML', or 'TEXT'.", ce.getMessage());
     }
 

--- a/src/test/java/com/marklogic/spark/writer/file/WriteDocumentZipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteDocumentZipFilesTest.java
@@ -1,7 +1,6 @@
 package com.marklogic.spark.writer.file;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.spark.AbstractIntegrationTest;
@@ -24,7 +23,7 @@ import java.util.zip.ZipFile;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class WriteZipFilesTest extends AbstractIntegrationTest {
+class WriteDocumentZipFilesTest extends AbstractIntegrationTest {
 
     @Test
     void defaultPartitionCount(@TempDir Path tempDir) throws Exception {
@@ -99,7 +98,9 @@ class WriteZipFilesTest extends AbstractIntegrationTest {
 
     private void verifyZipFilesHaveExpectedFilenames(Path tempDir) {
         // Expecting the same prefix that's used by MLCP.
-        final String expectedPrefix = new SimpleDateFormat("yyyyMMddHHmmssZ").format(new Date());
+        // Not verifying minutes/seconds as there's a reasonable chance that those can differ slightly between the
+        // files being written and then being verified.
+        final String expectedPrefix = new SimpleDateFormat("yyyyMMddHH").format(new Date());
         for (File file : tempDir.toFile().listFiles()) {
             String name = file.getName();
             assertTrue(name.startsWith(expectedPrefix), String.format("Filename %s did not start with %s", name, expectedPrefix));


### PR DESCRIPTION
Did a little renaming for consistency.

Added what should be very helpful logging in `ForestReader` for how much and how fast each forest is read.

Added example to CONTRIBUTING for common test case of querying for documents.