### PR TITLE
MLE-12717 Can now convert MLCP metadata into REST metadata

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/file/MlcpMetadataConverter.java
+++ b/src/main/java/com/marklogic/spark/reader/file/MlcpMetadataConverter.java
@@ -1,0 +1,146 @@
+package com.marklogic.spark.reader.file;
+
+import com.marklogic.client.io.DocumentMetadataHandle;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.Namespace;
+import org.jdom2.input.SAXBuilder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Handles converting an MLCP metadata document, generated when creating an MLCP archive, into a
+ * {@code DocumentMetadataHandle} instance, thus allowing it to be reused with the REST API. The MLCP metadata
+ * document is expected to have a root element of "com.marklogic.contentpump.DocumentMetadata".
+ */
+class MlcpMetadataConverter {
+
+    private static final Namespace SECURITY_NAMESPACE = Namespace.getNamespace("sec", "http://marklogic.com/xdmp/security");
+    private final SAXBuilder saxBuilder;
+
+    MlcpMetadataConverter() {
+        this.saxBuilder = new SAXBuilder();
+    }
+
+    DocumentMetadataHandle convert(InputStream inputStream) throws JDOMException, IOException {
+        Document doc = this.saxBuilder.build(inputStream);
+        Element mlcpMetadata = doc.getRootElement();
+        Element properties = mlcpMetadata.getChild("properties");
+
+        DocumentMetadataHandle restMetadata = properties != null ?
+            newMetadataWithProperties(properties.getText()) :
+            new DocumentMetadataHandle();
+
+        addCollections(mlcpMetadata, restMetadata);
+        addPermissions(mlcpMetadata, restMetadata);
+        addQuality(mlcpMetadata, restMetadata);
+        addMetadataValues(mlcpMetadata, restMetadata);
+        return restMetadata;
+    }
+
+    /**
+     * This allows for the logic in DocumentMetadataHandle for parsing the properties fragment to be reused.
+     *
+     * @param propertiesXml
+     * @return
+     */
+    private DocumentMetadataHandle newMetadataWithProperties(String propertiesXml) {
+        String restXml = String.format("<rapi:metadata xmlns:rapi='http://marklogic.com/rest-api'>%s</rapi:metadata>", propertiesXml);
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        metadata.fromBuffer(restXml.getBytes());
+        return metadata;
+    }
+
+    private void addCollections(Element mlcpMetadata, DocumentMetadataHandle restMetadata) {
+        Element collections = mlcpMetadata.getChild("collectionsList");
+        if (collections != null) {
+            for (Element string : collections.getChildren("string")) {
+                restMetadata.getCollections().add(string.getText());
+            }
+        }
+    }
+
+    private void addQuality(Element mlcpMetadata, DocumentMetadataHandle restMetadata) {
+        Element quality = mlcpMetadata.getChild("quality");
+        if (quality != null) {
+            restMetadata.setQuality(Integer.parseInt(quality.getText()));
+        }
+    }
+
+    private void addMetadataValues(Element mlcpMetadata, DocumentMetadataHandle restMetadata) {
+        Element collections = mlcpMetadata.getChild("meta");
+        if (collections != null) {
+            for (Element entry : collections.getChildren("entry")) {
+                List<Element> strings = entry.getChildren("string");
+                String key = strings.get(0).getText();
+                String value = strings.get(1).getText();
+                restMetadata.getMetadataValues().put(key, value);
+            }
+        }
+    }
+
+    /**
+     * The "permissionsList" element can contain permissions that have references to other permissions, where it's
+     * not clear which permission it's referring to. For example:
+     * <p>
+     * <com.marklogic.xcc.ContentPermission>
+     * <capability reference="../../com.marklogic.xcc.ContentPermission/capability"/>
+     * <p>
+     * It this does not seem reliably to determine the capability of each permission based on each
+     * com.marklogic.xcc.ContentPermission element. But each such element does associate a roleId and a roleName
+     * together. The value of the "permString" element, which associates roleIds and capabilities, can then be used as
+     * a reliable source of permission information, with each roleId being bounced against a map of roleId -> roleName.
+     *
+     * @param mlcpMetadata
+     * @param restMetadata
+     * @throws IOException
+     * @throws JDOMException
+     */
+    private void addPermissions(Element mlcpMetadata, DocumentMetadataHandle restMetadata) throws IOException, JDOMException {
+        Element permString = mlcpMetadata.getChild("permString");
+        if (permString == null) {
+            return;
+        }
+
+        Element permissionsList = mlcpMetadata.getChild("permissionsList");
+        if (permissionsList == null) {
+            return;
+        }
+
+        Map<String, String> roleIdsToNames = buildRoleMap(permissionsList);
+
+        Element perms = this.saxBuilder.build(new StringReader(permString.getText())).getRootElement();
+        for (Element perm : perms.getChildren("permission", SECURITY_NAMESPACE)) {
+            String capability = perm.getChildText("capability", SECURITY_NAMESPACE);
+            DocumentMetadataHandle.Capability cap = DocumentMetadataHandle.Capability.valueOf(capability.toUpperCase());
+            String roleId = perm.getChildText("role-id", SECURITY_NAMESPACE);
+            String roleName = roleIdsToNames.get(roleId);
+            if (restMetadata.getPermissions().containsKey(roleName)) {
+                restMetadata.getPermissions().get(roleName).add(cap);
+            } else {
+                restMetadata.getPermissions().add(roleName, cap);
+            }
+        }
+    }
+
+    /**
+     * @param permissionsList
+     * @return a map of roleId -> roleName based on the role and role elements in each
+     * com.marklogic.xcc.ContentPermission element.
+     */
+    private Map<String, String> buildRoleMap(Element permissionsList) {
+        Map<String, String> roleIdsToNames = new HashMap<>();
+        for (Element permission : permissionsList.getChildren("com.marklogic.xcc.ContentPermission")) {
+            String role = permission.getChildText("role");
+            String roleId = permission.getChildText("roleId");
+            roleIdsToNames.put(roleId, role);
+        }
+        return roleIdsToNames;
+    }
+}

