### PR TITLE
Added logging of progress

### DIFF
--- a/src/main/java/com/marklogic/spark/ContextSupport.java
+++ b/src/main/java/com/marklogic/spark/ContextSupport.java
@@ -121,7 +121,7 @@ public class ContextSupport implements Serializable {
         }
     }
 
-    protected final long getNumericOption(String optionName, long defaultValue, long minimumValue) {
+    public final long getNumericOption(String optionName, long defaultValue, long minimumValue) {
         try {
             long value = this.getProperties().containsKey(optionName) ?
                 Long.parseLong(this.getProperties().get(optionName)) :

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -90,6 +90,9 @@ public abstract class Options {
     public static final String WRITE_TOTAL_THREAD_COUNT = "spark.marklogic.write.totalThreadCount";
     public static final String WRITE_ABORT_ON_FAILURE = "spark.marklogic.write.abortOnFailure";
 
+    // For logging progress when writing documents or processing with custom code.
+    public static final String WRITE_LOG_PROGRESS = "spark.marklogic.write.logProgress";
+
     // For writing via custom code.
     public static final String WRITE_INVOKE = "spark.marklogic.write.invoke";
     public static final String WRITE_JAVASCRIPT = "spark.marklogic.write.javascript";

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
@@ -39,6 +39,18 @@ class WriteRowsTest extends AbstractWriteTest {
     }
 
     @Test
+    void logProgressTest() {
+        newWriter(2)
+            // Including these options here to ensure they don't cause any issues, though we're not yet able to
+            // assert on the info-level log entries that they add.
+            .option(Options.WRITE_BATCH_SIZE, 8)
+            .option(Options.WRITE_LOG_PROGRESS, 50)
+            .save();
+
+        verifyTwoHundredDocsWereWritten();
+    }
+
+    @Test
     void batchSizeGreaterThanNumberOfRowsToWrite() {
         newWriter()
             .option(Options.WRITE_BATCH_SIZE, 1000)
@@ -128,7 +140,7 @@ class WriteRowsTest extends AbstractWriteTest {
     @Test
     void invalidBatchSize() {
         DataFrameWriter writer = newWriter().option(Options.WRITE_BATCH_SIZE, 0);
-        ConnectorException ex = assertThrowsConnectorException(() -> writer.save());
+        ConnectorException ex = assertThrows(ConnectorException.class, () -> writer.save());
         assertEquals("The value of 'spark.marklogic.write.batchSize' must be 1 or greater.", ex.getMessage(),
             "Note that batchSize is very different for writing than it is for reading. For writing, it specifies the " +
                 "exact number of documents to send to MarkLogic in each call. For reading, it used to determine how " +

--- a/src/test/java/com/marklogic/spark/writer/customcode/ProcessWithCustomCodeTest.java
+++ b/src/test/java/com/marklogic/spark/writer/customcode/ProcessWithCustomCodeTest.java
@@ -17,6 +17,25 @@ import static org.junit.jupiter.api.Assertions.*;
 class ProcessWithCustomCodeTest extends AbstractWriteTest {
 
     @Test
+    void logProgressTest() {
+        newSparkSession().read().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_XQUERY, "for $i in 1 to 100 return $i")
+            .load()
+            .write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            // With "uneven" numbers like this, the user will still see 5 progress entries, but the counts won't even -
+            // they'll be 24, 40, 64, 80, and 100.
+            .option(Options.WRITE_BATCH_SIZE, 8)
+            .option(Options.WRITE_LOG_PROGRESS, 20)
+            .option(Options.WRITE_JAVASCRIPT, "var URI; console.log('Nothing to do here.')")
+            .mode(SaveMode.Append)
+            .save();
+
+        assertTrue(true, "No assertion needed, this test is only for manual inspection of the progress log entries.");
+    }
+
+    @Test
     void invokeJavaScript() {
         newWriterWithDefaultConfig("three-uris.csv", 2)
             .option(Options.WRITE_INVOKE, "/processUri.sjs")


### PR DESCRIPTION
Works for writing documents (the main use case) and reprocessing data (also a good use case). Not doing anything for exporting yet because in most cases in Flux, we don't have control over the data source used for writing.