### PR TITLE
MLE-14516 User can now configure total thread count

### DIFF
--- a/src/main/java/com/marklogic/spark/ContextSupport.java
+++ b/src/main/java/com/marklogic/spark/ContextSupport.java
@@ -122,7 +122,7 @@ public class ContextSupport implements Serializable {
             long value = this.getProperties().containsKey(optionName) ?
                 Long.parseLong(this.getProperties().get(optionName)) :
                 defaultValue;
-            if (value < minimumValue) {
+            if (value != defaultValue && value < minimumValue) {
                 throw new ConnectorException(String.format("The value of '%s' must be %d or greater.", getOptionNameForMessage(optionName), minimumValue));
             }
             return value;

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -86,6 +86,7 @@ public abstract class Options {
 
     public static final String WRITE_BATCH_SIZE = "spark.marklogic.write.batchSize";
     public static final String WRITE_THREAD_COUNT = "spark.marklogic.write.threadCount";
+    public static final String WRITE_TOTAL_THREAD_COUNT = "spark.marklogic.write.totalThreadCount";
     public static final String WRITE_ABORT_ON_FAILURE = "spark.marklogic.write.abortOnFailure";
 
     // For writing via custom code.

--- a/src/main/resources/marklogic-spark-messages.properties
+++ b/src/main/resources/marklogic-spark-messages.properties
@@ -10,6 +10,7 @@ spark.marklogic.write.graph=
 spark.marklogic.write.graphOverride=
 spark.marklogic.write.jsonRootName=
 spark.marklogic.write.threadCount=
+spark.marklogic.write.totalThreadCount=
 spark.marklogic.write.transformParams=
 spark.marklogic.write.uriTemplate=
 spark.marklogic.write.xmlRootName=

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
@@ -23,7 +23,6 @@ import org.apache.spark.SparkException;
 import org.apache.spark.sql.DataFrameWriter;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -56,7 +55,10 @@ class WriteRowsTest extends AbstractWriteTest {
 
     @Test
     void twoPartitions() {
-        newWriter(2).save();
+        newWriter(2)
+            .option(Options.WRITE_TOTAL_THREAD_COUNT, 16)
+            .option(Options.WRITE_BATCH_SIZE, 10)
+            .save();
 
         // Just verifies that the operation succeeds with multiple partitions. Check the logging to see that two
         // partitions were in fact created, each with its own WriteBatcher.
@@ -122,9 +124,9 @@ class WriteRowsTest extends AbstractWriteTest {
     @Test
     void userNotPermittedToWriteAndFailOnCommit() {
         ConnectorException ex = assertThrowsConnectorException(() -> newWriter()
-                .option(Options.CLIENT_USERNAME, "spark-no-write-user")
-                .option(Options.WRITE_BATCH_SIZE, 500)
-                .save()
+            .option(Options.CLIENT_USERNAME, "spark-no-write-user")
+            .option(Options.WRITE_BATCH_SIZE, 500)
+            .save()
         );
 
         verifyFailureIsDueToLackOfPermission(ex);
@@ -152,10 +154,10 @@ class WriteRowsTest extends AbstractWriteTest {
     @Test
     void userNotPermittedToWriteAndFailOnWrite() {
         ConnectorException ex = assertThrowsConnectorException(() -> newWriter()
-                .option(Options.CLIENT_USERNAME, "spark-no-write-user")
-                .option(Options.WRITE_BATCH_SIZE, 1)
-                .option(Options.WRITE_THREAD_COUNT, 1)
-                .save()
+            .option(Options.CLIENT_USERNAME, "spark-no-write-user")
+            .option(Options.WRITE_BATCH_SIZE, 1)
+            .option(Options.WRITE_THREAD_COUNT, 1)
+            .save()
         );
 
         verifyFailureIsDueToLackOfPermission(ex);


### PR DESCRIPTION
We may not stick with this name. In hindsight, it would be better if `threadCount` referred to this number so a user didn't need to think about partitions, and we could have `partitionThreadCount` as well. 