### PR TITLE
Removing published dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,49 +23,61 @@ repositories {
   mavenCentral()
 }
 
+configurations {
+  // Defines all the implementation dependencies, but in such a way that they are not included as dependencies in the
+  // library's pom.xml file. This is due to the shadow jar being published instead of a jar only containing this
+  // project's classes. The shadow jar is published due to the need to relocate several packages to avoid conflicts
+  // with Spark.
+  shadowDependencies
+
+  // This approach allows for all of the dependencies to be available for compilation and for running tests.
+  compileOnly.extendsFrom(shadowDependencies)
+  testImplementation.extendsFrom(compileOnly)
+}
+
 dependencies {
-  compileOnly 'org.apache.spark:spark-sql_2.12:' + sparkVersion
-  implementation ("com.marklogic:marklogic-client-api:6.6.0") {
+  // This is compileOnly as any environment this is used in will provide the Spark dependencies itself.
+  compileOnly ('org.apache.spark:spark-sql_2.12:' + sparkVersion) {
+    // Excluded from our ETL tool for size reasons, so excluded here as well to ensure we don't need it.
+    exclude module: "rocksdbjni"
+  }
+
+  shadowDependencies ("com.marklogic:marklogic-client-api:6.6.0") {
     // The Java Client uses Jackson 2.15.2; Scala 3.4.x does not yet support that and will throw the following error:
     // Scala module 2.14.2 requires Jackson Databind version >= 2.14.0 and < 2.15.0 - Found jackson-databind version 2.15.2
     // So the 4 Jackson modules are excluded to allow for Spark's to be used.
-    exclude module: 'jackson-core'
-    exclude module: 'jackson-databind'
-    exclude module: 'jackson-annotations'
-    exclude module: 'jackson-dataformat-csv'
+    exclude group: "com.fasterxml.jackson.core"
+    exclude group: "com.fasterxml.jackson.dataformat"
   }
 
   // For XML support; supports converting a string of JSON into a string of XML.
   // See ArbitraryRowConverter for more information.
-  implementation "org.json:json:20240303"
+  shadowDependencies "org.json:json:20240303"
 
   // Need this so that an OkHttpClientConfigurator can be created.
-  implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+  shadowDependencies 'com.squareup.okhttp3:okhttp:4.12.0'
 
   // Makes it possible to use lambdas in Java 8 to implement Spark's Function1 and Function2 interfaces
   // See https://github.com/scala/scala-java8-compat for more information
-  implementation("org.scala-lang.modules:scala-java8-compat_2.12:1.0.2") {
+  shadowDependencies("org.scala-lang.modules:scala-java8-compat_2.12:1.0.2") {
     // Prefer the Scala libraries used within the user's Spark runtime.
     exclude module: "scala-library"
   }
 
-  implementation "org.apache.jena:jena-arq:4.10.0"
-  implementation "org.jdom:jdom2:2.0.6.1"
+  shadowDependencies ("org.apache.jena:jena-arq:4.10.0") {
+    exclude group: "com.fasterxml.jackson.core"
+    exclude group: "com.fasterxml.jackson.dataformat"
+  }
 
-  testImplementation 'org.apache.spark:spark-sql_2.12:' + sparkVersion
+  shadowDependencies "org.jdom:jdom2:2.0.6.1"
 
-  // The exclusions in these two modules ensure that we use the Jackson libraries from spark-sql when running the tests.
   testImplementation ('com.marklogic:ml-app-deployer:4.7.0') {
-    exclude module: 'jackson-core'
-    exclude module: 'jackson-databind'
-    exclude module: 'jackson-annotations'
-    exclude module: 'jackson-dataformat-csv'
+    exclude group: "com.fasterxml.jackson.core"
+    exclude group: "com.fasterxml.jackson.dataformat"
   }
   testImplementation ('com.marklogic:marklogic-junit5:1.4.0') {
-    exclude module: 'jackson-core'
-    exclude module: 'jackson-databind'
-    exclude module: 'jackson-annotations'
-    exclude module: 'jackson-dataformat-csv'
+    exclude group: "com.fasterxml.jackson.core"
+    exclude group: "com.fasterxml.jackson.dataformat"
   }
 
   testImplementation "ch.qos.logback:logback-classic:1.3.14"
@@ -114,7 +126,11 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
 }
 
 shadowJar {
-  // "all" is the default; no need for that in the connector filename.
+  configurations = [project.configurations.shadowDependencies]
+
+  // "all" is the default; no need for that in the connector filename. This also results in this becoming the library
+  // artifact that is published as a dependency. That is desirable as it includes the relocated packages listed below,
+  // which a dependent would otherwise have to manage themselves.
   archiveClassifier.set("")
 
   // Spark uses an older version of OkHttp; see


### PR DESCRIPTION
Realized that since we're publishing the shadow jar for the connector - i.e. the jar that contains all of the dependencies, including several whose packages are relocated to avoid conflicts with Spark - that we don't want any dependencies declared since a user gets all of them via the single connector jar. 

Did a little Gradle trickery to accomplish this - made a new `shadowDependencies` configuration that acts like `implementation` but avoids adding any dependencies to the pom.xml file. 

Also fixed an issue where Jackson dependencies from Jena could take precedence over what Spark requires. 