### PR TITLE
MLE-12523 Refactor: Adding FileContext

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/file/AbstractRdfFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/AbstractRdfFileReader.java
@@ -1,17 +1,13 @@
 package com.marklogic.spark.reader.file;
 
-import com.marklogic.spark.Options;
 import org.apache.commons.io.IOUtils;
-import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.PartitionReader;
-import org.apache.spark.util.SerializableConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -34,10 +30,7 @@ abstract class AbstractRdfFileReader implements PartitionReader<InternalRow> {
         IOUtils.closeQuietly(this.inputStream);
     }
 
-    protected final InputStream openStream(Path path, SerializableConfiguration hadoopConfiguration, Map<String, String> properties) throws IOException {
-        final boolean isGzipped = "gzip".equalsIgnoreCase(properties.get(Options.READ_FILES_COMPRESSION));
-        return isGzipped ?
-            new GZIPInputStream(path.getFileSystem(hadoopConfiguration.value()).open(path)) :
-            path.getFileSystem(hadoopConfiguration.value()).open(path);
+    protected final InputStream openStream(FilePartition filePartition, FileContext fileContext) throws IOException {
+        return fileContext.isGzip() ? new GZIPInputStream(fileContext.open(filePartition)) : fileContext.open(filePartition);
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/file/FileBatch.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FileBatch.java
@@ -36,6 +36,7 @@ class FileBatch implements Batch {
         // This config is needed to resolve file paths. This is our last chance to access it and provide a serialized
         // version to the factory, which must be serializable itself.
         Configuration config = SparkSession.active().sparkContext().hadoopConfiguration();
-        return new FilePartitionReaderFactory(properties, new SerializableConfiguration(config));
+        FileContext fileContext = new FileContext(properties, new SerializableConfiguration(config));
+        return new FilePartitionReaderFactory(fileContext);
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/file/FileContext.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FileContext.java
@@ -1,0 +1,41 @@
+package com.marklogic.spark.reader.file;
+
+import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.ContextSupport;
+import com.marklogic.spark.Options;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.util.SerializableConfiguration;
+
+import java.io.Serializable;
+import java.util.Map;
+
+class FileContext extends ContextSupport implements Serializable {
+
+    private SerializableConfiguration hadoopConfiguration;
+
+    FileContext(Map<String, String> properties, SerializableConfiguration hadoopConfiguration) {
+        super(properties);
+        this.hadoopConfiguration = hadoopConfiguration;
+    }
+
+    boolean isZip() {
+        return "zip".equalsIgnoreCase(getStringOption(Options.READ_FILES_COMPRESSION));
+    }
+
+    boolean isGzip() {
+        return "gzip".equalsIgnoreCase(getStringOption(Options.READ_FILES_COMPRESSION));
+    }
+
+    FSDataInputStream open(FilePartition filePartition) {
+        try {
+            Path hadoopPath = new Path(filePartition.getPath());
+            FileSystem fileSystem = hadoopPath.getFileSystem(hadoopConfiguration.value());
+            return fileSystem.open(hadoopPath);
+        } catch (Exception e) {
+            throw new ConnectorException(String.format(
+                "Unable to read file at %s; cause: %s", filePartition, e.getMessage()), e);
+        }
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/file/FilePartition.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FilePartition.java
@@ -15,4 +15,9 @@ class FilePartition implements InputPartition {
     String getPath() {
         return path;
     }
+
+    @Override
+    public String toString() {
+        return path;
+    }
 }

--- a/src/main/java/com/marklogic/spark/reader/file/GZIPAggregateXMLFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/GZIPAggregateXMLFileReader.java
@@ -1,11 +1,9 @@
 package com.marklogic.spark.reader.file;
 
-import org.apache.hadoop.fs.Path;
-import org.apache.spark.util.SerializableConfiguration;
+import com.marklogic.spark.ConnectorException;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -14,12 +12,18 @@ import java.util.zip.GZIPInputStream;
  */
 class GZIPAggregateXMLFileReader extends AggregateXMLFileReader {
 
-    GZIPAggregateXMLFileReader(FilePartition partition, Map<String, String> properties, SerializableConfiguration hadoopConfiguration) {
-        super(partition, properties, hadoopConfiguration);
+    GZIPAggregateXMLFileReader(FilePartition filePartition, FileContext fileContext) {
+        super(filePartition, fileContext);
     }
 
     @Override
-    protected InputStream makeInputStream(Path path, SerializableConfiguration hadoopConfiguration) throws IOException {
-        return new GZIPInputStream(path.getFileSystem(hadoopConfiguration.value()).open(path));
+    protected InputStream makeInputStream(FilePartition filePartition, FileContext fileContext) {
+        InputStream inputStream = fileContext.open(filePartition);
+        try {
+            return new GZIPInputStream(inputStream);
+        } catch (IOException ex) {
+            throw new ConnectorException(String.format(
+                "Unable to read file at %s; cause: %s", filePartition.getPath(), ex.getMessage()));
+        }
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
@@ -1,14 +1,11 @@
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.unsafe.types.ByteArray;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.apache.spark.util.SerializableConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,22 +14,16 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 class MlcpArchiveFileReader implements PartitionReader<InternalRow> {
+
+    private static final Logger logger = LoggerFactory.getLogger(MlcpArchiveFileReader.class);
+
     private final String path;
     private final ZipInputStream zipInputStream;
     private ZipEntry currentZipEntry;
-    private static final Logger logger = LoggerFactory.getLogger(MlcpArchiveFileReader.class);
-    public MlcpArchiveFileReader(FilePartition filePartition, SerializableConfiguration hadoopConfiguration) {
+
+    MlcpArchiveFileReader(FilePartition filePartition, FileContext fileContext) {
         this.path = filePartition.getPath();
-        try {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Reading zip file {}", this.path);
-            }
-            Path hadoopPath = new Path(this.path);
-            FileSystem fileSystem = hadoopPath.getFileSystem(hadoopConfiguration.value());
-            this.zipInputStream = new ZipInputStream(fileSystem.open(hadoopPath));
-        } catch (IOException e) {
-            throw new ConnectorException(String.format("Unable to read zip file at %s; cause: %s", this.path, e.getMessage()), e);
-        }
+        this.zipInputStream = new ZipInputStream(fileContext.open(filePartition));
     }
 
     @Override

--- a/src/main/java/com/marklogic/spark/reader/file/QuadsFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/QuadsFileReader.java
@@ -1,26 +1,22 @@
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;
-import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.PartitionReader;
-import org.apache.spark.util.SerializableConfiguration;
 
 import java.io.IOException;
-import java.util.Map;
 
 class QuadsFileReader extends AbstractRdfFileReader implements PartitionReader<InternalRow> {
 
     private final QuadStreamReader quadStreamReader;
 
-    QuadsFileReader(FilePartition partition, SerializableConfiguration hadoopConfiguration, Map<String, String> properties) {
+    QuadsFileReader(FilePartition partition, FileContext fileContext) {
         super(partition);
-        final Path path = new Path(partition.getPath());
         try {
-            this.inputStream = openStream(path, hadoopConfiguration, properties);
+            this.inputStream = openStream(partition, fileContext);
             this.quadStreamReader = new QuadStreamReader(partition.getPath(), inputStream);
         } catch (Exception e) {
-            throw new ConnectorException(String.format("Unable to read RDF file at %s; cause: %s", path, e.getMessage()), e);
+            throw new ConnectorException(String.format("Unable to read file at %s; cause: %s", partition.getPath(), e.getMessage()), e);
         }
     }
 

--- a/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
@@ -1,12 +1,8 @@
 package com.marklogic.spark.reader.file;
 
-import com.marklogic.spark.ConnectorException;
 import org.apache.commons.io.IOUtils;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.PartitionReader;
-import org.apache.spark.util.SerializableConfiguration;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,18 +21,12 @@ class RdfZipFileReader implements PartitionReader<InternalRow> {
 
     private RdfStreamReader rdfStreamReader;
 
-    RdfZipFileReader(FilePartition partition, SerializableConfiguration hadoopConfiguration) {
+    RdfZipFileReader(FilePartition partition, FileContext fileContext) {
         this.path = partition.getPath();
         if (logger.isTraceEnabled()) {
             logger.trace("Reading path: {}", this.path);
         }
-        try {
-            Path hadoopPath = new Path(partition.getPath());
-            FileSystem fileSystem = hadoopPath.getFileSystem(hadoopConfiguration.value());
-            this.customZipInputStream = new CustomZipInputStream(fileSystem.open(hadoopPath));
-        } catch (Exception e) {
-            throw new ConnectorException(String.format("Unable to read %s; cause: %s", this.path, e.getMessage()), e);
-        }
+        this.customZipInputStream = new CustomZipInputStream(fileContext.open(partition));
     }
 
     @Override

--- a/src/main/java/com/marklogic/spark/reader/file/TriplesFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/TriplesFileReader.java
@@ -1,26 +1,22 @@
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;
-import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.PartitionReader;
-import org.apache.spark.util.SerializableConfiguration;
 
 import java.io.IOException;
-import java.util.Map;
 
 class TriplesFileReader extends AbstractRdfFileReader implements PartitionReader<InternalRow> {
 
     private final TripleStreamReader tripleStreamReader;
 
-    TriplesFileReader(FilePartition partition, SerializableConfiguration hadoopConfiguration, Map<String, String> properties) {
+    TriplesFileReader(FilePartition partition, FileContext fileContext) {
         super(partition);
-        final Path path = new Path(partition.getPath());
         try {
-            this.inputStream = openStream(path, hadoopConfiguration, properties);
+            this.inputStream = openStream(partition, fileContext);
             this.tripleStreamReader = new TripleStreamReader(partition.getPath(), this.inputStream);
         } catch (Exception e) {
-            throw new ConnectorException(String.format("Unable to read RDF file at %s; cause: %s", path, e.getMessage()), e);
+            throw new ConnectorException(String.format("Unable to read RDF file at %s; cause: %s", partition.getPath(), e.getMessage()), e);
         }
     }
 

--- a/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
@@ -1,14 +1,11 @@
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.unsafe.types.ByteArray;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.apache.spark.util.SerializableConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,18 +22,9 @@ class ZipFileReader implements PartitionReader<InternalRow> {
     private final ZipInputStream zipInputStream;
     private ZipEntry currentZipEntry;
 
-    ZipFileReader(FilePartition partition, SerializableConfiguration hadoopConfiguration) {
+    ZipFileReader(FilePartition partition, FileContext fileContext) {
         this.path = partition.getPath();
-        try {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Reading zip file {}", this.path);
-            }
-            Path hadoopPath = new Path(this.path);
-            FileSystem fileSystem = hadoopPath.getFileSystem(hadoopConfiguration.value());
-            this.zipInputStream = new ZipInputStream(fileSystem.open(hadoopPath));
-        } catch (IOException e) {
-            throw new ConnectorException(String.format("Unable to read zip file at %s; cause: %s", this.path, e.getMessage()), e);
-        }
+        this.zipInputStream = new ZipInputStream(fileContext.open(partition));
     }
 
     @Override

--- a/src/test/java/com/marklogic/spark/reader/file/ReadGZIPAggregateXMLFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadGZIPAggregateXMLFilesTest.java
@@ -42,7 +42,7 @@ class ReadGZIPAggregateXMLFilesTest extends AbstractIntegrationTest {
 
         ConnectorException ex = assertThrowsConnectorException(() -> dataset.count());
         String message = ex.getMessage();
-        assertTrue(message.startsWith("Unable to open file:///"), "Unexpected error: " + message);
+        assertTrue(message.startsWith("Unable to read file at file:///"), "Unexpected error: " + message);
         assertTrue(message.endsWith("cause: Not in GZIP format"), "Unexpected error: " + message);
     }
 


### PR DESCRIPTION
No functional change here. Adding `FileContext` for the following reasons:

1. Can carry out the map of properties and the SerializableConfiguration class.
2. Can have convenience methods for parsing options.
3. Can have a very useful `open` method that is used by every file reader. 
4. Will add `isReadAbortOnFailure()` to it in the next PR. 