### PR TITLE
Fixed bug where success item count wasn't incremented

### DIFF
--- a/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
@@ -190,6 +190,7 @@ class WriteBatcherDataWriter implements DataWriter<InternalRow> {
         return new BatchRetrier(
             writeContext.newDocumentManager(this.databaseClient),
             writeContext.getStringOption(Options.WRITE_TEMPORAL_COLLECTION),
+            successfulBatch -> successItemCount.getAndAdd(successfulBatch.size()),
             (failedDoc, failure) -> {
                 Util.MAIN_LOGGER.error("Unable to write document with URI: {}; cause: {}", failedDoc.getUri(), failure.getMessage());
                 failedItemCount.incrementAndGet();


### PR DESCRIPTION
The `BatchRetrier` was neglecting to bump up the success item count when a batch succeeded. 