### PR TITLE
Fixed progress logging bug

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,20 @@ df2.head()
 json.loads(df2.head()['content'])
 ```
 
+For a quick test of writing documents, use the following:
+
+```
+
+spark.read.option("header", True).csv("src/test/resources/data.csv")\
+    .repartition(2)\
+    .write.format("marklogic")\
+    .option("spark.marklogic.client.uri", "spark-test-user:spark@localhost:8000")\
+    .option("spark.marklogic.write.permissions", "spark-user-role,read,spark-user-role,update")\
+    .option("spark.marklogic.write.logProgress", 50)\
+    .option("spark.marklogic.write.batchSize", 10)\
+    .mode("append")\
+    .save()
+```
 
 # Testing against a local Spark cluster
 

--- a/src/main/java/com/marklogic/spark/DefaultSource.java
+++ b/src/main/java/com/marklogic/spark/DefaultSource.java
@@ -93,6 +93,7 @@ public class DefaultSource implements TableProvider, DataSourceRegister {
             return new MarkLogicTable(schema, properties);
         }
 
+        WriteProgressLogger.progressCounter.set(0);
         return new MarkLogicTable(new WriteContext(schema, properties));
     }
 

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -90,7 +90,9 @@ public abstract class Options {
     public static final String WRITE_THREAD_COUNT_PER_PARTITION = "spark.marklogic.write.threadCountPerPartition";
     public static final String WRITE_ABORT_ON_FAILURE = "spark.marklogic.write.abortOnFailure";
 
-    // For logging progress when writing documents or processing with custom code.
+    // For logging progress when writing documents or processing with custom code. Defines the interval at which
+    // progress should be logged - e.g. a value of 10,000 will result in a message being logged on every 10,000 items
+    // being written/processed.
     public static final String WRITE_LOG_PROGRESS = "spark.marklogic.write.logProgress";
 
     // For writing via custom code.

--- a/src/main/java/com/marklogic/spark/ProgressLogger.java
+++ b/src/main/java/com/marklogic/spark/ProgressLogger.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.spark;
+
+import java.io.Serializable;
+
+public abstract class ProgressLogger implements Serializable {
+
+    static final long serialVersionUID = 1;
+
+    private final long progressInterval;
+    private final int batchSize;
+    private final String message;
+
+    protected ProgressLogger(long progressInterval, int batchSize, String message) {
+        this.progressInterval = progressInterval;
+        this.batchSize = batchSize;
+        this.message = message;
+    }
+
+    protected abstract long getNewSum(long itemCount);
+
+    public void logProgressIfNecessary(long itemCount) {
+        if (this.progressInterval > 0) {
+            long sum = getNewSum(itemCount);
+            if (sum >= progressInterval) {
+                long lowerBound = sum / (this.progressInterval);
+                long upperBound = (lowerBound * this.progressInterval) + this.batchSize;
+                if (sum >= lowerBound && sum < upperBound) {
+                    Util.MAIN_LOGGER.info(message, sum);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/marklogic/spark/WriteProgressLogger.java
+++ b/src/main/java/com/marklogic/spark/WriteProgressLogger.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.spark;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class WriteProgressLogger extends ProgressLogger {
+
+    public static final AtomicLong progressCounter = new AtomicLong(0);
+
+    public WriteProgressLogger(long progressInterval, int batchSize, String message) {
+        super(progressInterval, batchSize, message);
+    }
+
+    @Override
+    protected long getNewSum(long itemCount) {
+        return progressCounter.addAndGet(itemCount);
+    }
+}

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
@@ -48,6 +48,12 @@ class WriteRowsTest extends AbstractWriteTest {
             .save();
 
         verifyTwoHundredDocsWereWritten();
+
+        // For manual inspection, run it again to ensure that the progress counter was reset.
+        newWriter(2)
+            .option(Options.WRITE_BATCH_SIZE, 10)
+            .option(Options.WRITE_LOG_PROGRESS, 40)
+            .save();
     }
 
     @Test


### PR DESCRIPTION
Realized in a Spark environment, the static for counting written docs wasn't getting reset. Did some refactoring to avoid duplicated code as well, and also to setup for potentially logging progress on reads.

Also defaulting the progress interval to 0 instead of 10000. This doesn't seem as useful in a Spark environment. Flux will default it to 10000 instead. 
