### PR TITLE
MLE-13771 Fixing bug where sqlCondition was added to op.and

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/optic/PlanUtil.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/PlanUtil.java
@@ -181,16 +181,8 @@ public abstract class PlanUtil {
             columnName;
     }
 
-    static ObjectNode buildWhere(List<OpticFilter> opticFilters) {
-        return newOperation("where", args -> {
-            // If there's only one filter, can toss it into the "where" clause. Else, toss an "and" into the "where" and
-            // then toss every filter into the "and" clause (which accepts 2 to N args).
-            final ArrayNode targetArgs = opticFilters.size() == 1 ?
-                args :
-                args.addObject().put("ns", "op").put("fn", "and").putArray("args");
-
-            opticFilters.forEach(planFilter -> planFilter.populateArg(targetArgs.addObject()));
-        });
+    static ObjectNode buildWhere(OpticFilter filter) {
+        return newOperation("where", args -> filter.populateArg(args.addObject()));
     }
 
     private static ObjectNode newOperation(String name, Consumer<ArrayNode> withArgs) {

--- a/src/main/java/com/marklogic/spark/reader/optic/ReadContext.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/ReadContext.java
@@ -155,7 +155,9 @@ public class ReadContext extends ContextSupport {
 
     void pushDownFiltersIntoOpticQuery(List<OpticFilter> opticFilters) {
         this.opticFilters = opticFilters;
-        addOperatorToPlan(PlanUtil.buildWhere(opticFilters));
+        // Add each filter in a separate "where" so we don't toss an op.sqlCondition into an op.and,
+        // which Optic does not allow.
+        opticFilters.forEach(filter -> addOperatorToPlan(PlanUtil.buildWhere(filter)));
     }
 
     void pushDownLimit(int limit) {


### PR DESCRIPTION
Was able to reproduce the bug by including 2 filters, one of which produced a `sqlCondition`. I was not able to reproduce an issue where an `and` is created with a `sqlCondition` on the left or right. Have not figured out a way to force Spark to pass that to our connector. 