### PR TITLE
Removed scala-java8-compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,13 +57,6 @@ dependencies {
   // Need this so that an OkHttpClientConfigurator can be created.
   shadowDependencies 'com.squareup.okhttp3:okhttp:4.12.0'
 
-  // Makes it possible to use lambdas in Java 8 to implement Spark's Function1 and Function2 interfaces
-  // See https://github.com/scala/scala-java8-compat for more information
-  shadowDependencies("org.scala-lang.modules:scala-java8-compat_2.12:1.0.2") {
-    // Prefer the Scala libraries used within the user's Spark runtime.
-    exclude module: "scala-library"
-  }
-
   shadowDependencies ("org.apache.jena:jena-arq:4.10.0") {
     exclude group: "com.fasterxml.jackson.core"
     exclude group: "com.fasterxml.jackson.dataformat"

--- a/src/main/java/com/marklogic/spark/reader/JsonRowDeserializer.java
+++ b/src/main/java/com/marklogic/spark/reader/JsonRowDeserializer.java
@@ -13,7 +13,6 @@ import scala.Function1;
 import scala.Function2;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
-import scala.compat.java8.JFunction;
 
 import java.util.ArrayList;
 
@@ -33,17 +32,10 @@ public class JsonRowDeserializer {
     private final Function2<JsonFactory, String, JsonParser> jsonParserCreator;
     private final Function1<String, UTF8String> utf8StringCreator;
 
-    // Ignoring warnings about JFunction.func until an alternative can be found.
-    @SuppressWarnings("java:S1874")
     public JsonRowDeserializer(StructType schema) {
         this.jacksonParser = newJacksonParser(schema);
-
-        // Used https://github.com/scala/scala-java8-compat in the DHF Spark 2 connector. Per the README for
-        // scala-java8-compat, we should be able to use scala.jdk.FunctionConverters since those are part of Scala
-        // 2.13. However, that is not yet working within PySpark. So sticking with this "legacy" approach as it seems
-        // to work fine in both vanilla Spark (i.e. JUnit tests) and PySpark.
-        this.jsonParserCreator = JFunction.func(CreateJacksonParser::string);
-        this.utf8StringCreator = JFunction.func(UTF8String::fromString);
+        this.jsonParserCreator = CreateJacksonParser::string;
+        this.utf8StringCreator = UTF8String::fromString;
     }
 
     public InternalRow deserializeJson(String json) {


### PR DESCRIPTION
No longer needed as we only support Java 11 or higher. This was a shim only needed for Java 8 support.
