### PR TITLE
MLE-12390 Refactoring in preparation for real PR

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/document/DocumentRowSchema.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentRowSchema.java
@@ -2,12 +2,17 @@ package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.io.DocumentMetadataHandle;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
 
 import javax.xml.namespace.QName;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
 
 public abstract class DocumentRowSchema {
 
@@ -44,6 +49,61 @@ public abstract class DocumentRowSchema {
         addPropertiesToMetadata(row, metadata);
         addMetadataValuesToMetadata(row, metadata);
         return metadata;
+    }
+
+    public static void populateCollectionsColumn(Object[] row, DocumentMetadataHandle metadata) {
+        UTF8String[] collections = new UTF8String[metadata.getCollections().size()];
+        Iterator<String> iterator = metadata.getCollections().iterator();
+        for (int i = 0; i < collections.length; i++) {
+            collections[i] = UTF8String.fromString(iterator.next());
+        }
+        row[3] = ArrayData.toArrayData(collections);
+    }
+
+    public static void populatePermissionsColumn(Object[] row, DocumentMetadataHandle metadata) {
+        DocumentMetadataHandle.DocumentPermissions perms = metadata.getPermissions();
+        UTF8String[] roles = new UTF8String[perms.size()];
+        Object[] capabilityArrays = new Object[perms.size()];
+        int i = 0;
+        for (Map.Entry<String, Set<DocumentMetadataHandle.Capability>> entry : perms.entrySet()) {
+            roles[i] = UTF8String.fromString(entry.getKey());
+            UTF8String[] capabilities = new UTF8String[entry.getValue().size()];
+            int j = 0;
+            Iterator<DocumentMetadataHandle.Capability> iterator = entry.getValue().iterator();
+            while (iterator.hasNext()) {
+                capabilities[j++] = UTF8String.fromString(iterator.next().name());
+            }
+            capabilityArrays[i++] = ArrayData.toArrayData(capabilities);
+        }
+        row[4] = ArrayBasedMapData.apply(roles, capabilityArrays);
+    }
+
+    public static void populateQualityColumn(Object[] row, DocumentMetadataHandle metadata) {
+        row[5] = metadata.getQuality();
+    }
+
+    public static void populatePropertiesColumn(Object[] row, DocumentMetadataHandle metadata) {
+        DocumentMetadataHandle.DocumentProperties props = metadata.getProperties();
+        UTF8String[] keys = new UTF8String[props.size()];
+        UTF8String[] values = new UTF8String[props.size()];
+        int index = 0;
+        for (QName key : props.keySet()) {
+            keys[index] = UTF8String.fromString(key.toString());
+            values[index++] = UTF8String.fromString(props.get(key, String.class));
+        }
+        row[6] = ArrayBasedMapData.apply(keys, values);
+    }
+
+    public static void populateMetadataValuesColumn(Object[] row, DocumentMetadataHandle metadata) {
+        DocumentMetadataHandle.DocumentMetadataValues metadataValues = metadata.getMetadataValues();
+        UTF8String[] keys = new UTF8String[metadataValues.size()];
+        UTF8String[] values = new UTF8String[metadataValues.size()];
+        int index = 0;
+        for (Map.Entry<String, String> entry : metadataValues.entrySet()) {
+            keys[index] = UTF8String.fromString(entry.getKey());
+            values[index++] = UTF8String.fromString(entry.getValue());
+        }
+        row[7] = ArrayBasedMapData.apply(keys, values);
     }
 
     private static void addCollectionsToMetadata(InternalRow row, DocumentMetadataHandle metadata) {

--- a/src/main/java/com/marklogic/spark/reader/document/ForestReader.java
+++ b/src/main/java/com/marklogic/spark/reader/document/ForestReader.java
@@ -14,18 +14,13 @@ import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
-import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
-import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.unsafe.types.ByteArray;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.namespace.QName;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -130,6 +125,11 @@ class ForestReader implements PartitionReader<InternalRow> {
         return new GenericInternalRow(row);
     }
 
+    @Override
+    public void close() {
+        closeCurrentDocumentPage();
+    }
+    
     private List<String> getNextBatchOfUris() {
         long start = System.currentTimeMillis();
         List<String> uris = uriBatcher.nextBatchOfUris();
@@ -159,80 +159,24 @@ class ForestReader implements PartitionReader<InternalRow> {
 
     private void populateMetadataColumns(Object[] row, DocumentMetadataHandle metadata) {
         if (requestedMetadataHas(DocumentManager.Metadata.COLLECTIONS)) {
-            populateCollectionsColumn(row, metadata);
+            DocumentRowSchema.populateCollectionsColumn(row, metadata);
         }
         if (requestedMetadataHas(DocumentManager.Metadata.PERMISSIONS)) {
-            populatePermissionsColumn(row, metadata);
+            DocumentRowSchema.populatePermissionsColumn(row, metadata);
         }
         if (requestedMetadataHas(DocumentManager.Metadata.QUALITY)) {
-            row[5] = metadata.getQuality();
+            DocumentRowSchema.populateQualityColumn(row, metadata);
         }
         if (requestedMetadataHas(DocumentManager.Metadata.PROPERTIES)) {
-            populatePropertiesColumn(row, metadata);
+            DocumentRowSchema.populatePropertiesColumn(row, metadata);
         }
         if (requestedMetadataHas(DocumentManager.Metadata.METADATAVALUES)) {
-            populateMetadataValuesColumn(row, metadata);
+            DocumentRowSchema.populateMetadataValuesColumn(row, metadata);
         }
-    }
-
-    private void populateCollectionsColumn(Object[] row, DocumentMetadataHandle metadata) {
-        UTF8String[] collections = new UTF8String[metadata.getCollections().size()];
-        Iterator<String> iterator = metadata.getCollections().iterator();
-        for (int i = 0; i < collections.length; i++) {
-            collections[i] = UTF8String.fromString(iterator.next());
-        }
-        row[3] = ArrayData.toArrayData(collections);
-    }
-
-    private void populatePermissionsColumn(Object[] row, DocumentMetadataHandle metadata) {
-        DocumentMetadataHandle.DocumentPermissions perms = metadata.getPermissions();
-        UTF8String[] roles = new UTF8String[perms.size()];
-        Object[] capabilityArrays = new Object[perms.size()];
-        int i = 0;
-        for (Map.Entry<String, Set<DocumentMetadataHandle.Capability>> entry : perms.entrySet()) {
-            roles[i] = UTF8String.fromString(entry.getKey());
-            UTF8String[] capabilities = new UTF8String[entry.getValue().size()];
-            int j = 0;
-            Iterator<DocumentMetadataHandle.Capability> iterator = entry.getValue().iterator();
-            while (iterator.hasNext()) {
-                capabilities[j++] = UTF8String.fromString(iterator.next().name());
-            }
-            capabilityArrays[i++] = ArrayData.toArrayData(capabilities);
-        }
-        row[4] = ArrayBasedMapData.apply(roles, capabilityArrays);
-    }
-
-    private void populatePropertiesColumn(Object[] row, DocumentMetadataHandle metadata) {
-        DocumentMetadataHandle.DocumentProperties props = metadata.getProperties();
-        UTF8String[] keys = new UTF8String[props.size()];
-        UTF8String[] values = new UTF8String[props.size()];
-        int index = 0;
-        for (QName key : props.keySet()) {
-            keys[index] = UTF8String.fromString(key.toString());
-            values[index++] = UTF8String.fromString(props.get(key, String.class));
-        }
-        row[6] = ArrayBasedMapData.apply(keys, values);
-    }
-
-    private void populateMetadataValuesColumn(Object[] row, DocumentMetadataHandle metadata) {
-        DocumentMetadataHandle.DocumentMetadataValues metadataValues = metadata.getMetadataValues();
-        UTF8String[] keys = new UTF8String[metadataValues.size()];
-        UTF8String[] values = new UTF8String[metadataValues.size()];
-        int index = 0;
-        for (Map.Entry<String, String> entry : metadataValues.entrySet()) {
-            keys[index] = UTF8String.fromString(entry.getKey());
-            values[index++] = UTF8String.fromString(entry.getValue());
-        }
-        row[7] = ArrayBasedMapData.apply(keys, values);
     }
 
     private boolean requestedMetadataHas(DocumentManager.Metadata metadata) {
         return requestedMetadata.contains(metadata) || requestedMetadata.contains(DocumentManager.Metadata.ALL);
-    }
-
-    @Override
-    public void close() {
-        closeCurrentDocumentPage();
     }
 
     private void closeCurrentDocumentPage() {

--- a/src/main/java/com/marklogic/spark/reader/file/MlcpMetadata.java
+++ b/src/main/java/com/marklogic/spark/reader/file/MlcpMetadata.java
@@ -1,0 +1,26 @@
+package com.marklogic.spark.reader.file;
+
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.Format;
+
+/**
+ * Captures all the metadata, including document format, from an XML metadata entry in an MLCP archive file.
+ */
+class MlcpMetadata {
+
+    private DocumentMetadataHandle metadata;
+    private Format format;
+
+    MlcpMetadata(DocumentMetadataHandle metadata, Format format) {
+        this.metadata = metadata;
+        this.format = format;
+    }
+
+    DocumentMetadataHandle getMetadata() {
+        return metadata;
+    }
+
+    Format getFormat() {
+        return format;
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/file/MlcpMetadataConverter.java
+++ b/src/main/java/com/marklogic/spark/reader/file/MlcpMetadataConverter.java
@@ -1,6 +1,7 @@
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.Format;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -28,7 +29,7 @@ class MlcpMetadataConverter {
         this.saxBuilder = new SAXBuilder();
     }
 
-    DocumentMetadataHandle convert(InputStream inputStream) throws JDOMException, IOException {
+    MlcpMetadata convert(InputStream inputStream) throws JDOMException, IOException {
         Document doc = this.saxBuilder.build(inputStream);
         Element mlcpMetadata = doc.getRootElement();
         Element properties = mlcpMetadata.getChild("properties");
@@ -41,7 +42,14 @@ class MlcpMetadataConverter {
         addPermissions(mlcpMetadata, restMetadata);
         addQuality(mlcpMetadata, restMetadata);
         addMetadataValues(mlcpMetadata, restMetadata);
-        return restMetadata;
+
+        Format javaFormat = null;
+        Element format = mlcpMetadata.getChild("format");
+        if (format != null && format.getChild("name") != null) {
+            javaFormat = Format.valueOf(format.getChildText("name").toUpperCase());
+        }
+
+        return new MlcpMetadata(restMetadata, javaFormat);
     }
 
     /**

--- a/src/test/java/com/marklogic/spark/reader/file/ConvertMlcpMetadataTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ConvertMlcpMetadataTest.java
@@ -1,6 +1,7 @@
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.Format;
 import com.marklogic.junit5.PermissionsTester;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ClassPathResource;
@@ -16,7 +17,10 @@ class ConvertMlcpMetadataTest {
     @Test
     void test() throws Exception {
         InputStream input = new ClassPathResource("mlcp-metadata/complete.xml").getInputStream();
-        DocumentMetadataHandle metadata = new MlcpMetadataConverter().convert(input);
+        MlcpMetadata mlcpMetadata = new MlcpMetadataConverter().convert(input);
+        assertEquals(Format.XML, mlcpMetadata.getFormat());
+
+        DocumentMetadataHandle metadata = mlcpMetadata.getMetadata();
 
         assertEquals(2, metadata.getCollections().size());
         assertTrue(metadata.getCollections().contains("collection1"));


### PR DESCRIPTION
This does 2 things:

1. Moves a bunch of logic into DocumentRowSchema so it can be reused by MlcpArchiveFileReader.
2. Enhances MlcpMetadataConverter to handle the MLCP format value. (Technically not a refactor, but it's a tiny change). 