### PR TITLE
MLE-12813 Can now set a root JSON name

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,6 +191,7 @@ The following options control how the connector writes rows as documents to Mark
 | spark.marklogic.write.collections | Comma-delimited string of collection names to add to each document. |
 | spark.marklogic.write.permissions | Comma-delimited string of role names and capabilities to add to each document - e.g. role1,read,role2,update,role3,execute . |
 | spark.marklogic.write.fileRows.documentType | Forces a document type when MarkLogic does not recognize a URI extension; must be one of `JSON`, `XML`, or `TEXT`. |
+| spark.marklogic.write.jsonRootName | As of 2.3.0, specifies a root field name when writing JSON documents based on arbitrary rows. |
 | spark.marklogic.write.temporalCollection | Name of a temporal collection to assign each document to. |
 | spark.marklogic.write.threadCount | The number of threads used within each partition to send documents to MarkLogic; defaults to 4. |
 | spark.marklogic.write.transform | Name of a REST transform to apply to each document. |

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -104,6 +104,27 @@ the parameter values contains a comma:
     .option("spark.marklogic.write.transformParams", "my-param;has,commas")
     .option("spark.marklogic.write.transformParamsDelimiter", ";")
 
+### Setting a JSON root name
+
+As of 2.3.0, when writing JSON documents based on arbitrary rows, you can specify a root field name to be inserted 
+at the top level of the document. Each column value will then be included in an object assigned to that root field name.
+This can be useful when you want your JSON data to be more self-documenting. For example, a document representing an 
+employee may be easier to understand if it has a single root field named "Employee" with every property of the employee
+captured in an object assigned to the "Employee" field.
+
+The following will produce JSON documents that each have a single root field named "myRootField", with all column
+values in a row assigned to an object associated with "myRootField":
+
+```
+df.write.format("marklogic") \
+  .option("spark.marklogic.client.uri", "spark-example-user:password@localhost:8003") \
+  .option("spark.marklogic.write.permissions", "rest-reader,read,rest-writer,update") \
+  .option("spark.marklogic.write.uriPrefix", "/write/") \
+  .option("spark.marklogic.write.jsonRootName", "myRootField") \
+  .mode("append") \
+  .save()
+```
+
 ### Controlling document URIs
 
 By default, the connector will construct a URI for each document beginning with a UUID and ending with `.json`. A 
@@ -134,6 +155,14 @@ The following template would construct URIs based on those two columns:
 
 Both columns should have values in each row in the DataFrame. If the connector encounters a row that does not have a 
 value for any column in the URI template, an error will be thrown.