--- a/src/test/java/com/marklogic/spark/reader/file/ConvertMlcpMetadataTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ConvertMlcpMetadataTest.java
@@ -1,0 +1,41 @@
+package com.marklogic.spark.reader.file;
+
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.junit5.PermissionsTester;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+import javax.xml.namespace.QName;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConvertMlcpMetadataTest {
+
+    @Test
+    void test() throws Exception {
+        InputStream input = new ClassPathResource("mlcp-metadata/complete.xml").getInputStream();
+        DocumentMetadataHandle metadata = new MlcpMetadataConverter().convert(input);
+
+        assertEquals(2, metadata.getCollections().size());
+        assertTrue(metadata.getCollections().contains("collection1"));
+        assertTrue(metadata.getCollections().contains("collection2"));
+
+        assertEquals(10, metadata.getQuality());
+
+        assertEquals(2, metadata.getMetadataValues().size());
+        assertEquals("value1", metadata.getMetadataValues().get("meta1"));
+        assertEquals("value2", metadata.getMetadataValues().get("meta2"));
+
+        assertEquals(2, metadata.getProperties().size());
+        assertEquals("value1", metadata.getProperties().get(new QName("org:example", "key1")));
+        assertEquals("value2", metadata.getProperties().get("key2"));
+
+        assertEquals(2, metadata.getPermissions().size());
+        PermissionsTester tester = new PermissionsTester(metadata.getPermissions());
+        tester.assertReadPermissionExists("spark-user-role");
+        tester.assertUpdatePermissionExists("spark-user-role");
+        tester.assertReadPermissionExists("qconsole-user");
+    }
+}

--- a/src/test/resources/mlcp-metadata/complete.xml
+++ b/src/test/resources/mlcp-metadata/complete.xml
@@ -1,0 +1,46 @@
+<com.marklogic.contentpump.DocumentMetadata>
+  <format>
+    <name>xml</name>
+  </format>
+  <collectionsList class="vector">
+    <string>collection1</string>
+    <string>collection2</string>
+  </collectionsList>
+  <permissionsList class="vector">
+    <com.marklogic.xcc.ContentPermission>
+      <capability>
+        <name>read</name>
+        <symbol>R</symbol>
+      </capability>
+      <role>spark-user-role</role>
+      <roleId>3908672739498265499</roleId>
+    </com.marklogic.xcc.ContentPermission>
+    <com.marklogic.xcc.ContentPermission>
+      <capability reference="../../com.marklogic.xcc.ContentPermission/capability"/>
+      <role>qconsole-user</role>
+      <roleId>16675984334178111809</roleId>
+    </com.marklogic.xcc.ContentPermission>
+    <com.marklogic.xcc.ContentPermission>
+      <capability>
+        <name>update</name>
+        <symbol>U</symbol>
+      </capability>
+      <role>spark-user-role</role>
+      <roleId>3908672739498265499</roleId>
+    </com.marklogic.xcc.ContentPermission>
+  </permissionsList>
+  <permString>&lt;perms&gt;&lt;sec:permission xmlns:sec=&quot;http://marklogic.com/xdmp/security&quot;&gt;&lt;sec:capability&gt;read&lt;/sec:capability&gt;&lt;sec:role-id&gt;3908672739498265499&lt;/sec:role-id&gt;&lt;/sec:permission&gt;&lt;sec:permission xmlns:sec=&quot;http://marklogic.com/xdmp/security&quot;&gt;&lt;sec:capability&gt;read&lt;/sec:capability&gt;&lt;sec:role-id&gt;16675984334178111809&lt;/sec:role-id&gt;&lt;/sec:permission&gt;&lt;sec:permission xmlns:sec=&quot;http://marklogic.com/xdmp/security&quot;&gt;&lt;sec:capability&gt;update&lt;/sec:capability&gt;&lt;sec:role-id&gt;3908672739498265499&lt;/sec:role-id&gt;&lt;/sec:permission&gt;&lt;/perms&gt;</permString>
+  <quality>10</quality>
+  <meta>
+    <entry>
+      <string>meta2</string>
+      <string>value2</string>
+    </entry>
+    <entry>
+      <string>meta1</string>
+      <string>value1</string>
+    </entry>
+  </meta>
+  <properties>&lt;prop:properties xmlns:prop=&quot;http://marklogic.com/xdmp/property&quot;&gt;&lt;key2 xsi:type=&quot;xs:string&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;&gt;value2&lt;/key2&gt;&lt;key1 xsi:type=&quot;xs:string&quot; xmlns=&quot;org:example&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;&gt;value1&lt;/key1&gt;&lt;/prop:properties&gt;</properties>
+  <isNakedProps>false</isNakedProps>
+</com.marklogic.contentpump.DocumentMetadata>


### PR DESCRIPTION
This is intended to be used by MLE-12388 - importing an MLCP archive. The intent is that an MLCP metadata document can be converted by `MlcpMetadataConverter` into a `DocumentMetadataHandle` object, which can then be converted into the appropriate column values in our `DocumentRowSchema`.