### PR TITLE
MLE-14413 Fixing bug with duplicate groupBy column names

### DIFF
--- a/src/main/java/com/marklogic/spark/DefaultSource.java
+++ b/src/main/java/com/marklogic/spark/DefaultSource.java
@@ -90,9 +90,6 @@ public class DefaultSource implements TableProvider, DataSourceRegister {
         } else if (isReadTriplesOperation(properties)) {
             return new DocumentTable(TripleRowSchema.SCHEMA);
         } else if (isReadOperation(properties)) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Creating new table for reading");
-            }
             return new MarkLogicTable(schema, properties);
         }
 
@@ -148,7 +145,11 @@ public class DefaultSource implements TableProvider, DataSourceRegister {
         try {
             // columnInfo is what forces a minimum MarkLogic version of 10.0-9 or higher.
             StringHandle columnInfoHandle = rowManager.columnInfo(dslPlan, new StringHandle());
-            return SchemaInferrer.inferSchema(columnInfoHandle.get());
+            StructType schema = SchemaInferrer.inferSchema(columnInfoHandle.get());
+            if (Util.MAIN_LOGGER.isDebugEnabled()) {
+                logger.debug("Inferred schema from Optic columnInfo: {}", schema);
+            }
+            return schema;
         } catch (Exception ex) {
             throw new ConnectorException(String.format("Unable to run Optic query %s; cause: %s", query, ex.getMessage()), ex);
         }

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticBatch.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticBatch.java
@@ -43,8 +43,8 @@ class OpticBatch implements Batch {
 
     @Override
     public PartitionReaderFactory createReaderFactory() {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Creating new partition reader factory");
+        if (logger.isTraceEnabled()) {
+            logger.trace("Creating new partition reader factory");
         }
         return new OpticPartitionReaderFactory(opticReadContext);
     }

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticReadContext.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticReadContext.java
@@ -40,10 +40,7 @@ import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -174,7 +171,10 @@ public class OpticReadContext extends ContextSupport {
             .map(PlanUtil::expressionToColumnName)
             .collect(Collectors.toList());
 
-        addOperatorToPlan(PlanUtil.buildGroupByAggregation(groupByColumnNames, aggregation));
+        if (logger.isDebugEnabled()) {
+            logger.debug("groupBy column names: {}", groupByColumnNames);
+        }
+        addOperatorToPlan(PlanUtil.buildGroupByAggregation(new HashSet(groupByColumnNames), aggregation));
 
         StructType newSchema = buildSchemaWithColumnNames(groupByColumnNames);
 
@@ -213,6 +213,9 @@ public class OpticReadContext extends ContextSupport {
             this.planAnalysis = new PlanAnalysis(planAnalysis.getBoundedPlan(), mergedPartitions);
         }
 
+        if (Util.MAIN_LOGGER.isDebugEnabled()) {
+            Util.MAIN_LOGGER.debug("Schema after pushing down aggregation: {}", newSchema);
+        }
         this.schema = newSchema;
     }
 

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticScan.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticScan.java
@@ -45,8 +45,8 @@ class OpticScan implements Scan {
 
     @Override
     public Batch toBatch() {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Creating new batch");
+        if (logger.isTraceEnabled()) {
+            logger.trace("Creating new batch");
         }
         return new OpticBatch(opticReadContext);
     }

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticScanBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticScanBuilder.java
@@ -55,8 +55,8 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
 
     @Override
     public Scan build() {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Creating new scan");
+        if (logger.isTraceEnabled()) {
+            logger.trace("Creating new scan");
         }
         return new OpticScan(opticReadContext);
     }

--- a/src/main/java/com/marklogic/spark/reader/optic/PlanUtil.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/PlanUtil.java
@@ -29,9 +29,7 @@ import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -72,7 +70,13 @@ public abstract class PlanUtil {
     private PlanUtil() {
     }
 
-    static ObjectNode buildGroupByAggregation(List<String> columnNames, Aggregation aggregation) {
+    /**
+     * @param columnNames a set of unique column names is needed as Optic will otherwise throw an error via a
+     *                    "duplicate check" per a fix for https://bugtrack.marklogic.com/56662 .
+     * @param aggregation
+     * @return
+     */
+    static ObjectNode buildGroupByAggregation(Set<String> columnNames, Aggregation aggregation) {
         return newOperation("group-by", groupByArgs -> {
             ArrayNode columns = groupByArgs.addArray();
             columnNames.forEach(columnName -> populateSchemaCol(columns.addObject(), columnName));

--- a/src/test/java/com/marklogic/spark/reader/optic/GroupByDuplicateColumnNamesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/GroupByDuplicateColumnNamesTest.java
@@ -1,0 +1,85 @@
+package com.marklogic.spark.reader.optic;
+
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GroupByDuplicateColumnNamesTest extends AbstractPushDownTest {
+
+    @Test
+    void sameColumnNameTwice() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'Authors', '')")
+            .load()
+            .groupBy("CitationID", "CitationID")
+            .sum("LuckyNumber")
+            .orderBy("CitationID")
+            .collectAsList();
+
+        assertEquals(5, rows.size(), "This verifies that the duplicate groupBy column name is not passed to Optic, " +
+            "which would cause an error of 'Grouping key shouldn't have duplicates'.");
+        assertRowsReadFromMarkLogic(5, "The groupBy/sum should have been pushed down.");
+
+        String message = "The first two columns are expected to both be named " +
+            "'CitationID', which is a little surprising but appears to be expected by Spark. And the " +
+            "columns should have the same CitationID value.";
+        for (int i = 0; i < 5; i++) {
+            Row row = rows.get(i);
+            int expectedCitationID = i + 1;
+            assertEquals(expectedCitationID, row.getLong(0), message);
+            assertEquals(expectedCitationID, row.getLong(1), message);
+        }
+    }
+
+    @Test
+    void sameColumnViaFieldReference() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'Authors', '')")
+            .load()
+            .withColumn("otherID", new Column("CitationID"))
+            .groupBy("otherID", "CitationID")
+            .sum("LuckyNumber")
+            .collectAsList();
+
+        assertEquals(5, rows.size());
+        assertRowsReadFromMarkLogic(5, "The groupBy/sum should have been pushed down.");
+
+        String message = "withColumn does not seem to work correctly for our connector when it only creates an alias. Our " +
+            "connector is not passed 'CitationID' and 'otherID', but rather it gets 'CitationID' twice. So our " +
+            "connector doesn't even know about 'otherID'. The connector then returns rows with the correct values for " +
+            "'CitationID' and 'SUM(LuckyNumber)', but for an unknown reason, JsonRowDeserializer does not copy the " +
+            "'CitationID' value into the 'CitationID' column. And it understandably leaves the 'otherID' column " +
+            "blank since it doesn't know about that column.";
+        rows.forEach(row -> {
+            assertEquals(0, row.getLong(0), message);
+            assertEquals(0, row.getLong(1), message);
+        });
+    }
+
+    @Test
+    void groupByTwoColumns() {
+        List<Row> rows = newDefaultReader()
+            .option(Options.READ_OPTIC_QUERY, "op.fromView('Medical', 'Authors', '')")
+            .load()
+            .withColumn("CitationIDPlusOne", new Column("CitationID").plus(1))
+            .groupBy("CitationID", "CitationIDPlusOne")
+            .sum("LuckyNumber")
+            .orderBy("CitationID")
+            .collectAsList();
+
+        assertEquals(5, rows.size());
+        assertRowsReadFromMarkLogic(15, "Surprisingly, Spark never calls pushDownAggregation in this scenario. The " +
+            "use of withColumn with a new set of values seems to prevent that, but it is not known why. We get back " +
+            "the correct data from Spark, but the groupBy/sum are not pushed down. ");
+        for (int i = 0; i < 5; i++) {
+            Row row = rows.get(i);
+            assertEquals(i + 1, row.getLong(0));
+            assertEquals(i + 2, row.getLong(1));
+        }
+    }
+}


### PR DESCRIPTION
Tweaked some debug/trace logging as well while testing this. 

Note the second test case - we're not able to support `withColumn` when it simply aliases another column. 