### PR TITLE
Refactor: Standardize on lower-camel-case for acronyms

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/file/AggregateXmlFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/AggregateXmlFileReader.java
@@ -8,16 +8,16 @@ import org.apache.spark.sql.connector.read.PartitionReader;
 
 import java.io.InputStream;
 
-class AggregateXMLFileReader implements PartitionReader<InternalRow> {
+class AggregateXmlFileReader implements PartitionReader<InternalRow> {
 
     private final FilePartition filePartition;
     private final FileContext fileContext;
 
     private InputStream inputStream;
-    private AggregateXMLSplitter aggregateXMLSplitter;
+    private AggregateXmlSplitter aggregateXMLSplitter;
     private InternalRow nextRowToReturn;
 
-    AggregateXMLFileReader(FilePartition filePartition, FileContext fileContext) {
+    AggregateXmlFileReader(FilePartition filePartition, FileContext fileContext) {
         this.filePartition = filePartition;
         this.fileContext = fileContext;
     }
@@ -69,7 +69,7 @@ class AggregateXMLFileReader implements PartitionReader<InternalRow> {
         try {
             this.inputStream = fileContext.open(filePartition);
             String identifierForError = "file " + filePartition.getPath();
-            this.aggregateXMLSplitter = new AggregateXMLSplitter(identifierForError, this.inputStream, fileContext.getProperties());
+            this.aggregateXMLSplitter = new AggregateXmlSplitter(identifierForError, this.inputStream, fileContext.getProperties());
             return true;
         } catch (ConnectorException ex) {
             if (fileContext.isReadAbortOnFailure()) {

--- a/src/main/java/com/marklogic/spark/reader/file/AggregateXmlSplitter.java
+++ b/src/main/java/com/marklogic/spark/reader/file/AggregateXmlSplitter.java
@@ -21,7 +21,7 @@ import java.util.Map;
  * Knows how to split an aggregate XML document and return a row for each user-defined child element. Each row has
  * a schema matching that of {@code FileRowSchema}.
  */
-class AggregateXMLSplitter {
+class AggregateXmlSplitter {
 
     private final Iterator<StringHandle> contentStream;
     private final String identifierForErrors;
@@ -38,7 +38,7 @@ class AggregateXMLSplitter {
      * @param inputStream         the stream of aggregate XML data
      * @param properties          connector properties
      */
-    AggregateXMLSplitter(String identifierForErrors, InputStream inputStream, Map<String, String> properties) {
+    AggregateXmlSplitter(String identifierForErrors, InputStream inputStream, Map<String, String> properties) {
         this.identifierForErrors = identifierForErrors;
         this.uriElement = properties.get(Options.READ_AGGREGATES_XML_URI_ELEMENT);
         this.uriNamespace = properties.get(Options.READ_AGGREGATES_XML_URI_NAMESPACE);

--- a/src/main/java/com/marklogic/spark/reader/file/FilePartitionReaderFactory.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FilePartitionReaderFactory.java
@@ -28,12 +28,12 @@ class FilePartitionReaderFactory implements PartitionReaderFactory {
             return new MlcpArchiveFileReader(filePartition, fileContext);
         } else if (fileContext.hasOption(Options.READ_AGGREGATES_XML_ELEMENT)) {
             return fileContext.isZip() ?
-                new ZipAggregateXMLFileReader(filePartition, fileContext) :
-                new AggregateXMLFileReader(filePartition, fileContext);
+                new ZipAggregateXmlFileReader(filePartition, fileContext) :
+                new AggregateXmlFileReader(filePartition, fileContext);
         } else if (fileContext.isZip()) {
             return new ZipFileReader(filePartition, fileContext);
         } else if (fileContext.isGzip()) {
-            return new GZIPFileReader(filePartition, fileContext);
+            return new GzipFileReader(filePartition, fileContext);
         }
 
         throw new ConnectorException(String.format("File is not supported: %s", filePartition.getPath()));

--- a/src/main/java/com/marklogic/spark/reader/file/GzipFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/GzipFileReader.java
@@ -16,14 +16,14 @@ import java.io.InputStream;
  * Expects to read a single gzipped file and return a single row. May expand the scope of this later to expect multiple
  * files and to thus return multiple rows.
  */
-class GZIPFileReader implements PartitionReader<InternalRow> {
+class GzipFileReader implements PartitionReader<InternalRow> {
 
     private final FilePartition filePartition;
     private final FileContext fileContext;
 
     private InternalRow rowToReturn = null;
 
-    GZIPFileReader(FilePartition partition, FileContext fileContext) {
+    GzipFileReader(FilePartition partition, FileContext fileContext) {
         this.filePartition = partition;
         this.fileContext = fileContext;
     }

--- a/src/main/java/com/marklogic/spark/reader/file/ZipAggregateXmlFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/ZipAggregateXmlFileReader.java
@@ -12,22 +12,22 @@ import java.io.IOException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-class ZipAggregateXMLFileReader implements PartitionReader<InternalRow> {
+class ZipAggregateXmlFileReader implements PartitionReader<InternalRow> {
 
-    private static final Logger logger = LoggerFactory.getLogger(ZipAggregateXMLFileReader.class);
+    private static final Logger logger = LoggerFactory.getLogger(ZipAggregateXmlFileReader.class);
 
     private final FileContext fileContext;
     private final ZipInputStream zipInputStream;
     private final String path;
 
-    private AggregateXMLSplitter aggregateXMLSplitter;
+    private AggregateXmlSplitter aggregateXMLSplitter;
 
     // Used solely for a default URI prefix.
     private int entryCounter;
 
     private InternalRow rowToReturn;
 
-    ZipAggregateXMLFileReader(FilePartition filePartition, FileContext fileContext) {
+    ZipAggregateXmlFileReader(FilePartition filePartition, FileContext fileContext) {
         this.fileContext = fileContext;
         this.path = filePartition.getPath();
         this.zipInputStream = new ZipInputStream(fileContext.open(filePartition));
@@ -102,7 +102,7 @@ class ZipAggregateXMLFileReader implements PartitionReader<InternalRow> {
             String identifierForError = "entry " + zipEntry.getName() + " in " + this.path;
 
             try {
-                aggregateXMLSplitter = new AggregateXMLSplitter(identifierForError, this.zipInputStream, this.fileContext.getProperties());
+                aggregateXMLSplitter = new AggregateXmlSplitter(identifierForError, this.zipInputStream, this.fileContext.getProperties());
                 // Fail fast if the next entry is not valid XML.
                 aggregateXMLSplitter.hasNext();
                 return true;

--- a/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriterFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriterFactory.java
@@ -27,7 +27,7 @@ class DocumentFileWriterFactory implements DataWriterFactory {
             if ("zip".equalsIgnoreCase(compression)) {
                 return new ZipFileWriter(properties, hadoopConfiguration, partitionId);
             }
-            return new GZIPFileWriter(properties, hadoopConfiguration);
+            return new GzipFileWriter(properties, hadoopConfiguration);
         }
         return new DocumentFileWriter(properties, hadoopConfiguration);
     }

--- a/src/main/java/com/marklogic/spark/writer/file/GzipFileWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/file/GzipFileWriter.java
@@ -8,9 +8,9 @@ import java.io.OutputStream;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
-class GZIPFileWriter extends DocumentFileWriter {
+class GzipFileWriter extends DocumentFileWriter {
 
-    GZIPFileWriter(Map<String, String> properties, SerializableConfiguration hadoopConfiguration) {
+    GzipFileWriter(Map<String, String> properties, SerializableConfiguration hadoopConfiguration) {
         super(properties, hadoopConfiguration);
     }
 

--- a/src/test/java/com/marklogic/spark/reader/file/ReadAggregateXmlFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadAggregateXmlFilesTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class ReadAggregateXMLFilesTest extends AbstractIntegrationTest {
+class ReadAggregateXmlFilesTest extends AbstractIntegrationTest {
 
     @Test
     void noNamespace() {

--- a/src/test/java/com/marklogic/spark/reader/file/ReadAggregateXmlZipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadAggregateXmlZipFilesTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class ReadAggregateXMLZipFilesTest extends AbstractIntegrationTest {
+class ReadAggregateXmlZipFilesTest extends AbstractIntegrationTest {
 
     @Test
     void zipWithTwoAggregateXMLFiles() {

--- a/src/test/java/com/marklogic/spark/reader/file/ReadGzipAggregateXmlFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadGzipAggregateXmlFilesTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class ReadGZIPAggregateXMLFilesTest extends AbstractIntegrationTest {
+class ReadGzipAggregateXmlFilesTest extends AbstractIntegrationTest {
 
     @Test
     void noNamespace() {

--- a/src/test/java/com/marklogic/spark/reader/file/ReadGzipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadGzipFilesTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class ReadGZIPFilesTest extends AbstractIntegrationTest {
+class ReadGzipFilesTest extends AbstractIntegrationTest {
 
     @Test
     void readThreeGZIPFiles() {

--- a/src/test/java/com/marklogic/spark/writer/file/WriteDocumentGzipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteDocumentGzipFilesTest.java
@@ -15,7 +15,7 @@ import java.nio.file.Path;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class WriteDocumentGZIPFilesTest extends AbstractIntegrationTest {
+class WriteDocumentGzipFilesTest extends AbstractIntegrationTest {
 
     @Test
     void test(@TempDir Path tempDir) {


### PR DESCRIPTION
We were mostly doing lower-camel-case, but not everywhere. No functional changes here, just renames. 