### PR TITLE
MLE-12373 Added logging for file metrics

### DIFF
--- a/src/main/java/com/marklogic/spark/writer/CommitMessage.java
+++ b/src/main/java/com/marklogic/spark/writer/CommitMessage.java
@@ -8,48 +8,31 @@ public class CommitMessage implements WriterCommitMessage {
 
     private final int successItemCount;
     private final int failedItemCount;
-    private final int partitionId;
-    private final long taskId;
-    private final long epochId;
     private final Set<String> graphs;
 
     /**
      * @param successItemCount
      * @param failedItemCount
      * @param partitionId
-     * @param taskId
-     * @param epochId          only populated when using Spark streaming
      * @param graphs           zero or more MarkLogic Semantics graph names, each of which is associated with a
      *                         graph document in MarkLogic that must be created after all the documents have been
      *                         written.
      */
-    public CommitMessage(int successItemCount, int failedItemCount, int partitionId, long taskId, long epochId, Set<String> graphs) {
+    public CommitMessage(int successItemCount, int failedItemCount, Set<String> graphs) {
         this.successItemCount = successItemCount;
         this.failedItemCount = failedItemCount;
-        this.partitionId = partitionId;
-        this.taskId = taskId;
-        this.epochId = epochId;
         this.graphs = graphs;
     }
 
-    public int getSuccessItemCount() {
+    int getSuccessItemCount() {
         return successItemCount;
     }
 
-    public int getFailedItemCount() {
+    int getFailedItemCount() {
         return failedItemCount;
     }
 
-    public Set<String> getGraphs() {
+    Set<String> getGraphs() {
         return graphs;
-    }
-
-    @Override
-    public String toString() {
-        return epochId != 0L ?
-            String.format("[partitionId: %d; taskId: %d; epochId: %d]; docCount: %d; failedItemCount: %d",
-                partitionId, taskId, epochId, successItemCount, failedItemCount) :
-            String.format("[partitionId: %d; taskId: %d]; docCount: %d; failedItemCount: %d",
-                partitionId, taskId, successItemCount, failedItemCount);
     }
 }

--- a/src/main/java/com/marklogic/spark/writer/MarkLogicWrite.java
+++ b/src/main/java/com/marklogic/spark/writer/MarkLogicWrite.java
@@ -26,17 +26,12 @@ import org.apache.spark.sql.connector.write.PhysicalWriteInfo;
 import org.apache.spark.sql.connector.write.WriterCommitMessage;
 import org.apache.spark.sql.connector.write.streaming.StreamingDataWriterFactory;
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
 public class MarkLogicWrite implements BatchWrite, StreamingWrite {
-
-    private static final Logger logger = LoggerFactory.getLogger("com.marklogic.spark");
 
     private WriteContext writeContext;
 
@@ -91,9 +86,7 @@ public class MarkLogicWrite implements BatchWrite, StreamingWrite {
 
     @Override
     public void abort(WriterCommitMessage[] messages) {
-        if (messages != null && messages.length > 0 && messages[0] != null) {
-            Util.MAIN_LOGGER.warn("Abort messages received: {}", Arrays.asList(messages));
-        }
+        // No action. We may eventually want to show the partial progress via the commit messages.
     }
 
     @Override
@@ -103,16 +96,12 @@ public class MarkLogicWrite implements BatchWrite, StreamingWrite {
 
     @Override
     public void commit(long epochId, WriterCommitMessage[] messages) {
-        if (messages != null && messages.length > 0 && logger.isDebugEnabled()) {
-            logger.debug("Commit messages received for epochId {}: {}", epochId, Arrays.asList(messages));
-        }
+        commit(messages);
     }
 
     @Override
     public void abort(long epochId, WriterCommitMessage[] messages) {
-        if (messages != null && messages.length > 0) {
-            Util.MAIN_LOGGER.warn("Abort messages received for epochId {}: {}", epochId, Arrays.asList(messages));
-        }
+        abort(messages);
     }
 
     private Object determineWriterFactory() {
@@ -127,10 +116,6 @@ public class MarkLogicWrite implements BatchWrite, StreamingWrite {
     }
 
     private CommitResults aggregateCommitMessages(WriterCommitMessage[] messages) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Commit messages received: {}", Arrays.asList(messages));
-        }
-
         int successCount = 0;
         int failureCount = 0;
         Set<String> graphs = new HashSet<>();

--- a/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
@@ -48,9 +48,6 @@ class WriteBatcherDataWriter implements DataWriter<InternalRow> {
     private final DataMovementManager dataMovementManager;
     private final WriteBatcher writeBatcher;
     private final DocBuilder docBuilder;
-    private final int partitionId;
-    private final long taskId;
-    private final long epochId;
 
     // Used to capture the first failure that occurs during a request to MarkLogic.
     private final AtomicReference<Throwable> writeFailure;
@@ -61,11 +58,8 @@ class WriteBatcherDataWriter implements DataWriter<InternalRow> {
     private final AtomicInteger successItemCount = new AtomicInteger(0);
     private final AtomicInteger failedItemCount = new AtomicInteger(0);
 
-    WriteBatcherDataWriter(WriteContext writeContext, int partitionId, long taskId, long epochId) {
+    WriteBatcherDataWriter(WriteContext writeContext) {
         this.writeContext = writeContext;
-        this.partitionId = partitionId;
-        this.taskId = taskId;
-        this.epochId = epochId;
         this.writeFailure = new AtomicReference<>();
         this.docBuilder = this.writeContext.newDocBuilder();
         this.databaseClient = writeContext.connectToMarkLogic();
@@ -109,7 +103,7 @@ class WriteBatcherDataWriter implements DataWriter<InternalRow> {
             graphs = ((RdfRowConverter) rowConverter).getGraphs();
         }
 
-        return new CommitMessage(successItemCount.get(), failedItemCount.get(), partitionId, taskId, epochId, graphs);
+        return new CommitMessage(successItemCount.get(), failedItemCount.get(), graphs);
     }
 
     @Override

--- a/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriterFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriterFactory.java
@@ -30,11 +30,11 @@ class WriteBatcherDataWriterFactory implements DataWriterFactory, StreamingDataW
 
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
-        return new WriteBatcherDataWriter(writeContext, partitionId, taskId, 0L);
+        return new WriteBatcherDataWriter(writeContext);
     }
 
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId, long epochId) {
-        return new WriteBatcherDataWriter(writeContext, partitionId, taskId, epochId);
+        return new WriteBatcherDataWriter(writeContext);
     }
 }

--- a/src/main/java/com/marklogic/spark/writer/customcode/CustomCodeWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/customcode/CustomCodeWriter.java
@@ -38,21 +38,12 @@ class CustomCodeWriter implements DataWriter<InternalRow> {
     private final String externalVariableDelimiter;
     private ObjectMapper objectMapper;
 
-    // Only used for commit messages
-    private final int partitionId;
-    private final long taskId;
-    private final long epochId;
-
     // Updated after each call to MarkLogic.
     private int successItemCount;
     private int failedItemCount;
 
-    CustomCodeWriter(CustomCodeContext customCodeContext, int partitionId, long taskId, long epochId) {
+    CustomCodeWriter(CustomCodeContext customCodeContext) {
         this.customCodeContext = customCodeContext;
-        this.partitionId = partitionId;
-        this.taskId = taskId;
-        this.epochId = epochId;
-
         this.databaseClient = customCodeContext.connectToMarkLogic();
 
         this.batchSize = customCodeContext.optionExists(Options.WRITE_BATCH_SIZE) ?
@@ -82,7 +73,7 @@ class CustomCodeWriter implements DataWriter<InternalRow> {
     @Override
     public WriterCommitMessage commit() {
         flush();
-        CommitMessage message = new CommitMessage(successItemCount, failedItemCount, partitionId, taskId, epochId, null);
+        CommitMessage message = new CommitMessage(successItemCount, failedItemCount, null);
         if (logger.isDebugEnabled()) {
             logger.debug("Committing {}", message);
         }

--- a/src/main/java/com/marklogic/spark/writer/customcode/CustomCodeWriterFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/customcode/CustomCodeWriterFactory.java
@@ -16,11 +16,11 @@ public class CustomCodeWriterFactory implements DataWriterFactory, StreamingData
 
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
-        return new CustomCodeWriter(customCodeContext, partitionId, taskId, 0l);
+        return new CustomCodeWriter(customCodeContext);
     }
 
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId, long epochId) {
-        return new CustomCodeWriter(customCodeContext, partitionId, taskId, epochId);
+        return new CustomCodeWriter(customCodeContext);
     }
 }

--- a/src/main/java/com/marklogic/spark/writer/file/DocumentFileBatch.java
+++ b/src/main/java/com/marklogic/spark/writer/file/DocumentFileBatch.java
@@ -1,5 +1,6 @@
 package com.marklogic.spark.writer.file;
 
+import com.marklogic.spark.Util;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.write.BatchWrite;
@@ -28,7 +29,31 @@ class DocumentFileBatch implements BatchWrite {
 
     @Override
     public void commit(WriterCommitMessage[] messages) {
-        // No messages expected yet.
+        if (Util.MAIN_LOGGER.isInfoEnabled() && messages != null && messages.length > 0) {
+            int fileCount = 0;
+            int zipFileCount = 0;
+            int zipEntryCount = 0;
+            String path = null;
+            for (WriterCommitMessage message : messages) {
+                if (message instanceof FileCommitMessage) {
+                    path = ((FileCommitMessage)message).getPath();
+                    fileCount += ((FileCommitMessage) message).getFileCount();
+                } else if (message instanceof ZipCommitMessage) {
+                    path = ((ZipCommitMessage)message).getPath();
+                    zipFileCount++;
+                    zipEntryCount += ((ZipCommitMessage) message).getZipEntryCount();
+                }
+            }
+            if (fileCount == 1) {
+                Util.MAIN_LOGGER.info("Wrote 1 file to {}.", path);
+            } else if (fileCount > 1) {
+                Util.MAIN_LOGGER.info("Wrote {} files to {}.", fileCount, path);
+            } else if (zipFileCount == 1) {
+                Util.MAIN_LOGGER.info("Wrote 1 zip file containing {} entries to {}.", zipEntryCount, path);
+            } else if (zipFileCount > 1) {
+                Util.MAIN_LOGGER.info("Wrote {} zip files containing a total of {} entries to {}.", zipFileCount, zipEntryCount, path);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriter.java
@@ -21,25 +21,28 @@ class DocumentFileWriter implements DataWriter<InternalRow> {
 
     private static final Logger logger = LoggerFactory.getLogger(DocumentFileWriter.class);
 
-    private final Map<String, String> properties;
     private final SerializableConfiguration hadoopConfiguration;
     private final ContentWriter contentWriter;
 
+    private final String path;
+    private int fileCounter;
+
     DocumentFileWriter(Map<String, String> properties, SerializableConfiguration hadoopConfiguration) {
-        this.properties = properties;
+        this.path = properties.get("path");
         this.hadoopConfiguration = hadoopConfiguration;
         this.contentWriter = new ContentWriter(properties);
     }
 
     @Override
     public void write(InternalRow row) throws IOException {
-        final Path path = makePath(row);
+        final Path filePath = makeFilePath(row);
         if (logger.isTraceEnabled()) {
-            logger.trace("Will write to: {}", path);
+            logger.trace("Will write to: {}", filePath);
         }
-        OutputStream outputStream = makeOutputStream(path);
+        OutputStream outputStream = makeOutputStream(filePath);
         try {
             this.contentWriter.writeContent(row, outputStream);
+            fileCounter++;
         } finally {
             IOUtils.closeQuietly(outputStream);
         }
@@ -47,7 +50,7 @@ class DocumentFileWriter implements DataWriter<InternalRow> {
 
     @Override
     public WriterCommitMessage commit() {
-        return null;
+        return new FileCommitMessage(this.path, fileCounter);
     }
 
     @Override
@@ -60,11 +63,10 @@ class DocumentFileWriter implements DataWriter<InternalRow> {
         // Nothing to close.
     }
 
-    private Path makePath(InternalRow row) {
-        String dir = properties.get("path");
+    private Path makeFilePath(InternalRow row) {
         final String uri = row.getString(0);
-        String path = makeFilePath(uri);
-        return path.charAt(0) == '/' ? new Path(dir + path) : new Path(dir, path);
+        String filePath = makeFilePath(uri);
+        return filePath.charAt(0) == '/' ? new Path(this.path + filePath) : new Path(this.path, filePath);
     }
 
     // Protected so it can be overridden by subclass.

--- a/src/main/java/com/marklogic/spark/writer/file/FileCommitMessage.java
+++ b/src/main/java/com/marklogic/spark/writer/file/FileCommitMessage.java
@@ -1,0 +1,22 @@
+package com.marklogic.spark.writer.file;
+
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+
+class FileCommitMessage implements WriterCommitMessage {
+
+    private final String path;
+    private final int fileCount;
+
+    FileCommitMessage(String path, int fileCount) {
+        this.path = path;
+        this.fileCount = fileCount;
+    }
+
+    String getPath() {
+        return path;
+    }
+
+    int getFileCount() {
+        return fileCount;
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/file/ZipCommitMessage.java
+++ b/src/main/java/com/marklogic/spark/writer/file/ZipCommitMessage.java
@@ -1,0 +1,22 @@
+package com.marklogic.spark.writer.file;
+
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+
+class ZipCommitMessage implements WriterCommitMessage {
+
+    private final String path;
+    private final int zipEntryCount;
+
+    ZipCommitMessage(String path, int zipEntryCount) {
+        this.path = path;
+        this.zipEntryCount = zipEntryCount;
+    }
+
+    String getPath() {
+        return path;
+    }
+
+    int getZipEntryCount() {
+        return zipEntryCount;
+    }
+}


### PR DESCRIPTION
I revamped our commit messages, as I realized now that we log useful summary metrics, there's little to no value in debug logging of the messages themselves:

- Removed partitionId / taskId / epochId from the messages (these were being logged at the debug level, but I don't see any value in that).
- Added new commit message objects for files and zips.
