### PR TITLE
MLE-12333 Option names in error messages can now be overridden

### DIFF
--- a/src/main/java/com/marklogic/spark/DefaultSource.java
+++ b/src/main/java/com/marklogic/spark/DefaultSource.java
@@ -129,7 +129,7 @@ public class DefaultSource implements TableProvider, DataSourceRegister {
     private StructType inferSchemaFromOpticQuery(Map<String, String> caseSensitiveOptions) {
         final String query = caseSensitiveOptions.get(Options.READ_OPTIC_QUERY);
         if (query == null || query.trim().length() < 1) {
-            throw new IllegalArgumentException(String.format("No Optic query found; must define %s", Options.READ_OPTIC_QUERY));
+            throw new ConnectorException(String.format("No Optic query found; must define %s", Options.READ_OPTIC_QUERY));
         }
         RowManager rowManager = new ContextSupport(caseSensitiveOptions).connectToMarkLogic().newRowManager();
         RawQueryDSLPlan dslPlan = rowManager.newRawQueryDSLPlan(new StringHandle(query));
@@ -138,7 +138,7 @@ public class DefaultSource implements TableProvider, DataSourceRegister {
             StringHandle columnInfoHandle = rowManager.columnInfo(dslPlan, new StringHandle());
             return SchemaInferrer.inferSchema(columnInfoHandle.get());
         } catch (Exception ex) {
-            throw new ConnectorException(String.format("Unable to run Optic DSL query %s; cause: %s", query, ex.getMessage()), ex);
+            throw new ConnectorException(String.format("Unable to run Optic query %s; cause: %s", query, ex.getMessage()), ex);
         }
     }
 

--- a/src/main/java/com/marklogic/spark/reader/customcode/CustomCodeContext.java
+++ b/src/main/java/com/marklogic/spark/reader/customcode/CustomCodeContext.java
@@ -59,6 +59,7 @@ public class CustomCodeContext extends ContextSupport {
             String content = readFileToString(properties.get(callOptions.xqueryFileOptionName));
             call.xquery(content);
         } else {
+            // The ETL tool validates this itself via a validator.
             throw new ConnectorException("Must specify one of the following options: " + Arrays.asList(
                 callOptions.invokeOptionName, callOptions.javascriptOptionName, callOptions.xqueryOptionName
             ));

--- a/src/main/java/com/marklogic/spark/reader/document/SearchQueryBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/document/SearchQueryBuilder.java
@@ -152,7 +152,7 @@ public class SearchQueryBuilder {
             String delimiter = transformParamsDelimiter != null && transformParamsDelimiter.trim().length() > 0 ? transformParamsDelimiter : ",";
             String[] params = transformParams.split(delimiter);
             if (params.length % 2 != 0) {
-                throw new IllegalArgumentException("Transform params must have an equal number of parameter names and values: " + transformParams);
+                throw new IllegalArgumentException("Transform parameters must have an equal number of parameter names and values: " + transformParams);
             }
             for (int i = 0; i < params.length; i += 2) {
                 String name = params[i];

--- a/src/main/java/com/marklogic/spark/reader/optic/ReadContext.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/ReadContext.java
@@ -111,7 +111,7 @@ public class ReadContext extends ContextSupport {
         if (ex.getMessage().contains(indicatorOfNoRowsExisting)) {
             Util.MAIN_LOGGER.info("No rows were found, so will not create any partitions.");
         } else {
-            throw new ConnectorException(String.format("Unable to run Optic DSL query %s; cause: %s", query, ex.getMessage()), ex);
+            throw new ConnectorException(String.format("Unable to run Optic query %s; cause: %s", query, ex.getMessage()), ex);
         }
     }
 

--- a/src/main/java/com/marklogic/spark/reader/optic/SchemaInferrer.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/SchemaInferrer.java
@@ -83,7 +83,7 @@ public abstract class SchemaInferrer {
                 }
                 schema = schema.add(makeColumnName(column), determineSparkType(column), isColumnNullable(column));
             } catch (JsonProcessingException e) {
-                throw new ConnectorException(String.format("Unable to parse JSON: %s; cause: %s", columnInfo, e.getMessage()), e);
+                throw new ConnectorException(String.format("Unable to parse schema JSON: %s; cause: %s", columnInfo, e.getMessage()), e);
             }
         }
         return schema;

--- a/src/main/java/com/marklogic/spark/writer/FileRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/FileRowConverter.java
@@ -50,8 +50,9 @@ class FileRowConverter implements RowConverter {
             try {
                 content.withFormat(Format.valueOf(value.toUpperCase()));
             } catch (IllegalArgumentException e) {
-                String message = "Invalid value for option %s: %s; must be one of 'JSON', 'XML', or 'TEXT'.";
-                throw new ConnectorException(String.format(message, Options.WRITE_FILE_ROWS_DOCUMENT_TYPE, value));
+                String message = "Invalid value for %s: %s; must be one of 'JSON', 'XML', or 'TEXT'.";
+                String optionAlias = writeContext.getOptionNameForMessage(Options.WRITE_FILE_ROWS_DOCUMENT_TYPE);
+                throw new ConnectorException(String.format(message, optionAlias, value));
             }
         }
     }

--- a/src/main/java/com/marklogic/spark/writer/WriteContext.java
+++ b/src/main/java/com/marklogic/spark/writer/WriteContext.java
@@ -23,6 +23,7 @@ import com.marklogic.client.datamovement.WriteEvent;
 import com.marklogic.client.document.GenericDocumentManager;
 import com.marklogic.client.document.ServerTransform;
 import com.marklogic.client.impl.GenericDocumentImpl;
+import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.ContextSupport;
 import com.marklogic.spark.Options;
 import com.marklogic.spark.Util;
@@ -124,7 +125,8 @@ public class WriteContext extends ContextSupport {
      */
     private void configureTemplateUriMaker(DocBuilderFactory factory) {
         String uriTemplate = getProperties().get(Options.WRITE_URI_TEMPLATE);
-        factory.withUriMaker(new SparkRowUriMaker(uriTemplate));
+        String optionAlias = getOptionNameForMessage(Options.WRITE_URI_TEMPLATE);
+        factory.withUriMaker(new SparkRowUriMaker(uriTemplate, optionAlias));
         Stream.of(Options.WRITE_URI_PREFIX, Options.WRITE_URI_SUFFIX, Options.WRITE_URI_REPLACE).forEach(option -> {
             String value = getProperties().get(option);
             if (value != null && value.trim().length() > 0) {
@@ -170,9 +172,9 @@ public class WriteContext extends ContextSupport {
         String delimiter = delimiterValue != null && delimiterValue.trim().length() > 0 ? delimiterValue : ",";
         String[] params = paramsValue.split(delimiter);
         if (params.length % 2 != 0) {
-            throw new IllegalArgumentException(
+            throw new ConnectorException(
                 String.format("The %s option must contain an equal number of parameter names and values; received: %s",
-                    Options.WRITE_TRANSFORM_PARAMS, paramsValue)
+                    getOptionNameForMessage(Options.WRITE_TRANSFORM_PARAMS), paramsValue)
             );
         }
         for (int i = 0; i < params.length; i += 2) {

--- a/src/main/java/com/marklogic/spark/writer/rdf/RdfRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/rdf/RdfRowConverter.java
@@ -38,7 +38,8 @@ public class RdfRowConverter implements RowConverter {
         String tempGraphOverride = writeContext.getStringOption(Options.WRITE_GRAPH_OVERRIDE);
         if (graph != null && tempGraphOverride != null) {
             throw new ConnectorException(String.format("Can only specify one of %s and %s.",
-                Options.WRITE_GRAPH, Options.WRITE_GRAPH_OVERRIDE));
+                writeContext.getOptionNameForMessage(Options.WRITE_GRAPH),
+                writeContext.getOptionNameForMessage(Options.WRITE_GRAPH_OVERRIDE)));
         }
         if (graph != null) {
             this.defaultGraph = graph;

--- a/src/main/resources/marklogic-spark-messages.properties
+++ b/src/main/resources/marklogic-spark-messages.properties
@@ -1,0 +1,13 @@
+# Defines various messages for the connector. Intended to be inherited and overridden by the ETL tool via
+# marklogic-spark-messages_en.properties, where each option name can be associated with a CLI option in the ETL tool.
+spark.marklogic.client.uri=
+spark.marklogic.read.batchSize=
+spark.marklogic.read.documents.partitionsPerForest=
+spark.marklogic.read.numPartitions=
+spark.marklogic.write.batchSize=
+spark.marklogic.write.fileRows.documentType=
+spark.marklogic.write.graph=
+spark.marklogic.write.graphOverride=
+spark.marklogic.write.threadCount=
+spark.marklogic.write.transformParams=
+spark.marklogic.write.uriTemplate=

--- a/src/test/java/com/marklogic/spark/reader/document/BuildSearchQueryTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/BuildSearchQueryTest.java
@@ -48,6 +48,6 @@ class BuildSearchQueryTest extends AbstractIntegrationTest {
             .withTransformParams("param1,value1,param2");
 
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> builder.buildQuery(client));
-        assertEquals("Transform params must have an equal number of parameter names and values: param1,value1,param2", ex.getMessage());
+        assertEquals("Transform parameters must have an equal number of parameter names and values: param1,value1,param2", ex.getMessage());
     }
 }

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
@@ -66,7 +66,7 @@ class ReadDocumentRowsTest extends AbstractIntegrationTest {
             .load();
 
         ConnectorException ex = assertThrowsConnectorException(() -> dataset.count());
-        assertEquals("Value of 'spark.marklogic.read.batchSize' option must be numeric.", ex.getMessage());
+        assertEquals("The value of 'spark.marklogic.read.batchSize' must be numeric.", ex.getMessage());
     }
 
     @Test

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsWithPartitionCountsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsWithPartitionCountsTest.java
@@ -47,7 +47,7 @@ class ReadDocumentRowsWithPartitionCountsTest extends AbstractIntegrationTest {
             .load();
 
         ConnectorException ex = assertThrows(ConnectorException.class, () -> dataset.count());
-        assertEquals("Value of 'spark.marklogic.read.documents.partitionsPerForest' option must be numeric.", ex.getMessage());
+        assertEquals("The value of 'spark.marklogic.read.documents.partitionsPerForest' must be numeric.", ex.getMessage());
     }
 
     @ParameterizedTest

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadRowsTest.java
@@ -86,7 +86,7 @@ class ReadRowsTest extends AbstractIntegrationTest {
         DataFrameReader reader = newDefaultReader().option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'ViewNotFound')");
         RuntimeException ex = assertThrows(RuntimeException.class, () -> reader.load());
 
-        assertTrue(ex.getMessage().startsWith("Unable to run Optic DSL query op.fromView('Medical', 'ViewNotFound'); cause: "),
+        assertTrue(ex.getMessage().startsWith("Unable to run Optic query op.fromView('Medical', 'ViewNotFound'); cause: "),
             "If the query throws an error for any reason other than no rows being found, the error should be wrapped " +
                 "in a new error with a message containing the user's query to assist with debugging; actual " +
                 "message: " + ex.getMessage());
@@ -109,7 +109,7 @@ class ReadRowsTest extends AbstractIntegrationTest {
             .option(Options.READ_NUM_PARTITIONS, "abc")
             .load();
         ConnectorException ex = assertThrows(ConnectorException.class, () -> reader.count());
-        assertEquals("Value of 'spark.marklogic.read.numPartitions' option must be numeric.", ex.getMessage());
+        assertEquals("The value of 'spark.marklogic.read.numPartitions' must be numeric.", ex.getMessage());
     }
 
     @Test
@@ -119,7 +119,7 @@ class ReadRowsTest extends AbstractIntegrationTest {
             .load();
 
         ConnectorException ex = assertThrows(ConnectorException.class, () -> reader.count());
-        assertEquals("Value of 'spark.marklogic.read.numPartitions' option must be 1 or greater.", ex.getMessage());
+        assertEquals("The value of 'spark.marklogic.read.numPartitions' must be 1 or greater.", ex.getMessage());
     }
 
     @Test
@@ -129,7 +129,7 @@ class ReadRowsTest extends AbstractIntegrationTest {
             .load();
 
         ConnectorException ex = assertThrows(ConnectorException.class, () -> reader.count());
-        assertEquals("Value of 'spark.marklogic.read.batchSize' option must be numeric.", ex.getMessage());
+        assertEquals("The value of 'spark.marklogic.read.batchSize' must be numeric.", ex.getMessage());
     }
 
     @Test
@@ -138,6 +138,6 @@ class ReadRowsTest extends AbstractIntegrationTest {
             .option(Options.READ_BATCH_SIZE, "-1")
             .load();
         ConnectorException ex = assertThrows(ConnectorException.class, () -> reader.count());
-        assertEquals("Value of 'spark.marklogic.read.batchSize' option must be 0 or greater.", ex.getMessage());
+        assertEquals("The value of 'spark.marklogic.read.batchSize' must be 0 or greater.", ex.getMessage());
     }
 }

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadStreamOfRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadStreamOfRowsTest.java
@@ -16,6 +16,7 @@
 package com.marklogic.spark.reader.optic;
 
 import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.streaming.DataStreamReader;
 import org.junit.jupiter.api.Test;
@@ -87,7 +88,7 @@ class ReadStreamOfRowsTest extends AbstractIntegrationTest {
             .format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri());
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> reader.load());
+        ConnectorException ex = assertThrows(ConnectorException.class, () -> reader.load());
         assertEquals("No Optic query found; must define spark.marklogic.read.opticQuery", ex.getMessage());
     }
 }

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadWithClientUriTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadWithClientUriTest.java
@@ -16,6 +16,7 @@
 package com.marklogic.spark.reader.optic;
 
 import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.DataTypes;
@@ -145,11 +146,8 @@ class ReadWithClientUriTest extends AbstractIntegrationTest {
     }
 
     private void verifyClientUriIsInvalid(String clientUri) {
-        IllegalArgumentException ex = assertThrows(
-            IllegalArgumentException.class,
-            () -> readRowsWithClientUri(clientUri)
-        );
-
+        ConnectorException ex = assertThrows(ConnectorException.class,
+            () -> readRowsWithClientUri(clientUri));
         assertEquals(
             "Invalid value for spark.marklogic.client.uri; must be username:password@host:port",
             ex.getMessage()

--- a/src/test/java/com/marklogic/spark/writer/WriteFileRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteFileRowsTest.java
@@ -148,7 +148,7 @@ class WriteFileRowsTest extends AbstractWriteTest {
         SparkException ex = assertThrows(SparkException.class, () -> writer.save());
         assertTrue(ex.getCause() instanceof ConnectorException);
         ConnectorException ce = (ConnectorException) ex.getCause();
-        assertEquals("Invalid value for option " + Options.WRITE_FILE_ROWS_DOCUMENT_TYPE + ": not valid; " +
+        assertEquals("Invalid value for " + Options.WRITE_FILE_ROWS_DOCUMENT_TYPE + ": not valid; " +
             "must be one of 'JSON', 'XML', or 'TEXT'.", ce.getMessage());
     }
 

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
@@ -99,7 +99,7 @@ class WriteRowsTest extends AbstractWriteTest {
     void invalidThreadCount() {
         DataFrameWriter writer = newWriter().option(Options.WRITE_THREAD_COUNT, 0);
         ConnectorException ex = assertThrows(ConnectorException.class, () -> writer.save());
-        assertEquals("Value of 'spark.marklogic.write.threadCount' option must be 1 or greater.", ex.getMessage());
+        assertEquals("The value of 'spark.marklogic.write.threadCount' must be 1 or greater.", ex.getMessage());
         verifyNoDocsWereWritten();
     }
 
@@ -107,7 +107,7 @@ class WriteRowsTest extends AbstractWriteTest {
     void invalidBatchSize() {
         DataFrameWriter writer = newWriter().option(Options.WRITE_BATCH_SIZE, 0);
         ConnectorException ex = assertThrowsConnectorException(() -> writer.save());
-        assertEquals("Value of 'spark.marklogic.write.batchSize' option must be 1 or greater.", ex.getMessage(),
+        assertEquals("The value of 'spark.marklogic.write.batchSize' must be 1 or greater.", ex.getMessage(),
             "Note that batchSize is very different for writing than it is for reading. For writing, it specifies the " +
                 "exact number of documents to send to MarkLogic in each call. For reading, it used to determine how " +
                 "many requests will be made by a partition, and zero is a valid value for reading.");

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsWithTransformTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsWithTransformTest.java
@@ -106,17 +106,15 @@ class WriteRowsWithTransformTest extends AbstractWriteTest {
 
     @Test
     void invalidTransformParams() {
-        SparkException ex = assertThrows(SparkException.class,
+        ConnectorException ex = assertThrowsConnectorException(
             () -> newWriterForSingleRow()
                 .option(Options.WRITE_TRANSFORM_NAME, "withParams")
                 .option(Options.WRITE_TRANSFORM_PARAMS, "param1,value1,param2")
                 .save());
 
-        Throwable cause = getCauseFromWriterException(ex);
-        assertTrue(cause instanceof IllegalArgumentException);
         assertEquals(
             "The spark.marklogic.write.transformParams option must contain an equal number of parameter names and values; received: param1,value1,param2",
-            cause.getMessage()
+            ex.getMessage()
         );
     }
 }

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsWithUriTemplateTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsWithUriTemplateTest.java
@@ -15,6 +15,7 @@
  */
 package com.marklogic.spark.writer;
 
+import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
 import org.apache.spark.SparkException;
 import org.junit.jupiter.api.Test;
@@ -100,15 +101,11 @@ class WriteRowsWithUriTemplateTest extends AbstractWriteTest {
     }
 
     private void verifyTemplateIsInvalid(String uriTemplate, String expectedMessage) {
-        SparkException ex = assertThrows(
-            SparkException.class,
+        ConnectorException ex = assertThrowsConnectorException(
             () -> newWriter().option(Options.WRITE_URI_TEMPLATE, uriTemplate).save()
         );
 
-        Throwable cause = getCauseFromWriterException(ex);
-        assertTrue(cause instanceof IllegalArgumentException, "Unexpected cause: " + cause);
-
-        String message = cause.getMessage();
+        String message = ex.getMessage();
         expectedMessage = "Invalid value for " + Options.WRITE_URI_TEMPLATE + ": " + uriTemplate + "; " + expectedMessage;
         assertEquals(expectedMessage, message, "Unexpected error message: " + message);
     }


### PR DESCRIPTION
Will have a follow up PR in spark-etl to override each of these option names with a CLI option. 

Did some cleanup of error messages as well while I was at it, as well as throwing `ConnectorException` more consistently. So a lot of little changes, nothing major though. 