### PR TITLE
MLE-14385 Can now read generic files

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/file/FilePartitionReaderFactory.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FilePartitionReaderFactory.java
@@ -1,6 +1,5 @@
 package com.marklogic.spark.reader.file;
 
-import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.InputPartition;
@@ -21,7 +20,7 @@ class FilePartitionReaderFactory implements PartitionReaderFactory {
     public PartitionReader<InternalRow> createReader(InputPartition partition) {
         final FilePartition filePartition = (FilePartition) partition;
         final String fileType = fileContext.getStringOption(Options.READ_FILES_TYPE);
-        
+
         if ("rdf".equalsIgnoreCase(fileType)) {
             if (fileContext.isZip()) {
                 return new RdfZipFileReader(filePartition, fileContext);
@@ -40,7 +39,6 @@ class FilePartitionReaderFactory implements PartitionReaderFactory {
         } else if (fileContext.isGzip()) {
             return new GzipFileReader(filePartition, fileContext);
         }
-
-        throw new ConnectorException(String.format("Files are not supported: %s", filePartition.getPaths()));
+        return new GenericFileReader(filePartition, fileContext);
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/file/FileUtil.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FileUtil.java
@@ -1,7 +1,5 @@
 package com.marklogic.spark.reader.file;
 
-import org.apache.spark.sql.connector.read.InputPartition;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/com/marklogic/spark/reader/file/GenericFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/GenericFileReader.java
@@ -1,0 +1,67 @@
+package com.marklogic.spark.reader.file;
+
+import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Util;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.connector.read.PartitionReader;
+import org.apache.spark.unsafe.types.ByteArray;
+import org.apache.spark.unsafe.types.UTF8String;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * "Generic" = read each file as-is with no special processing.
+ */
+class GenericFileReader implements PartitionReader<InternalRow> {
+
+    private final FilePartition filePartition;
+    private final FileContext fileContext;
+
+    private InternalRow nextRowToReturn;
+    private int filePathIndex;
+
+    GenericFileReader(FilePartition filePartition, FileContext fileContext) {
+        this.filePartition = filePartition;
+        this.fileContext = fileContext;
+    }
+
+    @Override
+    public boolean next() {
+        if (filePathIndex >= filePartition.getPaths().size()) {
+            return false;
+        }
+
+        final String path = filePartition.getPaths().get(filePathIndex);
+        filePathIndex++;
+        try {
+            try (InputStream inputStream = fileContext.openFile(path)) {
+                byte[] content = FileUtil.readBytes(inputStream);
+                nextRowToReturn = new GenericInternalRow(new Object[]{
+                    UTF8String.fromString(path),
+                    ByteArray.concat(content),
+                    null, null, null, null, null, null
+                });
+            }
+        } catch (Exception ex) {
+            String message = String.format("Unable to read file at %s; cause: %s", path, ex.getMessage());
+            if (fileContext.isReadAbortOnFailure()) {
+                throw new ConnectorException(message, ex);
+            }
+            Util.MAIN_LOGGER.warn(message);
+            return next();
+        }
+        return true;
+    }
+
+    @Override
+    public InternalRow get() {
+        return nextRowToReturn;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // Nothing to close.
+    }
+}

--- a/src/test/java/com/marklogic/spark/reader/file/ReadGenericFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadGenericFilesTest.java
@@ -1,0 +1,54 @@
+package com.marklogic.spark.reader.file;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.client.io.BytesHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.junit5.XmlNode;
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The generic file reader has support for aborting or continuing on failure - but we haven't yet found a way to
+ * force an error to occur. An encoding issue doesn't cause an error because the reader simply reads in all the
+ * bytes from the file.
+ */
+class ReadGenericFilesTest extends AbstractIntegrationTest {
+
+    @Test
+    void readAndWriteMixedFiles() {
+        Dataset<Row> dataset = newSparkSession().read().format(CONNECTOR_IDENTIFIER)
+            .option(Options.READ_NUM_PARTITIONS, 2)
+            .load("src/test/resources/mixed-files");
+
+        List<Row> rows = dataset.collectAsList();
+        assertEquals(4, rows.size());
+        rows.forEach(row -> {
+            assertFalse(row.isNullAt(0)); // URI
+            assertFalse(row.isNullAt(1)); // content
+            Stream.of(2, 3, 4, 5, 6, 7).forEach(index -> assertTrue(row.isNullAt(index),
+                "Expecting a null value for every column that isn't URI or content; index: " + index));
+        });
+
+        defaultWrite(dataset.write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.WRITE_COLLECTIONS, "generic")
+            .option(Options.WRITE_URI_REPLACE, ".*/mixed-files,''"));
+
+        JsonNode doc = readJsonDocument("/hello.json", "generic");
+        assertEquals("world", doc.get("hello").asText());
+        XmlNode xmlDoc = readXmlDocument("/hello.xml", "generic");
+        xmlDoc.assertElementValue("/hello", "world");
+        String text = getDatabaseClient().newTextDocumentManager().read("/hello.txt", new StringHandle()).get();
+        assertEquals("hello world", text.trim());
+        BytesHandle handle = getDatabaseClient().newBinaryDocumentManager().read("/hello2.txt.gz", new BytesHandle());
+        assertEquals(Format.BINARY, handle.getFormat());
+    }
+}

--- a/src/test/java/com/marklogic/spark/writer/WriteArchiveOfFailedDocumentsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteArchiveOfFailedDocumentsTest.java
@@ -37,7 +37,7 @@ class WriteArchiveOfFailedDocumentsTest extends AbstractWriteTest {
 
         SparkSession session = newSparkSession();
 
-        defaultWrite(session.read().format("binaryFile")
+        defaultWrite(session.read().format(CONNECTOR_IDENTIFIER)
             .load("src/test/resources/mixed-files")
             .repartition(1) // Forces a single partition writer and thus a single archive file being written.
             .write().format(CONNECTOR_IDENTIFIER)
@@ -63,7 +63,7 @@ class WriteArchiveOfFailedDocumentsTest extends AbstractWriteTest {
 
     @Test
     void multiplePartitions(@TempDir Path tempDir) {
-        defaultWrite(newSparkSession().read().format("binaryFile")
+        defaultWrite(newSparkSession().read().format(CONNECTOR_IDENTIFIER)
             .load("src/test/resources/mixed-files")
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.WRITE_URI_SUFFIX, ".json")
@@ -81,7 +81,7 @@ class WriteArchiveOfFailedDocumentsTest extends AbstractWriteTest {
 
     @Test
     void invalidArchivePath() {
-        ConnectorException ex = assertThrowsConnectorException(() -> defaultWrite(newSparkSession().read().format("binaryFile")
+        ConnectorException ex = assertThrowsConnectorException(() -> defaultWrite(newSparkSession().read().format(CONNECTOR_IDENTIFIER)
             .load("src/test/resources/mixed-files")
             .repartition(1)
             .write().format(CONNECTOR_IDENTIFIER)

--- a/src/test/java/com/marklogic/spark/writer/WritePartialBatchTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WritePartialBatchTest.java
@@ -12,7 +12,7 @@ class WritePartialBatchTest extends AbstractWriteTest {
 
     @Test
     void threeOutOfFourShouldFail() {
-        defaultWrite(newSparkSession().read().format("binaryFile")
+        defaultWrite(newSparkSession().read().format(CONNECTOR_IDENTIFIER)
             .load("src/test/resources/mixed-files")
             .repartition(1) // Forces all 4 docs to be written in a single batch.
             .write().format(CONNECTOR_IDENTIFIER)
@@ -28,7 +28,7 @@ class WritePartialBatchTest extends AbstractWriteTest {
 
     @Test
     void shouldThrowError() {
-        DataFrameWriter writer = newSparkSession().read().format("binaryFile")
+        DataFrameWriter writer = newSparkSession().read().format(CONNECTOR_IDENTIFIER)
             .load("src/test/resources/mixed-files")
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.WRITE_URI_SUFFIX, ".json")


### PR DESCRIPTION
Switched a couple tests over to use our connector for reading generic files. We still need tests for binaryFile as we support writing rows conforming to the schema used by binaryFile. 