### PR TITLE
MLE-12218 User can now configure partitions per forest

### DIFF
--- a/src/main/java/com/marklogic/spark/ContextSupport.java
+++ b/src/main/java/com/marklogic/spark/ContextSupport.java
@@ -113,11 +113,11 @@ public class ContextSupport implements Serializable {
                 Long.parseLong(this.getProperties().get(optionName)) :
                 defaultValue;
             if (value < minimumValue) {
-                throw new IllegalArgumentException(String.format("Value of '%s' option must be %d or greater", optionName, minimumValue));
+                throw new ConnectorException(String.format("Value of '%s' option must be %d or greater.", optionName, minimumValue));
             }
             return value;
         } catch (NumberFormatException ex) {
-            throw new IllegalArgumentException(String.format("Value of '%s' option must be numeric", optionName), ex);
+            throw new ConnectorException(String.format("Value of '%s' option must be numeric.", optionName), ex);
         }
     }
 

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -48,11 +48,13 @@ public abstract class Options {
     public static final String READ_DOCUMENTS_STRING_QUERY = "spark.marklogic.read.documents.stringQuery";
     // Corresponds to the complex query submitted via the request body at https://docs.marklogic.com/REST/POST/v1/search .
     public static final String READ_DOCUMENTS_QUERY = "spark.marklogic.read.documents.query";
+    public static final String READ_DOCUMENTS_QUERY_FORMAT = "spark.marklogic.read.documents.queryFormat";
     public static final String READ_DOCUMENTS_OPTIONS = "spark.marklogic.read.documents.options";
     public static final String READ_DOCUMENTS_DIRECTORY = "spark.marklogic.read.documents.directory";
     public static final String READ_DOCUMENTS_TRANSFORM = "spark.marklogic.read.documents.transform";
     public static final String READ_DOCUMENTS_TRANSFORM_PARAMS = "spark.marklogic.read.documents.transformParams";
     public static final String READ_DOCUMENTS_TRANSFORM_PARAMS_DELIMITER = "spark.marklogic.read.documents.transformParamsDelimiter";
+    public static final String READ_DOCUMENTS_PARTITIONS_PER_FOREST = "spark.marklogic.read.documents.partitionsPerForest";
 
     public static final String READ_FILES_COMPRESSION = "spark.marklogic.read.files.compression";
 

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentBatch.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentBatch.java
@@ -2,12 +2,19 @@ package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.datamovement.Forest;
+import com.marklogic.client.io.SearchHandle;
+import com.marklogic.client.query.QueryManager;
+import com.marklogic.client.query.SearchQueryDefinition;
 import org.apache.spark.sql.connector.read.Batch;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class DocumentBatch implements Batch {
+
+    private static final Logger logger = LoggerFactory.getLogger(DocumentBatch.class);
 
     private DocumentContext context;
 
@@ -25,9 +32,25 @@ class DocumentBatch implements Batch {
     public InputPartition[] planInputPartitions() {
         DatabaseClient client = this.context.connectToMarkLogic();
         Forest[] forests = client.newDataMovementManager().readForestConfig().listForests();
-        InputPartition[] partitions = new InputPartition[forests.length];
-        for (int i = 0; i < forests.length; i++) {
-            partitions[i] = new ForestPartition(forests[i].getForestName());
+
+        SearchQueryDefinition query = this.context.buildSearchQuery(client);
+        // Must null this out so SearchHandle still works below.
+        query.setResponseTransform(null);
+
+        QueryManager queryManager = client.newQueryManager();
+        queryManager.setPageLength(1);
+
+        SearchHandle handle = queryManager.search(query, new SearchHandle());
+        final long estimate = handle.getTotalResults();
+        final long serverTimestamp = handle.getServerTimestamp();
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Creating forest partitions; query estimate: {}; server timestamp: {}", estimate, serverTimestamp);
+        }
+        ForestPartitionPlanner planner = new ForestPartitionPlanner(context.getPartitionsPerForest());
+        ForestPartition[] partitions = planner.makePartitions(estimate, serverTimestamp, forests);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Created {} forest partitions", partitions.length);
         }
         return partitions;
     }

--- a/src/main/java/com/marklogic/spark/reader/document/ForestPartition.java
+++ b/src/main/java/com/marklogic/spark/reader/document/ForestPartition.java
@@ -6,13 +6,36 @@ class ForestPartition implements InputPartition {
 
     static final long serialVersionUID = 1;
 
-    private String forestName;
+    private final String forestName;
+    private final long serverTimestamp;
+    private final Long offsetStart;
+    private final Long offsetEnd;
 
-    ForestPartition(String forestName) {
+    ForestPartition(String forestName, long serverTimestamp, Long offsetStart, Long offsetEnd) {
         this.forestName = forestName;
+        this.serverTimestamp = serverTimestamp;
+        this.offsetStart = offsetStart;
+        this.offsetEnd = offsetEnd;
     }
 
-    public String getForestName() {
+    String getForestName() {
         return forestName;
+    }
+
+    long getServerTimestamp() {
+        return serverTimestamp;
+    }
+
+    Long getOffsetStart() {
+        return offsetStart;
+    }
+
+    Long getOffsetEnd() {
+        return offsetEnd;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("[%s; %d; %d]", forestName, offsetStart, offsetEnd);
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/document/ForestPartitionPlanner.java
+++ b/src/main/java/com/marklogic/spark/reader/document/ForestPartitionPlanner.java
@@ -1,0 +1,37 @@
+package com.marklogic.spark.reader.document;
+
+import com.marklogic.client.datamovement.Forest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class ForestPartitionPlanner {
+
+    private final int partitionsPerForest;
+
+    ForestPartitionPlanner(int partitionsPerForest) {
+        this.partitionsPerForest = partitionsPerForest;
+    }
+
+    ForestPartition[] makePartitions(long estimate, long serverTimestamp, Forest... forests) {
+        final long urisPerForest = (long) (Math.ceil((double) estimate / forests.length));
+        final long urisPerPartition = (long) (Math.ceil((double) urisPerForest / partitionsPerForest));
+
+        List<ForestPartition> partitions = new ArrayList<>();
+        for (int i = 0; i < forests.length; i++) {
+            Forest forest = forests[i];
+            long offset = 1;
+            for (int j = 0; j < partitionsPerForest; j++) {
+                // If the offset for this forest exceeds the estimate across all forests, then the user has asked for
+                // too many partitions. Any subsequent partition will not return any results, so we stop creating partitions.
+                if (offset > estimate) {
+                    break;
+                }
+                Long offsetEnd = j < (partitionsPerForest - 1) ? (urisPerPartition + offset - 1) : null;
+                partitions.add(new ForestPartition(forest.getForestName(), serverTimestamp, offset, offsetEnd));
+                offset += urisPerPartition;
+            }
+        }
+        return partitions.toArray(new ForestPartition[]{});
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/document/SearchQueryBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/document/SearchQueryBuilder.java
@@ -2,6 +2,7 @@ package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.document.ServerTransform;
+import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.*;
 
@@ -13,6 +14,7 @@ public class SearchQueryBuilder {
 
     private String stringQuery;
     private String query;
+    private Format queryFormat;
     private String[] collections;
     private String directory;
     private String optionsName;
@@ -46,6 +48,13 @@ public class SearchQueryBuilder {
      */
     public SearchQueryBuilder withQuery(String query) {
         this.query = query;
+        return this;
+    }
+
+    public SearchQueryBuilder withQueryFormat(String format) {
+        if (format != null) {
+            this.queryFormat = Format.valueOf(format.toUpperCase());
+        }
         return this;
     }
 
@@ -86,7 +95,11 @@ public class SearchQueryBuilder {
         // The Java Client misleadingly suggests a distinction amongst the 3 complex queries - structured,
         // serialized CTS, and combined - but the REST API does not.
         if (query != null) {
-            RawStructuredQueryDefinition queryDefinition = queryManager.newRawStructuredQueryDefinition(new StringHandle(query));
+            StringHandle queryHandle = new StringHandle(query);
+            if (queryFormat != null) {
+                queryHandle.withFormat(queryFormat);
+            }
+            RawStructuredQueryDefinition queryDefinition = queryManager.newRawStructuredQueryDefinition(queryHandle);
             if (stringQuery != null && stringQuery.length() > 0) {
                 queryDefinition.withCriteria(stringQuery);
             }

--- a/src/test/java/com/marklogic/spark/reader/document/MakeForestPartitionsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/MakeForestPartitionsTest.java
@@ -1,0 +1,76 @@
+package com.marklogic.spark.reader.document;
+
+import com.marklogic.client.datamovement.Forest;
+import com.marklogic.client.datamovement.impl.ForestImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MakeForestPartitionsTest {
+
+    private final long FAKE_SERVER_TIMESTAMP = 100;
+
+    ForestPartition[] partitions;
+
+    @Test
+    void twoForests() {
+        partitions = new ForestPartitionPlanner(3).makePartitions(300000, FAKE_SERVER_TIMESTAMP,
+            forest("f1"), forest("f2"));
+        assertEquals(6, partitions.length);
+
+        verifyPartition(0, "f1", 1, 50000);
+        verifyPartition(1, "f1", 50001, 100000);
+        verifyPartition(2, "f1", 100001, null);
+        verifyPartition(3, "f2", 1, 50000);
+        verifyPartition(4, "f2", 50001, 100000);
+        verifyPartition(5, "f2", 100001, null);
+    }
+
+    @Test
+    void threeForests() {
+        partitions = new ForestPartitionPlanner(3).makePartitions(300000, FAKE_SERVER_TIMESTAMP,
+            forest("f1"), forest("f2"), forest("f3"));
+        assertEquals(9, partitions.length);
+
+        verifyPartition(0, "f1", 1, 33334);
+        verifyPartition(1, "f1", 33335, 66668);
+        verifyPartition(2, "f1", 66669, null);
+        verifyPartition(3, "f2", 1, 33334);
+        verifyPartition(4, "f2", 33335, 66668);
+        verifyPartition(5, "f2", 66669, null);
+        verifyPartition(6, "f3", 1, 33334);
+        verifyPartition(7, "f3", 33335, 66668);
+        verifyPartition(8, "f3", 66669, null);
+    }
+
+    @Test
+    void onePartition() {
+        partitions = new ForestPartitionPlanner(1).makePartitions(300000, FAKE_SERVER_TIMESTAMP,
+            forest("f1"), forest("f2"), forest("f3"));
+        assertEquals(3, partitions.length);
+
+        verifyPartition(0, "f1", 1, null);
+        verifyPartition(1, "f2", 1, null);
+        verifyPartition(2, "f3", 1, null);
+    }
+
+    @Test
+    void farTooManyPartitions() {
+        partitions = new ForestPartitionPlanner(200).makePartitions(100, FAKE_SERVER_TIMESTAMP, forest("f1"), forest("f2"));
+        assertEquals(200, partitions.length, "If the user asks for more partitions than there are results, the " +
+            "planner is expected to create at most N partitions per forest, where N is 100 since that's the estimate " +
+            "of all matching results.");
+    }
+
+    private Forest forest(String name) {
+        return new ForestImpl(null, null, null, null, null, name, null, false, false);
+    }
+
+    private void verifyPartition(int partitionIndex, String forestName, int offsetStart, Integer offsetEnd) {
+        ForestPartition partition = partitions[partitionIndex];
+        assertEquals(forestName, partition.getForestName());
+        assertEquals(FAKE_SERVER_TIMESTAMP, partition.getServerTimestamp());
+        assertEquals(new Long(offsetStart), partition.getOffsetStart());
+        assertEquals(offsetEnd == null ? null : new Long(offsetEnd), partition.getOffsetEnd());
+    }
+}

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
@@ -52,7 +52,7 @@ class ReadDocumentRowsTest extends AbstractIntegrationTest {
             .load();
 
         ConnectorException ex = assertThrowsConnectorException(() -> dataset.count());
-        assertEquals("Invalid value for option spark.marklogic.read.batchSize: abc; must be numeric.", ex.getMessage());
+        assertEquals("Value of 'spark.marklogic.read.batchSize' option must be numeric.", ex.getMessage());
     }
 
     @Test
@@ -136,6 +136,7 @@ class ReadDocumentRowsTest extends AbstractIntegrationTest {
         String query = "{ \"query\": { \"queries\": [{ \"term-query\": { \"text\": [ \"Moria\" ] } }] } }";
         List<Row> rows = startRead()
             .option(Options.READ_DOCUMENTS_QUERY, query)
+            .option(Options.READ_DOCUMENTS_QUERY_FORMAT, "jsON")
             .load()
             .collectAsList();
 
@@ -163,6 +164,7 @@ class ReadDocumentRowsTest extends AbstractIntegrationTest {
 
         List<Row> rows = startRead()
             .option(Options.READ_DOCUMENTS_QUERY, query)
+            .option(Options.READ_DOCUMENTS_QUERY_FORMAT, "JSON")
             .load()
             .collectAsList();
 
@@ -195,6 +197,7 @@ class ReadDocumentRowsTest extends AbstractIntegrationTest {
 
         List<Row> rows = startRead()
             .option(Options.READ_DOCUMENTS_QUERY, combinedQuery.toString())
+            .option(Options.READ_DOCUMENTS_QUERY_FORMAT, "json")
             .load()
             .collectAsList();
 

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsWithPartitionCountsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsWithPartitionCountsTest.java
@@ -1,0 +1,61 @@
+package com.marklogic.spark.reader.document;
+
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ReadDocumentRowsWithPartitionCountsTest extends AbstractIntegrationTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 3, 16})
+    void test(int partitionCount) {
+        Dataset<Row> dataset = readAuthors(partitionCount);
+        assertEquals(15, dataset.count(), "Regardless of the partition count, the 15 authors " +
+            "should be returned.");
+    }
+
+    @Test
+    void wayTooManyPartitions() {
+        Dataset<Row> dataset = readAuthors(500);
+        assertEquals(15, dataset.count(), "Under the hood, the connector is expected to create 45 partitions, as " +
+            "there are expected to be 3 forests and there are 15 matching documents. So the most possible partitions " +
+            "for a forest would be 15, and thus 45 is the max. Regardless, this is expected to work and still return " +
+            "only the 15 matching author documents - it'll just be a little slower with so many partitions.");
+    }
+
+    @Test
+    void zeroPartitions() {
+        Dataset<Row> dataset = readAuthors(0);
+        ConnectorException ex = assertThrows(ConnectorException.class, () -> dataset.count());
+    }
+
+    @Test
+    void invalidValue() {
+        Dataset<Row> dataset = newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_DOCUMENTS_COLLECTIONS, "author")
+            .option(Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST, "abc")
+            .load();
+
+        ConnectorException ex = assertThrows(ConnectorException.class, () -> dataset.count());
+        assertEquals("Value of 'spark.marklogic.read.documents.partitionsPerForest' option must be numeric.", ex.getMessage());
+    }
+
+    private Dataset<Row> readAuthors(int partitionsPerForest) {
+        return newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_DOCUMENTS_COLLECTIONS, "author")
+            .option(Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST, partitionsPerForest)
+            .load();
+    }
+}

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadRowsTest.java
@@ -17,6 +17,7 @@
 package com.marklogic.spark.reader.optic;
 
 import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.DataFrameReader;
 import org.apache.spark.sql.Dataset;
@@ -107,8 +108,8 @@ class ReadRowsTest extends AbstractIntegrationTest {
         Dataset<Row> reader = newDefaultReader()
             .option(Options.READ_NUM_PARTITIONS, "abc")
             .load();
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> reader.count());
-        assertEquals("Value of 'spark.marklogic.read.numPartitions' option must be numeric", ex.getMessage());
+        ConnectorException ex = assertThrows(ConnectorException.class, () -> reader.count());
+        assertEquals("Value of 'spark.marklogic.read.numPartitions' option must be numeric.", ex.getMessage());
     }
 
     @Test
@@ -117,8 +118,8 @@ class ReadRowsTest extends AbstractIntegrationTest {
             .option(Options.READ_NUM_PARTITIONS, "0")
             .load();
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> reader.count());
-        assertEquals("Value of 'spark.marklogic.read.numPartitions' option must be 1 or greater", ex.getMessage());
+        ConnectorException ex = assertThrows(ConnectorException.class, () -> reader.count());
+        assertEquals("Value of 'spark.marklogic.read.numPartitions' option must be 1 or greater.", ex.getMessage());
     }
 
     @Test
@@ -127,8 +128,8 @@ class ReadRowsTest extends AbstractIntegrationTest {
             .option(Options.READ_BATCH_SIZE, "abc")
             .load();
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> reader.count());
-        assertEquals("Value of 'spark.marklogic.read.batchSize' option must be numeric", ex.getMessage());
+        ConnectorException ex = assertThrows(ConnectorException.class, () -> reader.count());
+        assertEquals("Value of 'spark.marklogic.read.batchSize' option must be numeric.", ex.getMessage());
     }
 
     @Test
@@ -136,7 +137,7 @@ class ReadRowsTest extends AbstractIntegrationTest {
         Dataset<Row> reader = newDefaultReader()
             .option(Options.READ_BATCH_SIZE, "-1")
             .load();
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> reader.count());
-        assertEquals("Value of 'spark.marklogic.read.batchSize' option must be 0 or greater", ex.getMessage());
+        ConnectorException ex = assertThrows(ConnectorException.class, () -> reader.count());
+        assertEquals("Value of 'spark.marklogic.read.batchSize' option must be 0 or greater.", ex.getMessage());
     }
 }

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
@@ -17,8 +17,10 @@ package com.marklogic.spark.writer;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.junit5.PermissionsTester;
+import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
 import org.apache.spark.SparkException;
+import org.apache.spark.sql.DataFrameWriter;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -94,27 +96,17 @@ class WriteRowsTest extends AbstractWriteTest {
 
     @Test
     void invalidThreadCount() {
-        SparkException ex = assertThrows(
-            SparkException.class,
-            () -> newWriter().option(Options.WRITE_THREAD_COUNT, 0).save()
-        );
-
-        Throwable cause = getCauseFromWriterException(ex);
-        assertTrue(cause instanceof IllegalArgumentException, "Unexpected cause: " + cause.getClass());
-        assertEquals("Value of 'spark.marklogic.write.threadCount' option must be 1 or greater", cause.getMessage());
+        DataFrameWriter writer = newWriter().option(Options.WRITE_THREAD_COUNT, 0);
+        ConnectorException ex = assertThrowsConnectorException(() -> writer.save());
+        assertEquals("Value of 'spark.marklogic.write.threadCount' option must be 1 or greater.", ex.getMessage());
         verifyNoDocsWereWritten();
     }
 
     @Test
     void invalidBatchSize() {
-        SparkException ex = assertThrows(
-            SparkException.class,
-            () -> newWriter().option(Options.WRITE_BATCH_SIZE, 0).save()
-        );
-
-        Throwable cause = getCauseFromWriterException(ex);
-        assertTrue(cause instanceof IllegalArgumentException, "Unexpected cause: " + cause.getClass());
-        assertEquals("Value of 'spark.marklogic.write.batchSize' option must be 1 or greater", cause.getMessage(),
+        DataFrameWriter writer = newWriter().option(Options.WRITE_BATCH_SIZE, 0);
+        ConnectorException ex = assertThrowsConnectorException(() -> writer.save());
+        assertEquals("Value of 'spark.marklogic.write.batchSize' option must be 1 or greater.", ex.getMessage(),
             "Note that batchSize is very different for writing than it is for reading. For writing, it specifies the " +
                 "exact number of documents to send to MarkLogic in each call. For reading, it used to determine how " +
                 "many requests will be made by a partition, and zero is a valid value for reading.");

--- a/src/test/java/com/marklogic/spark/writer/file/WriteDocumentZipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteDocumentZipFilesTest.java
@@ -93,6 +93,7 @@ class WriteDocumentZipFilesTest extends AbstractIntegrationTest {
             .format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.READ_DOCUMENTS_COLLECTIONS, "author")
+            .option(Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST, 1)
             .load();
     }
 


### PR DESCRIPTION
The main guts here is in the new `ForestPartitionPlanner` along with changes to `UrisBatcher`. 

Interestingly, had to add "queryFormat" as a parameter in order to call `queryManager.search`, whereas `queryManager.uris` doesn't require it. 

Updated a few tests based on a slight tweak to how invalid number values are handled. 