### PR TITLE
Fixed design in reading documents

### DIFF
--- a/src/main/java/com/marklogic/spark/DefaultSource.java
+++ b/src/main/java/com/marklogic/spark/DefaultSource.java
@@ -119,6 +119,7 @@ public class DefaultSource implements TableProvider, DataSourceRegister {
 
     private boolean isReadDocumentsOperation(Map<String, String> properties) {
         return properties.containsKey(Options.READ_DOCUMENTS_QUERY) ||
+            properties.containsKey(Options.READ_DOCUMENTS_STRING_QUERY) ||
             properties.containsKey(Options.READ_DOCUMENTS_COLLECTIONS) ||
             properties.containsKey(Options.READ_DOCUMENTS_DIRECTORY) ||
             properties.containsKey(Options.READ_DOCUMENTS_OPTIONS);

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -44,8 +44,10 @@ public abstract class Options {
     // "categories" as defined by https://docs.marklogic.com/REST/GET/v1/documents .
     public static final String READ_DOCUMENTS_CATEGORIES = "spark.marklogic.read.documents.categories";
     public static final String READ_DOCUMENTS_COLLECTIONS = "spark.marklogic.read.documents.collections";
+    // Corresponds to "q" at https://docs.marklogic.com/REST/POST/v1/search, known as a "string query".
+    public static final String READ_DOCUMENTS_STRING_QUERY = "spark.marklogic.read.documents.stringQuery";
+    // Corresponds to the complex query submitted via the request body at https://docs.marklogic.com/REST/POST/v1/search .
     public static final String READ_DOCUMENTS_QUERY = "spark.marklogic.read.documents.query";
-    public static final String READ_DOCUMENTS_QUERY_TYPE = "spark.marklogic.read.documents.queryType";
     public static final String READ_DOCUMENTS_OPTIONS = "spark.marklogic.read.documents.options";
     public static final String READ_DOCUMENTS_DIRECTORY = "spark.marklogic.read.documents.directory";
     public static final String READ_DOCUMENTS_TRANSFORM = "spark.marklogic.read.documents.transform";

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
@@ -49,8 +49,8 @@ class DocumentContext extends ContextSupport {
     SearchQueryDefinition buildSearchQuery(DatabaseClient client) {
         final Map<String, String> props = getProperties();
         return new SearchQueryBuilder()
+            .withStringQuery(props.get(Options.READ_DOCUMENTS_STRING_QUERY))
             .withQuery(props.get(Options.READ_DOCUMENTS_QUERY))
-            .withQueryType(props.get(Options.READ_DOCUMENTS_QUERY_TYPE))
             .withCollections(props.get(Options.READ_DOCUMENTS_COLLECTIONS))
             .withDirectory(props.get(Options.READ_DOCUMENTS_DIRECTORY))
             .withOptionsName(props.get(Options.READ_DOCUMENTS_OPTIONS))


### PR DESCRIPTION
Realized a couple things:

1. User needs to be able to specify both a "string query" and a "complex query".
2. The query type doesn't matter, even though the Java Client seems to suggest that it does. 