### PR TITLE
MLE-14384 User can now force document type

### DIFF
--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -118,9 +118,19 @@ public abstract class Options {
     public static final String WRITE_GRAPH = "spark.marklogic.write.graph";
     public static final String WRITE_GRAPH_OVERRIDE = "spark.marklogic.write.graphOverride";
 
-    // For writing rows adhering to Spark's binaryFile schema - https://spark.apache.org/docs/latest/sql-data-sources-binaryFile.html .
-    // This was introduced in 2.2.0 and unfortunately uses "fileRows" instead of "binaryFileRows".
+    /**
+     * For writing rows adhering to Spark's binaryFile schema - https://spark.apache.org/docs/latest/sql-data-sources-binaryFile.html .
+     *
+     * @deprecated since 2.3.0
+     */
+    @Deprecated(since = "2.3.0", forRemoval = true)
+    // We don't need Sonar to remind us of this deprecation.
+    @SuppressWarnings("java:S1133")
     public static final String WRITE_FILE_ROWS_DOCUMENT_TYPE = "spark.marklogic.write.fileRows.documentType";
+
+    // Forces a document type when writing rows corresponding to our document row schema. Used when the URI extension
+    // does not result in MarkLogic choosing the correct document type.
+    public static final String WRITE_DOCUMENT_TYPE = "spark.marklogic.write.documentType";
 
     // For writing rows adhering to {@code DocumentRowSchema} or {@code TripleRowSchema} to a filesystem.
     public static final String WRITE_FILES_COMPRESSION = "spark.marklogic.write.files.compression";

--- a/src/main/java/com/marklogic/spark/writer/DocumentRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/DocumentRowConverter.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.io.BytesHandle;
 import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.spark.Options;
 import com.marklogic.spark.Util;
 import com.marklogic.spark.reader.document.DocumentRowSchema;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -21,9 +23,11 @@ class DocumentRowConverter implements RowConverter {
 
     private final ObjectMapper objectMapper;
     private final String uriTemplate;
+    private final Format documentFormat;
 
-    DocumentRowConverter(String uriTemplate) {
-        this.uriTemplate = uriTemplate;
+    DocumentRowConverter(WriteContext writeContext) {
+        this.uriTemplate = writeContext.getStringOption(Options.WRITE_URI_TEMPLATE);
+        this.documentFormat = writeContext.getDocumentFormat();
         this.objectMapper = new ObjectMapper();
     }
 
@@ -35,11 +39,19 @@ class DocumentRowConverter implements RowConverter {
                 "once the MarkLogic Java Client 6.6.1 is available.", uri);
             return Optional.empty();
         }
+
         final BytesHandle content = new BytesHandle(row.getBinary(1));
-        String format = row.isNullAt(2) ? null : row.getString(2);
-        Optional<JsonNode> uriTemplateValues = deserializeContentToJson(uri, content, format);
+        if (this.documentFormat != null) {
+            content.withFormat(this.documentFormat);
+        }
+
+        JsonNode uriTemplateValues = null;
+        if (this.uriTemplate != null && this.uriTemplate.trim().length() > 0) {
+            String format = row.isNullAt(2) ? null : row.getString(2);
+            uriTemplateValues = deserializeContentToJson(uri, content, format);
+        }
         DocumentMetadataHandle metadata = DocumentRowSchema.makeDocumentMetadata(row);
-        return Optional.of(new DocBuilder.DocumentInputs(uri, content, uriTemplateValues.orElse(null), metadata));
+        return Optional.of(new DocBuilder.DocumentInputs(uri, content, uriTemplateValues, metadata));
     }
 
     @Override
@@ -47,13 +59,9 @@ class DocumentRowConverter implements RowConverter {
         return new ArrayList<>();
     }
 
-    private Optional<JsonNode> deserializeContentToJson(String initialUri, BytesHandle contentHandle, String format) {
-        if (this.uriTemplate == null || this.uriTemplate.trim().length() == 0 || contentHandle == null) {
-            return Optional.empty();
-        }
+    private JsonNode deserializeContentToJson(String initialUri, BytesHandle contentHandle, String format) {
         try {
-            JsonNode json = objectMapper.readTree(contentHandle.get());
-            return Optional.of(json);
+            return objectMapper.readTree(contentHandle.get());
         } catch (IOException e) {
             // Preserves the initial support in the 2.2.0 release.
             ObjectNode values = objectMapper.createObjectNode();
@@ -61,7 +69,7 @@ class DocumentRowConverter implements RowConverter {
             if (format != null) {
                 values.put("format", format);
             }
-            return Optional.of(values);
+            return values;
         }
     }
 }

--- a/src/main/java/com/marklogic/spark/writer/FileRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/FileRowConverter.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.io.BytesHandle;
 import com.marklogic.client.io.Format;
-import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.DataTypes;
@@ -44,15 +43,16 @@ class FileRowConverter implements RowConverter {
         return new ArrayList<>();
     }
 
+    // Telling Sonar to not tell us to remove this code, since we can't until 3.0.
+    @SuppressWarnings("java:S1874")
     private void forceFormatIfNecessary(BytesHandle content) {
-        if (writeContext.hasOption(Options.WRITE_FILE_ROWS_DOCUMENT_TYPE)) {
-            String value = writeContext.getProperties().get(Options.WRITE_FILE_ROWS_DOCUMENT_TYPE);
-            try {
-                content.withFormat(Format.valueOf(value.toUpperCase()));
-            } catch (IllegalArgumentException e) {
-                String message = "Invalid value for %s: %s; must be one of 'JSON', 'XML', or 'TEXT'.";
-                String optionAlias = writeContext.getOptionNameForMessage(Options.WRITE_FILE_ROWS_DOCUMENT_TYPE);
-                throw new ConnectorException(String.format(message, optionAlias, value));
+        Format format = writeContext.getDocumentFormat();
+        if (format != null) {
+            content.withFormat(format);
+        } else {
+            format = writeContext.getDeprecatedFileRowsDocumentFormat();
+            if (format != null) {
+                content.withFormat(format);
             }
         }
     }

--- a/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
@@ -161,7 +161,7 @@ class WriteBatcherDataWriter implements DataWriter<InternalRow> {
         if (writeContext.isUsingFileSchema()) {
             return new FileRowConverter(writeContext);
         } else if (DocumentRowSchema.SCHEMA.equals(writeContext.getSchema())) {
-            return new DocumentRowConverter(writeContext.getStringOption(Options.WRITE_URI_TEMPLATE));
+            return new DocumentRowConverter(writeContext);
         } else if (TripleRowSchema.SCHEMA.equals(writeContext.getSchema())) {
             return new RdfRowConverter(writeContext);
         }

--- a/src/main/java/com/marklogic/spark/writer/WriteContext.java
+++ b/src/main/java/com/marklogic/spark/writer/WriteContext.java
@@ -23,6 +23,7 @@ import com.marklogic.client.datamovement.WriteEvent;
 import com.marklogic.client.document.GenericDocumentManager;
 import com.marklogic.client.document.ServerTransform;
 import com.marklogic.client.impl.GenericDocumentImpl;
+import com.marklogic.client.io.Format;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.ContextSupport;
 import com.marklogic.spark.Options;
@@ -115,6 +116,41 @@ public class WriteContext extends ContextSupport {
         }
 
         return factory.newDocBuilder();
+    }
+
+    Format getDocumentFormat() {
+        if (hasOption(Options.WRITE_DOCUMENT_TYPE)) {
+            String value = getStringOption(Options.WRITE_DOCUMENT_TYPE);
+            try {
+                return Format.valueOf(value.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                String message = "Invalid value for %s: %s; must be one of 'JSON', 'XML', or 'TEXT'.";
+                String optionAlias = getOptionNameForMessage(Options.WRITE_DOCUMENT_TYPE);
+                throw new ConnectorException(String.format(message, optionAlias, value));
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @deprecated since 2.3.0; users should use getDocumentFormat instead.
+     */
+    @Deprecated(since = "2.3.0")
+    // We don't need Sonar to remind us of this deprecation.
+    @SuppressWarnings("java:S1133")
+    Format getDeprecatedFileRowsDocumentFormat() {
+        final String deprecatedOption = Options.WRITE_FILE_ROWS_DOCUMENT_TYPE;
+        if (hasOption(deprecatedOption)) {
+            String value = getStringOption(deprecatedOption);
+            try {
+                return Format.valueOf(value.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                String message = "Invalid value for %s: %s; must be one of 'JSON', 'XML', or 'TEXT'.";
+                String optionAlias = getOptionNameForMessage(deprecatedOption);
+                throw new ConnectorException(String.format(message, optionAlias, value));
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/resources/marklogic-spark-messages.properties
+++ b/src/main/resources/marklogic-spark-messages.properties
@@ -5,6 +5,7 @@ spark.marklogic.read.batchSize=
 spark.marklogic.read.documents.partitionsPerForest=
 spark.marklogic.read.numPartitions=
 spark.marklogic.write.batchSize=
+spark.marklogic.write.documentType=
 spark.marklogic.write.fileRows.documentType=
 spark.marklogic.write.graph=
 spark.marklogic.write.graphOverride=


### PR DESCRIPTION
Deprecated the "fileRows" option, as "documentType" is now useful any time we're writing document rows and the user wants to force a document type when MarkLogic cannot determine one. 