### PR TITLE
Can now include null fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,8 @@ dependencies {
     exclude group: "com.fasterxml.jackson.dataformat"
   }
 
-  // For XML support; supports converting a string of JSON into a string of XML.
-  // See ArbitraryRowConverter for more information.
-  shadowDependencies "org.json:json:20240303"
+  // Required for converting JSON to XML. Using 2.14.2 to align with Spark 3.4.1.
+  shadowDependencies "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.2"
 
   // Need this so that an OkHttpClientConfigurator can be created.
   shadowDependencies 'com.squareup.okhttp3:okhttp:4.12.0'

--- a/src/main/java/com/marklogic/spark/JsonRowSerializer.java
+++ b/src/main/java/com/marklogic/spark/JsonRowSerializer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.spark;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.json.JSONOptions;
+import org.apache.spark.sql.catalyst.json.JacksonGenerator;
+import org.apache.spark.sql.types.StructType;
+import scala.Predef;
+import scala.collection.JavaConverters;
+
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Handles serializing a Spark row into a JSON string. Includes support for all the options defined in Spark's
+ * JSONOptions.scala class.
+ */
+public class JsonRowSerializer {
+
+    private final StructType schema;
+    private final JSONOptions jsonOptions;
+    private final boolean includeNullFields;
+
+    public JsonRowSerializer(StructType schema, Map<String, String> connectorProperties) {
+        this.schema = schema;
+
+        final Map<String, String> options = buildOptionsForJsonOptions(connectorProperties);
+        this.includeNullFields = "false".equalsIgnoreCase(options.get("ignoreNullFields"));
+
+        this.jsonOptions = new JSONOptions(
+            // Funky code to convert a Java map into a Scala immutable Map.
+            JavaConverters.mapAsScalaMapConverter(options).asScala().toMap(Predef.$conforms()),
+
+            // As verified via tests, this default timezone ID is overridden by a user via
+            // the spark.sql.session.timeZone option.
+            "Z",
+
+            // We don't expect corrupted records - i.e. corrupted values - to be present in the index. But Spark
+            // requires this to be set. See
+            // https://medium.com/@sasidharan-r/how-to-handle-corrupt-or-bad-record-in-apache-spark-custom-logic-pyspark-aws-430ddec9bb41
+            // for more information.
+            "_corrupt_record"
+        );
+    }
+
+    public String serializeRowToJson(InternalRow row) {
+        StringWriter writer = new StringWriter();
+        JacksonGenerator jacksonGenerator = new JacksonGenerator(this.schema, writer, this.jsonOptions);
+        jacksonGenerator.write(row);
+        jacksonGenerator.flush();
+        return writer.toString();
+    }
+
+    /**
+     * A user can specify any of the options found in the JSONOptions.scala class - though it's not yet clear where
+     * a user finds out about these except via the Spark source code. "ignoreNullFields" however is expected to be the
+     * primary one that is configured.
+     */
+    private Map<String, String> buildOptionsForJsonOptions(Map<String, String> connectorProperties) {
+        Map<String, String> options = new HashMap<>();
+        connectorProperties.forEach((key, value) -> {
+            if (key.startsWith(Options.WRITE_JSON_SERIALIZATION_OPTION_PREFIX)) {
+                String optionName = key.substring(Options.WRITE_JSON_SERIALIZATION_OPTION_PREFIX.length());
+                options.put(optionName, value);
+            }
+        });
+        return options;
+    }
+
+    public JSONOptions getJsonOptions() {
+        return jsonOptions;
+    }
+
+    public boolean isIncludeNullFields() {
+        return this.includeNullFields;
+    }
+}

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -119,6 +119,12 @@ public abstract class Options {
     public static final String WRITE_XML_ROOT_NAME = "spark.marklogic.write.xmlRootName";
     public static final String WRITE_XML_NAMESPACE = "spark.marklogic.write.xmlNamespace";
 
+    // For serializing a row into JSON. Intent is to allow for other constants defined in the Spark
+    // JSONOptions.scala class to be used after "spark.marklogic.write.json."
+    // Example - "spark.marklogic.write.json.ignoreNullFields=false.
+    public static final String WRITE_JSON_SERIALIZATION_OPTION_PREFIX = "spark.marklogic.write.json.";
+
+
     // For writing RDF
     public static final String WRITE_GRAPH = "spark.marklogic.write.graph";
     public static final String WRITE_GRAPH_OVERRIDE = "spark.marklogic.write.graphOverride";

--- a/src/main/java/com/marklogic/spark/Util.java
+++ b/src/main/java/com/marklogic/spark/Util.java
@@ -15,10 +15,8 @@
  */
 package com.marklogic.spark;
 
-import org.apache.spark.sql.catalyst.json.JSONOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.collection.immutable.HashMap;
 
 import java.util.*;
 import java.util.stream.Stream;
@@ -30,19 +28,6 @@ public interface Util {
      * messages.
      */
     Logger MAIN_LOGGER = LoggerFactory.getLogger("com.marklogic.spark");
-
-    JSONOptions DEFAULT_JSON_OPTIONS = new JSONOptions(
-        new HashMap<>(),
-
-        // As verified via tests, this default timezone ID is overridden by a user via the spark.sql.session.timeZone option.
-        "Z",
-
-        // We don't expect corrupted records - i.e. corrupted values - to be present in the index. But Spark
-        // requires this to be set. See
-        // https://medium.com/@sasidharan-r/how-to-handle-corrupt-or-bad-record-in-apache-spark-custom-logic-pyspark-aws-430ddec9bb41
-        // for more information.
-        "_corrupt_record"
-    );
 
     static boolean hasOption(Map<String, String> properties, String... options) {
         return Stream.of(options)

--- a/src/main/java/com/marklogic/spark/reader/JsonRowDeserializer.java
+++ b/src/main/java/com/marklogic/spark/reader/JsonRowDeserializer.java
@@ -2,9 +2,10 @@ package com.marklogic.spark.reader;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import com.marklogic.spark.Util;
+import com.marklogic.spark.JsonRowSerializer;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.json.CreateJacksonParser;
+import org.apache.spark.sql.catalyst.json.JSONOptions;
 import org.apache.spark.sql.catalyst.json.JacksonParser;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructType;
@@ -15,6 +16,7 @@ import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 /**
  * Handles deserializing a JSON object into a Spark InternalRow. This is accomplished via Spark's JacksonParser.
@@ -45,6 +47,7 @@ public class JsonRowDeserializer {
     private JacksonParser newJacksonParser(StructType schema) {
         final boolean allowArraysAsStructs = true;
         final Seq<Filter> filters = JavaConverters.asScalaIterator(new ArrayList<Filter>().iterator()).toSeq();
-        return new JacksonParser(schema, Util.DEFAULT_JSON_OPTIONS, allowArraysAsStructs, filters);
+        JSONOptions jsonOptions = new JsonRowSerializer(schema, new HashMap<>()).getJsonOptions();
+        return new JacksonParser(schema, jsonOptions, allowArraysAsStructs, filters);
     }
 }

--- a/src/main/java/com/marklogic/spark/writer/ArbitraryRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/ArbitraryRowConverter.java
@@ -1,23 +1,21 @@
 package com.marklogic.spark.writer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.JsonRowSerializer;
 import com.marklogic.spark.Options;
-import com.marklogic.spark.Util;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.catalyst.json.JacksonGenerator;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.json.JSONObject;
-import org.json.XML;
 
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -32,24 +30,23 @@ class ArbitraryRowConverter implements RowConverter {
     private static final String MARKLOGIC_SPARK_FILE_PATH_COLUMN_NAME = "marklogic_spark_file_path";
 
     private final ObjectMapper objectMapper;
-
-    private final StructType schema;
+    private final XmlMapper xmlMapper;
+    private final JsonRowSerializer jsonRowSerializer;
     private final String uriTemplate;
     private final String jsonRootName;
     private final String xmlRootName;
     private final String xmlNamespace;
-
     private final int filePathIndex;
 
     ArbitraryRowConverter(WriteContext writeContext) {
-        this.schema = writeContext.getSchema();
-        this.filePathIndex = determineFilePathIndex();
-
+        this.filePathIndex = determineFilePathIndex(writeContext.getSchema());
         this.uriTemplate = writeContext.getStringOption(Options.WRITE_URI_TEMPLATE);
         this.jsonRootName = writeContext.getStringOption(Options.WRITE_JSON_ROOT_NAME);
         this.xmlRootName = writeContext.getStringOption(Options.WRITE_XML_ROOT_NAME);
         this.xmlNamespace = writeContext.getStringOption(Options.WRITE_XML_NAMESPACE);
         this.objectMapper = new ObjectMapper();
+        this.xmlMapper = this.xmlRootName != null ? new XmlMapper() : null;
+        this.jsonRowSerializer = new JsonRowSerializer(writeContext.getSchema(), writeContext.getProperties());
     }
 
     @Override
@@ -60,26 +57,49 @@ class ArbitraryRowConverter implements RowConverter {
             row.setNullAt(this.filePathIndex);
         }
 
-        final String json = convertRowToJSONString(row);
-        AbstractWriteHandle contentHandle = this.xmlRootName != null ?
-            new StringHandle(convertJsonToXml(json)).withFormat(Format.XML) :
-            new StringHandle(json).withFormat(Format.JSON);
+        final String json = this.jsonRowSerializer.serializeRowToJson(row);
 
+        AbstractWriteHandle contentHandle = null;
+        ObjectNode deserializedJson = null;
         ObjectNode uriTemplateValues = null;
-        if (this.uriTemplate != null || this.jsonRootName != null) {
-            ObjectNode jsonObject = readTree(json);
-            if (this.uriTemplate != null) {
-                uriTemplateValues = jsonObject;
-            }
-            if (this.jsonRootName != null) {
-                ObjectNode root = objectMapper.createObjectNode();
-                root.set(jsonRootName, jsonObject);
-                contentHandle = new JacksonHandle(root);
-                if (this.uriTemplate != null) {
-                    uriTemplateValues = root;
-                }
+        final boolean mustRemoveFilePathField = this.filePathIndex > 1 && jsonRowSerializer.isIncludeNullFields();
+
+        if (this.jsonRootName != null || this.xmlRootName != null || this.uriTemplate != null || mustRemoveFilePathField) {
+            deserializedJson = readTree(json);
+            if (mustRemoveFilePathField) {
+                deserializedJson.remove(MARKLOGIC_SPARK_FILE_PATH_COLUMN_NAME);
             }
         }
+
+        if (this.uriTemplate != null) {
+            uriTemplateValues = deserializedJson;
+        }
+
+        if (this.jsonRootName != null) {
+            ObjectNode jsonObjectWithRootName = objectMapper.createObjectNode();
+            jsonObjectWithRootName.set(jsonRootName, deserializedJson);
+            contentHandle = new JacksonHandle(jsonObjectWithRootName);
+            if (this.uriTemplate != null) {
+                uriTemplateValues = jsonObjectWithRootName;
+            }
+        }
+
+        if (contentHandle == null) {
+            // If the user wants XML, then we've definitely deserialized the JSON and removed the file path if
+            // needed. So use that JsonNode to produce an XML string.
+            if (xmlRootName != null) {
+                contentHandle = new StringHandle(convertJsonToXml(deserializedJson)).withFormat(Format.XML);
+            }
+            // If we've already gone to the effort of creating deserializedJson, use it for the content.
+            else if (deserializedJson != null) {
+                contentHandle = new JacksonHandle(deserializedJson);
+            } else {
+                // Simplest scenario where we never have a reason to incur the expense of deserializing the JSON string,
+                // so we can just use StringHandle.
+                contentHandle = new StringHandle(json).withFormat(Format.JSON);
+            }
+        }
+
         return Optional.of(new DocBuilder.DocumentInputs(initialUri, contentHandle, uriTemplateValues, null));
     }
 
@@ -98,7 +118,7 @@ class ArbitraryRowConverter implements RowConverter {
      *
      * @return
      */
-    private int determineFilePathIndex() {
+    private int determineFilePathIndex(StructType schema) {
         StructField[] fields = schema.fields();
         for (int i = 0; i < fields.length; i++) {
             if (MARKLOGIC_SPARK_FILE_PATH_COLUMN_NAME.equals(fields[i].name())) {
@@ -118,33 +138,29 @@ class ArbitraryRowConverter implements RowConverter {
         }
     }
 
-    private String convertRowToJSONString(InternalRow row) {
-        StringWriter writer = new StringWriter();
-        JacksonGenerator jacksonGenerator = new JacksonGenerator(this.schema, writer, Util.DEFAULT_JSON_OPTIONS);
-        jacksonGenerator.write(row);
-        jacksonGenerator.flush();
-        return writer.toString();
-    }
-
     /**
      * jackson-xml-mapper unfortunately does not yet support a root namespace. Nor does it allow for the root element
      * to be omitted. So we always end up with "ObjectNode" as a root element. See
-     * https://github.com/FasterXML/jackson-dataformat-xml/issues/541 for more information.
-     * <p>
-     * While JSON-Java does not support a root namespace, it does allow for the root element to be omitted. That is
-     * sufficient for us, as we can then generate our own root element - albeit via string concatentation - that
-     * includes a user-defined namespace.
+     * https://github.com/FasterXML/jackson-dataformat-xml/issues/541 for more information. So this method does some
+     * work to replace that root element with one based on user inputs.
      *
-     * @param json
+     * @param doc
      * @return
      */
-    private String convertJsonToXml(String json) {
-        JSONObject jsonObject = new JSONObject(json);
-        if (this.xmlNamespace != null) {
-            StringBuilder xml = new StringBuilder(String.format("<%s xmlns='%s'>", this.xmlRootName, this.xmlNamespace));
-            xml.append(XML.toString(jsonObject, null));
-            return xml.append(String.format("</%s>", this.xmlRootName)).toString();
+    private String convertJsonToXml(JsonNode doc) {
+        try {
+            String xml = xmlMapper.writer().writeValueAsString(doc);
+            String startTag = this.xmlNamespace != null ?
+                String.format("<%s xmlns='%s'>", this.xmlRootName, this.xmlNamespace) :
+                String.format("<%s>", this.xmlRootName);
+            return new StringBuilder(startTag)
+                .append(xml.substring("<ObjectNode>".length(), xml.length() - "</ObjectNode>".length()))
+                .append(String.format("</%s>", this.xmlRootName))
+                .toString();
+        } catch (JsonProcessingException e) {
+            // We don't expect this occur; Jackson should be able to convert any JSON object that it created into
+            // a valid XML document.
+            throw new ConnectorException(String.format("Unable to convert JSON to XML for doc: %s", doc), e);
         }
-        return XML.toString(jsonObject, this.xmlRootName);
     }
 }

--- a/src/test/java/com/marklogic/spark/writer/WriteNullValuesTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteNullValuesTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.spark.writer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.marklogic.junit5.XmlNode;
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.SaveMode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class WriteNullValuesTest extends AbstractIntegrationTest {
+
+    @Test
+    void jsonWithEmptyValues() {
+        newSparkSession().read()
+            .option("header", "true")
+            .option("inferSchema", "true")
+            .csv("src/test/resources/csv-files/empty-values.csv")
+            // Add the special file path column so we can verify it's not included in the JSON.
+            .withColumn("marklogic_spark_file_path", new Column("_metadata.file_path"))
+            .write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
+            .option(Options.WRITE_URI_TEMPLATE, "/a/{number}.json")
+            .option(Options.WRITE_JSON_SERIALIZATION_OPTION_PREFIX + "ignoreNullFields", "false")
+            .mode(SaveMode.Append)
+            .save();
+
+        JsonNode doc = readJsonDocument("/a/1.json");
+        assertEquals(1, doc.get("number").asInt());
+        assertEquals("blue", doc.get("color").asText());
+        assertEquals(JsonNodeType.NULL, doc.get("flag").getNodeType());
+        assertEquals(3, doc.size(), "The file path column should not be included in the serialization.");
+
+        doc = readJsonDocument("/a/2.json");
+        assertEquals(2, doc.get("number").asInt());
+        assertEquals(" ", doc.get("color").asText(), "Verifies that whitespace is retained by default.");
+        assertFalse(doc.get("flag").asBoolean());
+        assertEquals(3, doc.size(), "The file path column should not be included in the serialization.");
+    }
+
+    @Test
+    void xmlWithEmptyValues() {
+        newSparkSession().read()
+            .option("header", "true")
+            .option("inferSchema", "true")
+            .csv("src/test/resources/csv-files/empty-values.csv")
+            .withColumn("marklogic_spark_file_path", new Column("_metadata.file_path"))
+            .write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
+            .option(Options.WRITE_XML_ROOT_NAME, "test")
+            .option(Options.WRITE_URI_TEMPLATE, "/a/{number}.xml")
+            .option(Options.WRITE_JSON_SERIALIZATION_OPTION_PREFIX + "ignoreNullFields", "false")
+            .mode(SaveMode.Append)
+            .save();
+
+        XmlNode doc = readXmlDocument("/a/1.xml");
+        doc.assertElementValue(
+            "The empty flag column should be retained due to ignoreNullFields=true",
+            "/test/flag", "");
+        doc.assertElementValue("/test/number", "1");
+        doc.assertElementValue("/test/color", "blue");
+
+        // This is oddly misleading and won't show the whitespace in an element.
+        doc = readXmlDocument("/a/2.xml");
+        doc.assertElementValue("/test/number", "2");
+        doc.assertElementValue("/test/color", " ");
+        doc.assertElementValue("/test/flag", "false");
+    }
+
+    @Test
+    void jsonLinesWithNestedFieldsConvertedToXml() {
+        newSparkSession().read()
+            .option("ignoreNullFields", "false")
+            .json("src/test/resources/json-lines/nested-objects.txt")
+            .withColumn("marklogic_spark_file_path", new Column("_metadata.file_path"))
+            .write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
+            .option(Options.WRITE_XML_ROOT_NAME, "parent")
+            .option(Options.WRITE_URI_TEMPLATE, "/a/{id}.xml")
+            .option(Options.WRITE_JSON_SERIALIZATION_OPTION_PREFIX + "ignoreNullFields", "false")
+            .mode(SaveMode.Append)
+            .save();
+
+        XmlNode doc = readXmlDocument("/a/1.xml");
+        doc.assertElementValue("/parent/data/color", "blue");
+        doc.assertElementValue("/parent/data/numbers[1]", "1");
+        doc.assertElementValue("/parent/data/numbers[2]", "2");
+        doc.assertElementValue("/parent/hello", "world");
+        doc.assertElementValue("/parent/id", "1");
+
+        doc = readXmlDocument("/a/2.xml");
+        doc.assertElementValue(
+            "'hello' is added even though it doesn't exist on the line. This is due to ignoreNullFields being false " +
+                "and Spark adding 'hello' to the schema since it appears on the first line.",
+            "/parent/hello", "");
+    }
+}

--- a/src/test/resources/csv-files/empty-values.csv
+++ b/src/test/resources/csv-files/empty-values.csv
@@ -1,0 +1,3 @@
+number,color,flag
+1,blue,
+2, ,false

--- a/src/test/resources/json-lines/nested-objects.txt
+++ b/src/test/resources/json-lines/nested-objects.txt
@@ -1,0 +1,2 @@
+{"id": 1, "data": {"color": "blue", "numbers": [1, 2]}, "hello": "world"}
+{"id": 2, "data": {"color": "green", "numbers": [2, 3]}}


### PR DESCRIPTION
Had to make a few changes:

1. Extracted the code for generating a Spark `JSONOptions` object along with the duplicated code for serializing a Spark row into JSON - that's all now in `JsonRowSerializer`. 
2. User can now specify `spark.marklogic.write.json.(name of option)=value` to include any option defined in Spark's `JSONOptions` class. The main one of interest is "ignoreNullFields". We'll include support for that in Flux via a new `--include-null-fields` option for some import commands (definitely for CSV). 
3. Reworked `ArbitraryRowConverter` to now happily use Jackson XML instead of the JSON library for converting JSON into an XML string. 