+
+As of the 2.3.0 release, you can also use a [JSONPointer](https://www.rfc-editor.org/rfc/rfc6901) expression to 
+reference a value. This is often useful in conjunction with the `spark.marklogic.write.jsonRootName` option. For 
+example, if `spark.marklogic.write.jsonRootName` is set to "Employee", and you wish to include the `employee_id`
+value in a URI, you would use the following configuration:
+
+    .option("spark.marklogic.write.uriTemplate", "/example/{organization}/{/Employee/employee_id}.json")
+
 
 If you are writing file rows that conform to 
 [Spark's binaryFile schema](https://spark.apache.org/docs/latest/sql-data-sources-binaryFile.html), the `path`, 

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -89,6 +89,7 @@ public abstract class Options {
     // For writing documents to MarkLogic.
     public static final String WRITE_COLLECTIONS = "spark.marklogic.write.collections";
     public static final String WRITE_PERMISSIONS = "spark.marklogic.write.permissions";
+    public static final String WRITE_JSON_ROOT_NAME = "spark.marklogic.write.jsonRootName";
     public static final String WRITE_TEMPORAL_COLLECTION = "spark.marklogic.write.temporalCollection";
     public static final String WRITE_URI_PREFIX = "spark.marklogic.write.uriPrefix";
     public static final String WRITE_URI_REPLACE = "spark.marklogic.write.uriReplace";

--- a/src/main/java/com/marklogic/spark/writer/ArbitraryRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/ArbitraryRowConverter.java
@@ -4,12 +4,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.io.Format;
+import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
 import com.marklogic.spark.Util;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.json.JacksonGenerator;
+import org.apache.spark.sql.types.StructType;
 
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -24,25 +27,31 @@ class ArbitraryRowConverter implements RowConverter {
 
     private static ObjectMapper objectMapper = new ObjectMapper();
 
-    private WriteContext writeContext;
+    private final StructType schema;
+    private final String uriTemplate;
+    private final String jsonRootName;
 
     ArbitraryRowConverter(WriteContext writeContext) {
-        this.writeContext = writeContext;
+        this.schema = writeContext.getSchema();
+        this.uriTemplate = writeContext.getStringOption(Options.WRITE_URI_TEMPLATE);
+        this.jsonRootName = writeContext.getStringOption(Options.WRITE_JSON_ROOT_NAME);
     }
 
     @Override
     public Optional<DocBuilder.DocumentInputs> convertRow(InternalRow row) {
-        String json = convertRowToJSONString(row);
-        StringHandle content = new StringHandle(json).withFormat(Format.JSON);
+        final String json = convertRowToJSONString(row);
+        AbstractWriteHandle contentHandle = new StringHandle(json).withFormat(Format.JSON);
         ObjectNode columnValues = null;
-        if (writeContext.hasOption(Options.WRITE_URI_TEMPLATE)) {
-            try {
-                columnValues = (ObjectNode) objectMapper.readTree(json);
-            } catch (JsonProcessingException e) {
-                throw new ConnectorException(String.format("Unable to read JSON row: %s", e.getMessage()), e);
+        if (this.uriTemplate != null || this.jsonRootName != null) {
+            columnValues = readTree(json);
+            if (this.jsonRootName != null) {
+                ObjectNode root = objectMapper.createObjectNode();
+                root.set(jsonRootName, columnValues);
+                contentHandle = new JacksonHandle(root);
+                columnValues = root;
             }
         }
-        return Optional.of(new DocBuilder.DocumentInputs(null, content, columnValues, null));
+        return Optional.of(new DocBuilder.DocumentInputs(null, contentHandle, columnValues, null));
     }
 
     @Override
@@ -50,15 +59,21 @@ class ArbitraryRowConverter implements RowConverter {
         return new ArrayList<>();
     }
 
+    private ObjectNode readTree(String json) {
+        // We don't ever expect this to fail, as the JSON is produced by Spark's JacksonGenerator and should always
+        // be valid JSON. But Jackson throws a checked exception, so gotta handle it.
+        try {
+            return (ObjectNode) objectMapper.readTree(json);
+        } catch (JsonProcessingException e) {
+            throw new ConnectorException(String.format("Unable to read JSON row: %s", e.getMessage()), e);
+        }
+    }
+
     private String convertRowToJSONString(InternalRow row) {
-        StringWriter jsonObjectWriter = new StringWriter();
-        JacksonGenerator jacksonGenerator = new JacksonGenerator(
-            this.writeContext.getSchema(),
-            jsonObjectWriter,
-            Util.DEFAULT_JSON_OPTIONS
-        );
+        StringWriter writer = new StringWriter();
+        JacksonGenerator jacksonGenerator = new JacksonGenerator(this.schema, writer, Util.DEFAULT_JSON_OPTIONS);
         jacksonGenerator.write(row);
         jacksonGenerator.flush();
-        return jsonObjectWriter.toString();
+        return writer.toString();
     }
 }

--- a/src/test/java/com/marklogic/spark/writer/WriteFileRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteFileRowsTest.java
@@ -89,8 +89,6 @@ class WriteFileRowsTest extends AbstractWriteTest {
 
     @Test
     void uriTemplate() {
-        File f = new File("src/test/resources/mixed-files/hello.json");
-
         Dataset<Row> dataset = newSparkSession()
             .read()
             .format("binaryFile")

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsWithJsonRootNameTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsWithJsonRootNameTest.java
@@ -1,0 +1,48 @@
+package com.marklogic.spark.writer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.spark.Options;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WriteRowsWithJsonRootNameTest extends AbstractWriteTest {
+
+    @Test
+    void test() {
+        newWriter()
+            .option(Options.WRITE_JSON_ROOT_NAME, "myRootName")
+            .option(Options.WRITE_URI_TEMPLATE, "/myRootNameTest/{/myRootName/docNum}.json")
+            .save();
+
+        // Verify a few of the docs to ensure the rootName was used correctly.
+        for (int i = 1; i <= 3; i++) {
+            String uri = String.format("/myRootNameTest/%d.json", i);
+            JsonNode doc = readJsonDocument(uri, COLLECTION);
+            assertTrue(doc.has("myRootName"));
+            assertEquals(i, doc.get("myRootName").get("docNum").asInt());
+            assertEquals("doc" + i, doc.get("myRootName").get("docName").asText());
+        }
+    }
+
+    /**
+     * Per https://restfulapi.net/valid-json-key-names/ , it appears that any valid, escaped string works as a
+     * field name. So this verifies that a potentially bad field name is escaped correctly. Implementation-wise, we
+     * expect that to be handled automatically by the Jackson library.
+     */
+    @Test
+    void rootNameThatNeedsEscaping() {
+        final String weirdRootName = "{is-'this\"-valid?{";
+        newWriter()
+            .option(Options.WRITE_JSON_ROOT_NAME, weirdRootName)
+            .save();
+
+        // Verify one document to ensure the weird root name is valid.
+        String uri = getUrisInCollection(COLLECTION, 200).get(0);
+        JsonNode doc = readJsonDocument(uri);
+        assertTrue(doc.has(weirdRootName));
+        assertTrue(doc.get(weirdRootName).has("docNum"));
+        assertTrue(doc.get(weirdRootName).has("docName"));
+    }
+}

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsWithUriTemplateTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsWithUriTemplateTest.java
@@ -72,12 +72,12 @@ class WriteRowsWithUriTemplateTest extends AbstractWriteTest {
 
         Throwable cause = getCauseFromWriterException(ex);
         assertTrue(cause instanceof RuntimeException, "Unexpected cause: " + cause);
-        final String expectedMessage = "Did not find column 'doesntExist' in row: " +
+        final String expectedMessage = "Expression 'doesntExist' did not resolve to a value in row: " +
             "{\"id\":\"1\",\"content\":\"hello world\"," +
             "\"systemStart\":\"2014-04-03T11:00:00\",\"systemEnd\":\"2014-04-03T16:00:00\"," +
             "\"validStart\":\"2014-04-03T11:00:00\",\"validEnd\":\"2014-04-03T16:00:00\"," +
             "\"columnWithOnlyWhitespace\":\"   \"}; " +
-            "column is required by URI template: /test/{id}/{doesntExist}.json";
+            "expression is required by URI template: /test/{id}/{doesntExist}.json";
 
         assertEquals(expectedMessage, cause.getMessage(), "The entire JSON row is being included in the error " +
             "message so that the user is able to figure out what a column they chose in the URI template isn't " +


### PR DESCRIPTION
I stumbled into an enhancement while writing the test - uriTemplate expressions now support JSONPointer, which is indicated by an expression starting with "/". That allowed my test to work.