### PR TITLE
Renamed `ReadContext` to `OpticReadContext`

### DIFF
--- a/src/main/java/com/marklogic/spark/MarkLogicTable.java
+++ b/src/main/java/com/marklogic/spark/MarkLogicTable.java
@@ -16,7 +16,7 @@
 package com.marklogic.spark;
 
 import com.marklogic.spark.reader.optic.OpticScanBuilder;
-import com.marklogic.spark.reader.optic.ReadContext;
+import com.marklogic.spark.reader.optic.OpticReadContext;
 import com.marklogic.spark.reader.customcode.CustomCodeScanBuilder;
 import com.marklogic.spark.writer.MarkLogicWriteBuilder;
 import com.marklogic.spark.writer.WriteContext;
@@ -91,7 +91,7 @@ class MarkLogicTable implements SupportsRead, SupportsWrite {
         // This is needed by the Optic partition reader; capturing it in the ReadContext so that the reader does not
         // have a dependency on an active Spark session, which makes certain kinds of tests easier.
         int defaultMinPartitions = SparkSession.active().sparkContext().defaultMinPartitions();
-        return new OpticScanBuilder(new ReadContext(readProperties, readSchema, defaultMinPartitions));
+        return new OpticScanBuilder(new OpticReadContext(readProperties, readSchema, defaultMinPartitions));
     }
 
     @Override

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticBatch.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticBatch.java
@@ -25,12 +25,12 @@ class OpticBatch implements Batch {
 
     private static final Logger logger = LoggerFactory.getLogger(OpticBatch.class);
 
-    private final ReadContext readContext;
+    private final OpticReadContext opticReadContext;
     private final InputPartition[] partitions;
 
-    OpticBatch(ReadContext readContext) {
-        this.readContext = readContext;
-        PlanAnalysis planAnalysis = readContext.getPlanAnalysis();
+    OpticBatch(OpticReadContext opticReadContext) {
+        this.opticReadContext = opticReadContext;
+        PlanAnalysis planAnalysis = opticReadContext.getPlanAnalysis();
         partitions = planAnalysis != null ?
             planAnalysis.getPartitionArray() :
             new InputPartition[]{};
@@ -46,6 +46,6 @@ class OpticBatch implements Batch {
         if (logger.isDebugEnabled()) {
             logger.debug("Creating new partition reader factory");
         }
-        return new OpticPartitionReaderFactory(readContext);
+        return new OpticPartitionReaderFactory(opticReadContext);
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticMicroBatchStream.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticMicroBatchStream.java
@@ -39,13 +39,13 @@ class OpticMicroBatchStream implements MicroBatchStream {
 
     private static final Logger logger = LoggerFactory.getLogger(OpticMicroBatchStream.class);
 
-    private ReadContext readContext;
+    private OpticReadContext opticReadContext;
     private List<PlanAnalysis.Bucket> allBuckets;
     private int bucketIndex;
 
-    OpticMicroBatchStream(ReadContext readContext) {
-        this.readContext = readContext;
-        this.allBuckets = this.readContext.getPlanAnalysis().getAllBuckets();
+    OpticMicroBatchStream(OpticReadContext opticReadContext) {
+        this.opticReadContext = opticReadContext;
+        this.allBuckets = this.opticReadContext.getPlanAnalysis().getAllBuckets();
     }
 
     @Override
@@ -77,7 +77,7 @@ class OpticMicroBatchStream implements MicroBatchStream {
 
     @Override
     public PartitionReaderFactory createReaderFactory() {
-        return new OpticPartitionReaderFactory(this.readContext);
+        return new OpticPartitionReaderFactory(this.opticReadContext);
     }
 
     @Override

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticPartitionReader.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticPartitionReader.java
@@ -33,7 +33,7 @@ class OpticPartitionReader implements PartitionReader<InternalRow> {
 
     private static final Logger logger = LoggerFactory.getLogger(OpticPartitionReader.class);
 
-    private final ReadContext readContext;
+    private final OpticReadContext opticReadContext;
     private final PlanAnalysis.Partition partition;
     private final RowManager rowManager;
 
@@ -52,14 +52,14 @@ class OpticPartitionReader implements PartitionReader<InternalRow> {
     // are working correctly.
     static Consumer<Long> totalRowCountListener;
 
-    OpticPartitionReader(ReadContext readContext, PlanAnalysis.Partition partition) {
-        this.readContext = readContext;
+    OpticPartitionReader(OpticReadContext opticReadContext, PlanAnalysis.Partition partition) {
+        this.opticReadContext = opticReadContext;
         this.partition = partition;
-        this.rowManager = readContext.connectToMarkLogic().newRowManager();
+        this.rowManager = opticReadContext.connectToMarkLogic().newRowManager();
         // Nested values won't work with the JacksonParser used by JsonRowDeserializer, so we ask for type info to not
         // be in the rows.
         this.rowManager.setDatatypeStyle(RowManager.RowSetPart.HEADER);
-        this.jsonRowDeserializer = new JsonRowDeserializer(readContext.getSchema());
+        this.jsonRowDeserializer = new JsonRowDeserializer(opticReadContext.getSchema());
     }
 
     @Override
@@ -86,7 +86,7 @@ class OpticPartitionReader implements PartitionReader<InternalRow> {
             PlanAnalysis.Bucket bucket = partition.getBuckets().get(nextBucketIndex);
             nextBucketIndex++;
             long start = System.currentTimeMillis();
-            this.rowIterator = readContext.readRowsInBucket(rowManager, partition, bucket);
+            this.rowIterator = opticReadContext.readRowsInBucket(rowManager, partition, bucket);
             if (logger.isDebugEnabled()) {
                 this.totalDuration += System.currentTimeMillis() - start;
             }

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticPartitionReaderFactory.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticPartitionReaderFactory.java
@@ -27,10 +27,10 @@ class OpticPartitionReaderFactory implements PartitionReaderFactory {
     static final long serialVersionUID = 1;
 
     private static final Logger logger = LoggerFactory.getLogger(OpticPartitionReaderFactory.class);
-    private final ReadContext readContext;
+    private final OpticReadContext opticReadContext;
 
-    OpticPartitionReaderFactory(ReadContext readContext) {
-        this.readContext = readContext;
+    OpticPartitionReaderFactory(OpticReadContext opticReadContext) {
+        this.opticReadContext = opticReadContext;
     }
 
     @Override
@@ -38,6 +38,6 @@ class OpticPartitionReaderFactory implements PartitionReaderFactory {
         if (logger.isDebugEnabled()) {
             logger.debug("Creating reader for partition: {}", partition);
         }
-        return new OpticPartitionReader(this.readContext, (PlanAnalysis.Partition) partition);
+        return new OpticPartitionReader(this.opticReadContext, (PlanAnalysis.Partition) partition);
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticReadContext.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticReadContext.java
@@ -48,15 +48,15 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Captures state - all of which is serializable - that can be calculated at different times based on a user's inputs.
+ * Captures state - all of which is serializable - associated with a read operation involving an Optic query.
  * Also simplifies passing state around to the various Spark-required classes, as we only need one argument instead of
  * N arguments.
  */
-public class ReadContext extends ContextSupport {
+public class OpticReadContext extends ContextSupport {
 
     static final long serialVersionUID = 1;
 
-    private static final Logger logger = LoggerFactory.getLogger(ReadContext.class);
+    private static final Logger logger = LoggerFactory.getLogger(OpticReadContext.class);
 
     // The ideal batch size depends highly on what a user chooses to do after a load() - and of course the user may
     // choose to perform multiple operations on the dataset, each of which may benefit from a fairly different batch
@@ -69,7 +69,7 @@ public class ReadContext extends ContextSupport {
     private long serverTimestamp;
     private List<OpticFilter> opticFilters;
 
-    public ReadContext(Map<String, String> properties, StructType schema, int defaultMinPartitions) {
+    public OpticReadContext(Map<String, String> properties, StructType schema, int defaultMinPartitions) {
         super(properties);
         this.schema = schema;
 

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticScan.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticScan.java
@@ -27,15 +27,15 @@ class OpticScan implements Scan {
 
     private static final Logger logger = LoggerFactory.getLogger(OpticScan.class);
 
-    private ReadContext readContext;
+    private OpticReadContext opticReadContext;
 
-    OpticScan(ReadContext readContext) {
-        this.readContext = readContext;
+    OpticScan(OpticReadContext opticReadContext) {
+        this.opticReadContext = opticReadContext;
     }
 
     @Override
     public StructType readSchema() {
-        return readContext.getSchema();
+        return opticReadContext.getSchema();
     }
 
     @Override
@@ -48,11 +48,11 @@ class OpticScan implements Scan {
         if (logger.isDebugEnabled()) {
             logger.debug("Creating new batch");
         }
-        return new OpticBatch(readContext);
+        return new OpticBatch(opticReadContext);
     }
 
     @Override
     public MicroBatchStream toMicroBatchStream(String checkpointLocation) {
-        return new OpticMicroBatchStream(readContext);
+        return new OpticMicroBatchStream(opticReadContext);
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticScanBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticScanBuilder.java
@@ -35,7 +35,7 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
 
     private static final Logger logger = LoggerFactory.getLogger(OpticScanBuilder.class);
 
-    private final ReadContext readContext;
+    private final OpticReadContext opticReadContext;
     private List<Filter> pushedFilters;
 
     private static final Set<Class<? extends AggregateFunc>> SUPPORTED_AGGREGATE_FUNCTIONS = new HashSet<>();
@@ -49,8 +49,8 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
         SUPPORTED_AGGREGATE_FUNCTIONS.add(Sum.class);
     }
 
-    public OpticScanBuilder(ReadContext readContext) {
-        this.readContext = readContext;
+    public OpticScanBuilder(OpticReadContext opticReadContext) {
+        this.opticReadContext = opticReadContext;
     }
 
     @Override
@@ -58,7 +58,7 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
         if (logger.isDebugEnabled()) {
             logger.debug("Creating new scan");
         }
-        return new OpticScan(readContext);
+        return new OpticScan(opticReadContext);
     }
 
     /**
@@ -69,7 +69,7 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
     @Override
     public Filter[] pushFilters(Filter[] filters) {
         pushedFilters = new ArrayList<>();
-        if (readContext.planAnalysisFoundNoRows()) {
+        if (opticReadContext.planAnalysisFoundNoRows()) {
             return filters;
         }
 
@@ -94,7 +94,7 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
             }
         }
 
-        readContext.pushDownFiltersIntoOpticQuery(opticFilters);
+        opticReadContext.pushDownFiltersIntoOpticQuery(opticFilters);
         return unsupportedFilters.toArray(new Filter[0]);
     }
 
@@ -108,19 +108,19 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
 
     @Override
     public boolean pushLimit(int limit) {
-        if (readContext.planAnalysisFoundNoRows()) {
+        if (opticReadContext.planAnalysisFoundNoRows()) {
             return false;
         }
         if (logger.isDebugEnabled()) {
             logger.debug("Pushing down limit: {}", limit);
         }
-        readContext.pushDownLimit(limit);
+        opticReadContext.pushDownLimit(limit);
         return true;
     }
 
     @Override
     public boolean pushTopN(SortOrder[] orders, int limit) {
-        if (readContext.planAnalysisFoundNoRows()) {
+        if (opticReadContext.planAnalysisFoundNoRows()) {
             return false;
         }
         // This will be invoked when the user calls both orderBy and limit in their Spark program. If the user only
@@ -129,7 +129,7 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
         if (logger.isDebugEnabled()) {
             logger.debug("Pushing down topN: {}; limit: {}", Arrays.asList(orders), limit);
         }
-        readContext.pushDownTopN(orders, limit);
+        opticReadContext.pushDownTopN(orders, limit);
         return true;
     }
 
@@ -138,7 +138,7 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
         // If a single bucket exists - i.e. a single call will be made to MarkLogic - then any limit/orderBy can be
         // fully pushed down to MarkLogic. Otherwise, we also need Spark to apply the limit/orderBy to the returned rows
         // to ensure that the user receives the correct response.
-        return readContext.getBucketCount() > 1;
+        return opticReadContext.getBucketCount() > 1;
     }
 
     /**
@@ -152,7 +152,7 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
      */
     @Override
     public boolean supportCompletePushDown(Aggregation aggregation) {
-        if (readContext.planAnalysisFoundNoRows() || pushDownAggregatesIsDisabled()) {
+        if (opticReadContext.planAnalysisFoundNoRows() || pushDownAggregatesIsDisabled()) {
             return false;
         }
 
@@ -164,7 +164,7 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
             return false;
         }
 
-        if (readContext.getBucketCount() > 1) {
+        if (opticReadContext.getBucketCount() > 1) {
             if (Util.MAIN_LOGGER.isInfoEnabled()) {
                 Util.MAIN_LOGGER.info("Multiple requests will be made to MarkLogic; aggregation will be applied by Spark as well: {}",
                     describeAggregation(aggregation));
@@ -179,7 +179,7 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
         // For the initial 2.0 release, there aren't any known unsupported aggregate functions that can be called
         // after a "groupBy". If one is detected though, the aggregation won't be pushed down as it's uncertain if
         // pushing it down would produce the correct results.
-        if (readContext.planAnalysisFoundNoRows() || hasUnsupportedAggregateFunction(aggregation)) {
+        if (opticReadContext.planAnalysisFoundNoRows() || hasUnsupportedAggregateFunction(aggregation)) {
             return false;
         }
 
@@ -191,16 +191,16 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
         if (logger.isDebugEnabled()) {
             logger.debug("Pushing down aggregation: {}", describeAggregation(aggregation));
         }
-        readContext.pushDownAggregation(aggregation);
+        opticReadContext.pushDownAggregation(aggregation);
         return true;
     }
 
     @Override
     public void pruneColumns(StructType requiredSchema) {
-        if (readContext.planAnalysisFoundNoRows()) {
+        if (opticReadContext.planAnalysisFoundNoRows()) {
             return;
         }
-        if (requiredSchema.equals(readContext.getSchema())) {
+        if (requiredSchema.equals(opticReadContext.getSchema())) {
             if (logger.isDebugEnabled()) {
                 logger.debug("The schema to push down is equal to the existing schema, so not pushing it down.");
             }
@@ -209,7 +209,7 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
             if (logger.isDebugEnabled()) {
                 logger.debug("Pushing down required schema: {}", requiredSchema.json());
             }
-            readContext.pushDownRequiredSchema(requiredSchema);
+            opticReadContext.pushDownRequiredSchema(requiredSchema);
         }
     }
 
@@ -226,6 +226,6 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
     }
 
     private boolean pushDownAggregatesIsDisabled() {
-        return "false".equalsIgnoreCase(readContext.getProperties().get(Options.READ_PUSH_DOWN_AGGREGATES));
+        return "false".equalsIgnoreCase(opticReadContext.getProperties().get(Options.READ_PUSH_DOWN_AGGREGATES));
     }
 }

--- a/src/test/java/com/marklogic/spark/reader/optic/SerializeOpticReaderObjectsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/SerializeOpticReaderObjectsTest.java
@@ -1,6 +1,5 @@
 package com.marklogic.spark.reader.optic;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.Options;
@@ -38,7 +37,7 @@ class SerializeOpticReaderObjectsTest extends AbstractIntegrationTest {
         Map<String, String> props = new HashMap<>();
         props.put(Options.CLIENT_URI, makeClientUri());
         props.put(Options.READ_OPTIC_QUERY, NO_AUTHORS_QUERY);
-        ReadContext context = new ReadContext(props, new StructType().add("myType", DataTypes.StringType), 1);
+        OpticReadContext context = new OpticReadContext(props, new StructType().add("myType", DataTypes.StringType), 1);
         OpticPartitionReaderFactory factory = new OpticPartitionReaderFactory(context);
 
         factory = (OpticPartitionReaderFactory) SerializeUtil.serialize(factory);


### PR DESCRIPTION
Pure refactor - no functional changes. Wanted to make it more clear that this class is associated with an Optic query and not just any old read operation. 