### PR TITLE
Defaulting to including null fields.

### DIFF
--- a/src/main/java/com/marklogic/spark/JsonRowSerializer.java
+++ b/src/main/java/com/marklogic/spark/JsonRowSerializer.java
@@ -61,6 +61,8 @@ public class JsonRowSerializer {
      */
     private Map<String, String> buildOptionsForJsonOptions(Map<String, String> connectorProperties) {
         Map<String, String> options = new HashMap<>();
+        // Default to include null fields, as they are easily queried in MarkLogic.
+        options.put("ignoreNullFields", "false");
         connectorProperties.forEach((key, value) -> {
             if (key.startsWith(Options.WRITE_JSON_SERIALIZATION_OPTION_PREFIX)) {
                 String optionName = key.substring(Options.WRITE_JSON_SERIALIZATION_OPTION_PREFIX.length());

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsWithFilePathTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsWithFilePathTest.java
@@ -45,7 +45,9 @@ class WriteRowsWithFilePathTest extends AbstractWriteTest {
 
             JsonNode doc = readJsonDocument(uri);
             assertEquals(2, doc.size(), "The marklogic_spark_file_path column should not have been used when " +
-                "constructing the JSON document.");
+                "constructing the JSON document. This includes when ignoreNullFields is set to false. We still want " +
+                "the column removed as the column is an implementation detail that should not be exposed to the user. " +
+                "If we ever want the file path to be included in the document, we'll add an explicit feature for that.");
             assertTrue(doc.has("docNum"));
             assertTrue(doc.has("docName"));
         });

--- a/src/test/java/com/marklogic/spark/writer/WriteSparkJsonTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteSparkJsonTest.java
@@ -32,6 +32,7 @@ class WriteSparkJsonTest extends AbstractWriteTest {
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
             .option(Options.WRITE_URI_TEMPLATE, "/spark-json/{number}.json")
+            .option(Options.WRITE_JSON_SERIALIZATION_OPTION_PREFIX + "ignoreNullFields", "true")
             .mode(SaveMode.Append)
             .save();
 
@@ -58,6 +59,7 @@ class WriteSparkJsonTest extends AbstractWriteTest {
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
             .option(Options.WRITE_URI_TEMPLATE, "/spark-json/{number}.json")
+            .option(Options.WRITE_JSON_SERIALIZATION_OPTION_PREFIX + "ignoreNullFields", "true")
             .mode(SaveMode.Append)
             .save();
 
@@ -80,6 +82,7 @@ class WriteSparkJsonTest extends AbstractWriteTest {
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
             .option(Options.WRITE_URI_TEMPLATE, "/spark-json/{number}.json")
+            .option(Options.WRITE_JSON_SERIALIZATION_OPTION_PREFIX + "ignoreNullFields", "true")
             .mode(SaveMode.Append)
             .save();
 


### PR DESCRIPTION
This matches MLCP behavior for delimited files. And null fields are easy to query on and thus useful. And a user can easily drop them as well if desired. 