### PR TITLE
MLE-12850 Refactor of code for builing document rows

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/document/DocumentRowBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentRowBuilder.java
@@ -1,0 +1,168 @@
+package com.marklogic.spark.reader.document;
+
+import com.marklogic.client.document.DocumentManager;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
+import org.apache.spark.sql.catalyst.util.ArrayData;
+import org.apache.spark.unsafe.types.ByteArray;
+import org.apache.spark.unsafe.types.UTF8String;
+
+import javax.xml.namespace.QName;
+import java.util.*;
+
+/**
+ * Knows how to build a Spark row conforming to our {@code DocumentRowSchema}.
+ * <p>
+ * This has to support two different ways of specifying which metadata to include. {@code ForestReader} needs to
+ * capture the requested metadata in one way, while other approaches can just capture the metadata categories as a
+ * simple list of strings.
+ */
+public class DocumentRowBuilder {
+
+    private final List<String> metadataCategories;
+    private final Set<DocumentManager.Metadata> requestedMetadata;
+
+    private String uri;
+    private byte[] content;
+    private String format;
+    private DocumentMetadataHandle metadata;
+
+    public DocumentRowBuilder(List<String> metadataCategories) {
+        this.metadataCategories = metadataCategories != null ? metadataCategories : new ArrayList<>();
+        this.requestedMetadata = null;
+    }
+
+    public DocumentRowBuilder(Set<DocumentManager.Metadata> requestedMetadata) {
+        this.requestedMetadata = requestedMetadata;
+        this.metadataCategories = null;
+    }
+
+    public DocumentRowBuilder withUri(String uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public DocumentRowBuilder withContent(byte[] content) {
+        this.content = content;
+        return this;
+    }
+
+    public DocumentRowBuilder withFormat(String format) {
+        this.format = format;
+        return this;
+    }
+
+    public DocumentRowBuilder withMetadata(DocumentMetadataHandle metadata) {
+        this.metadata = metadata;
+        return this;
+    }
+
+    public GenericInternalRow buildRow() {
+        Object[] row = new Object[8];
+        row[0] = UTF8String.fromString(uri);
+        row[1] = ByteArray.concat(content);
+        if (format != null) {
+            row[2] = UTF8String.fromString(format);
+        }
+        if (metadata != null) {
+            if (includeCollections()) {
+                populateCollectionsColumn(row, metadata);
+            }
+            if (includePermissions()) {
+                populatePermissionsColumn(row, metadata);
+            }
+            if (includeQuality()) {
+                populateQualityColumn(row, metadata);
+            }
+            if (includeProperties()) {
+                populatePropertiesColumn(row, metadata);
+            }
+            if (includeMetadataValues()) {
+                populateMetadataValuesColumn(row, metadata);
+            }
+        }
+        return new GenericInternalRow(row);
+    }
+    
+    private boolean includeCollections() {
+        return includeMetadata("collections", DocumentManager.Metadata.COLLECTIONS);
+    }
+
+    private boolean includePermissions() {
+        return includeMetadata("permissions", DocumentManager.Metadata.PERMISSIONS);
+    }
+
+    private boolean includeQuality() {
+        return includeMetadata("quality", DocumentManager.Metadata.QUALITY);
+    }
+
+    private boolean includeProperties() {
+        return includeMetadata("properties", DocumentManager.Metadata.PROPERTIES);
+    }
+
+    private boolean includeMetadataValues() {
+        return includeMetadata("metadatavalues", DocumentManager.Metadata.METADATAVALUES);
+    }
+
+    private boolean includeMetadata(String categoryName, DocumentManager.Metadata metadataType) {
+        return metadataCategories != null ?
+            metadataCategories.contains(categoryName) || metadataCategories.isEmpty() :
+            requestedMetadata.contains(metadataType) || requestedMetadata.contains(DocumentManager.Metadata.ALL);
+    }
+
+    private void populateCollectionsColumn(Object[] row, DocumentMetadataHandle metadata) {
+        UTF8String[] collections = new UTF8String[metadata.getCollections().size()];
+        Iterator<String> iterator = metadata.getCollections().iterator();
+        for (int i = 0; i < collections.length; i++) {
+            collections[i] = UTF8String.fromString(iterator.next());
+        }
+        row[3] = ArrayData.toArrayData(collections);
+    }
+
+    private void populatePermissionsColumn(Object[] row, DocumentMetadataHandle metadata) {
+        DocumentMetadataHandle.DocumentPermissions perms = metadata.getPermissions();
+        UTF8String[] roles = new UTF8String[perms.size()];
+        Object[] capabilityArrays = new Object[perms.size()];
+        int i = 0;
+        for (Map.Entry<String, Set<DocumentMetadataHandle.Capability>> entry : perms.entrySet()) {
+            roles[i] = UTF8String.fromString(entry.getKey());
+            UTF8String[] capabilities = new UTF8String[entry.getValue().size()];
+            int j = 0;
+            Iterator<DocumentMetadataHandle.Capability> iterator = entry.getValue().iterator();
+            while (iterator.hasNext()) {
+                capabilities[j++] = UTF8String.fromString(iterator.next().name());
+            }
+            capabilityArrays[i++] = ArrayData.toArrayData(capabilities);
+        }
+        row[4] = ArrayBasedMapData.apply(roles, capabilityArrays);
+    }
+
+    private void populateQualityColumn(Object[] row, DocumentMetadataHandle metadata) {
+        row[5] = metadata.getQuality();
+    }
+
+    private void populatePropertiesColumn(Object[] row, DocumentMetadataHandle metadata) {
+        DocumentMetadataHandle.DocumentProperties props = metadata.getProperties();
+        UTF8String[] keys = new UTF8String[props.size()];
+        UTF8String[] values = new UTF8String[props.size()];
+        int index = 0;
+        for (QName key : props.keySet()) {
+            keys[index] = UTF8String.fromString(key.toString());
+            values[index++] = UTF8String.fromString(props.get(key, String.class));
+        }
+        row[6] = ArrayBasedMapData.apply(keys, values);
+    }
+
+    private void populateMetadataValuesColumn(Object[] row, DocumentMetadataHandle metadata) {
+        DocumentMetadataHandle.DocumentMetadataValues metadataValues = metadata.getMetadataValues();
+        UTF8String[] keys = new UTF8String[metadataValues.size()];
+        UTF8String[] values = new UTF8String[metadataValues.size()];
+        int index = 0;
+        for (Map.Entry<String, String> entry : metadataValues.entrySet()) {
+            keys[index] = UTF8String.fromString(entry.getKey());
+            values[index++] = UTF8String.fromString(entry.getValue());
+        }
+        row[7] = ArrayBasedMapData.apply(keys, values);
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentRowSchema.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentRowSchema.java
@@ -2,17 +2,12 @@ package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.io.DocumentMetadataHandle;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.unsafe.types.UTF8String;
 
 import javax.xml.namespace.QName;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
 
 public abstract class DocumentRowSchema {
 
@@ -49,61 +44,6 @@ public abstract class DocumentRowSchema {
         addPropertiesToMetadata(row, metadata);
         addMetadataValuesToMetadata(row, metadata);
         return metadata;
-    }
-
-    public static void populateCollectionsColumn(Object[] row, DocumentMetadataHandle metadata) {
-        UTF8String[] collections = new UTF8String[metadata.getCollections().size()];
-        Iterator<String> iterator = metadata.getCollections().iterator();
-        for (int i = 0; i < collections.length; i++) {
-            collections[i] = UTF8String.fromString(iterator.next());
-        }
-        row[3] = ArrayData.toArrayData(collections);
-    }
-
-    public static void populatePermissionsColumn(Object[] row, DocumentMetadataHandle metadata) {
-        DocumentMetadataHandle.DocumentPermissions perms = metadata.getPermissions();
-        UTF8String[] roles = new UTF8String[perms.size()];
-        Object[] capabilityArrays = new Object[perms.size()];
-        int i = 0;
-        for (Map.Entry<String, Set<DocumentMetadataHandle.Capability>> entry : perms.entrySet()) {
-            roles[i] = UTF8String.fromString(entry.getKey());
-            UTF8String[] capabilities = new UTF8String[entry.getValue().size()];
-            int j = 0;
-            Iterator<DocumentMetadataHandle.Capability> iterator = entry.getValue().iterator();
-            while (iterator.hasNext()) {
-                capabilities[j++] = UTF8String.fromString(iterator.next().name());
-            }
-            capabilityArrays[i++] = ArrayData.toArrayData(capabilities);
-        }
-        row[4] = ArrayBasedMapData.apply(roles, capabilityArrays);
-    }
-
-    public static void populateQualityColumn(Object[] row, DocumentMetadataHandle metadata) {
-        row[5] = metadata.getQuality();
-    }
-
-    public static void populatePropertiesColumn(Object[] row, DocumentMetadataHandle metadata) {
-        DocumentMetadataHandle.DocumentProperties props = metadata.getProperties();
-        UTF8String[] keys = new UTF8String[props.size()];
-        UTF8String[] values = new UTF8String[props.size()];
-        int index = 0;
-        for (QName key : props.keySet()) {
-            keys[index] = UTF8String.fromString(key.toString());
-            values[index++] = UTF8String.fromString(props.get(key, String.class));
-        }
-        row[6] = ArrayBasedMapData.apply(keys, values);
-    }
-
-    public static void populateMetadataValuesColumn(Object[] row, DocumentMetadataHandle metadata) {
-        DocumentMetadataHandle.DocumentMetadataValues metadataValues = metadata.getMetadataValues();
-        UTF8String[] keys = new UTF8String[metadataValues.size()];
-        UTF8String[] values = new UTF8String[metadataValues.size()];
-        int index = 0;
-        for (Map.Entry<String, String> entry : metadataValues.entrySet()) {
-            keys[index] = UTF8String.fromString(entry.getKey());
-            values[index++] = UTF8String.fromString(entry.getValue());
-        }
-        row[7] = ArrayBasedMapData.apply(keys, values);
     }
 
     private static void addCollectionsToMetadata(InternalRow row, DocumentMetadataHandle metadata) {

--- a/src/main/java/com/marklogic/spark/reader/file/ArchiveFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/ArchiveFileReader.java
@@ -3,12 +3,9 @@ package com.marklogic.spark.reader.file;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
-import com.marklogic.spark.reader.document.DocumentRowSchema;
+import com.marklogic.spark.reader.document.DocumentRowBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.connector.read.PartitionReader;
-import org.apache.spark.unsafe.types.ByteArray;
-import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +45,7 @@ class ArchiveFileReader implements PartitionReader<InternalRow> {
             return false;
         }
         String zipEntryName = zipEntry.getName();
-        DocumentMetadataHandle documentMetadataHandle = new DocumentMetadataHandle();
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
         if (logger.isTraceEnabled()) {
             logger.trace("Reading zip entry {} from zip file {}.", zipEntryName, this.path);
         }
@@ -61,12 +58,13 @@ class ArchiveFileReader implements PartitionReader<InternalRow> {
             if (!metadataEntry.getName().endsWith(".metadata")) {
                 throw new ConnectorException(String.format("Could not find metadata entry for entry %s", zipEntryName));
             }
-            documentMetadataHandle.fromBuffer(readZipEntry());
+            metadata.fromBuffer(readZipEntry());
         } catch (IOException e) {
             throw new ConnectorException(String.format("Unable to read zip file at %s; cause: %s", this.path, e.getMessage()), e);
         }
 
-        this.nextRowToReturn = makeRow(uri, content, documentMetadataHandle);
+        this.nextRowToReturn = new DocumentRowBuilder(this.metadataCategories)
+            .withUri(uri).withContent(content).withMetadata(metadata).buildRow();
         return true;
     }
 
@@ -87,51 +85,5 @@ class ArchiveFileReader implements PartitionReader<InternalRow> {
             throw new ConnectorException(String.format("Unable to read from zip file at %s; cause: %s",
                 this.path, e.getMessage()), e);
         }
-    }
-
-    private InternalRow makeRow(String uri, byte[] content, DocumentMetadataHandle documentMetadataHandle) {
-        Object[] row = new Object[8];
-        row[0] = UTF8String.fromString(uri);
-        row[1] = ByteArray.concat(content);
-        if (documentMetadataHandle.getFormat() != null) {
-            row[2] = UTF8String.fromString(documentMetadataHandle.getFormat().name());
-        }
-        if (this.metadataCategories.isEmpty()) {
-            populateAllMetadata(row, documentMetadataHandle);
-        } else {
-            populateMetadataCategories(row, documentMetadataHandle, metadataCategories);
-        }
-        return new GenericInternalRow(row);
-    }
-
-    private void populateAllMetadata(Object[] row, DocumentMetadataHandle documentMetadataHandle) {
-        DocumentRowSchema.populateCollectionsColumn(row, documentMetadataHandle);
-        DocumentRowSchema.populatePermissionsColumn(row, documentMetadataHandle);
-        DocumentRowSchema.populateQualityColumn(row, documentMetadataHandle);
-        DocumentRowSchema.populatePropertiesColumn(row, documentMetadataHandle);
-        DocumentRowSchema.populateMetadataValuesColumn(row, documentMetadataHandle);
-    }
-
-    private void populateMetadataCategories(Object[] row, DocumentMetadataHandle documentMetadataHandle,
-                                            List<String> metadataCategories) {
-        if (categoryIsIncluded("collections", metadataCategories)) {
-            DocumentRowSchema.populateCollectionsColumn(row, documentMetadataHandle);
-        }
-        if (categoryIsIncluded("permissions", metadataCategories)) {
-            DocumentRowSchema.populatePermissionsColumn(row, documentMetadataHandle);
-        }
-        if (categoryIsIncluded("quality", metadataCategories)) {
-            DocumentRowSchema.populateQualityColumn(row, documentMetadataHandle);
-        }
-        if (categoryIsIncluded("properties", metadataCategories)) {
-            DocumentRowSchema.populatePropertiesColumn(row, documentMetadataHandle);
-        }
-        if (categoryIsIncluded("metadatavalues", metadataCategories)) {
-            DocumentRowSchema.populateMetadataValuesColumn(row, documentMetadataHandle);
-        }
-    }
-
-    private boolean categoryIsIncluded(String category, List<String> metadataCategories) {
-        return metadataCategories.contains(category);
     }
 }

--- a/src/test/java/com/marklogic/spark/reader/file/ReadArchiveFileTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadArchiveFileTest.java
@@ -64,7 +64,7 @@ class ReadArchiveFileTest extends AbstractIntegrationTest {
         assertEquals(2, rows.size(), "Expecting 2 rows in the zip.");
         rows.forEach(row -> {
             verifyContent(row);
-            assertEquals("XML", row.get(2));
+            assertTrue(row.isNullAt(2));
             verifyCollections(row);
             verifyPermissions(row);
             assertNull(row.get(5), "Quality column should be null.");
@@ -95,7 +95,7 @@ class ReadArchiveFileTest extends AbstractIntegrationTest {
         assertEquals(2, rows.size(), "Expecting 2 rows in the zip.");
         rows.forEach(row -> {
             verifyContent(row);
-            assertEquals("XML", row.get(2));
+            assertTrue(row.isNullAt(2));
             assertNull(row.get(3), "Collections column should be null.");
             assertNull(row.get(4), "Permissions column should be null.");
             assertEquals(10, row.get(5));
@@ -126,7 +126,7 @@ class ReadArchiveFileTest extends AbstractIntegrationTest {
         assertEquals(2, rows.size(), "Expecting 2 rows in the zip.");
         rows.forEach(row -> {
             verifyContent(row);
-            assertEquals("XML", row.get(2));
+            assertTrue(row.isNullAt(2));
             verifyCollections(row);
             assertNull(row.get(4), "Permissions column should be null.");
             assertNull(row.get(5), "Quality column should be null.");
@@ -146,7 +146,8 @@ class ReadArchiveFileTest extends AbstractIntegrationTest {
             Row row = rows.get(i);
             assertTrue(row.getString(0).endsWith("/test/" + (i + 1) + ".xml"));
             verifyContent(row);
-            assertEquals("XML", row.get(2));
+            assertTrue(row.isNullAt(2), "There's no indication in an archive file as to what the format of a " +
+                "content entry is, so the 'format' column should always be null.");
             verifyCollections(row);
             verifyPermissions(row);
             assertEquals(10, row.get(5));


### PR DESCRIPTION
Started to duplicate this again for 12850 and decided to refactor via the new `DocumentRowBuilder` class. 

Also fixed one bug - the "format" column should not be XML when reading from an archive zip; we don't know what the format is because there's no indication in the zip. 

It is possible to populate "format" for MLCP archives because the MLCP metadata does contain a "format" element. 