### PR TITLE
Now logging progress for read operations

### DIFF
--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -71,6 +71,11 @@ public abstract class Options {
     public static final String READ_TRIPLES_FILTERED = "spark.marklogic.read.triples.filtered";
     public static final String READ_TRIPLES_BASE_IRI = "spark.marklogic.read.triples.baseIri";
 
+    // For logging progress when reading documents, rows, or items via custom code. Defines the interval at which
+    // progress should be logged - e.g. a value of 10,000 will result in a message being logged on every 10,000 items
+    // being written/processed.
+    public static final String READ_LOG_PROGRESS = "spark.marklogic.read.logProgress";
+
     public static final String READ_FILES_TYPE = "spark.marklogic.read.files.type";
     public static final String READ_FILES_COMPRESSION = "spark.marklogic.read.files.compression";
     public static final String READ_FILES_ENCODING = "spark.marklogic.read.files.encoding";

--- a/src/main/java/com/marklogic/spark/ReadProgressLogger.java
+++ b/src/main/java/com/marklogic/spark/ReadProgressLogger.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.spark;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Handles the progress counter for any operation involving reading from MarkLogic. A Spark job/application can only have
+ * one reader, and thus DefaultSource handles resetting this counter before a new read job starts up. A static counter
+ * is used so that all reader partitions in the same JVM can have their progress aggregated and logged.
+ */
+public class ReadProgressLogger extends ProgressLogger {
+
+    public static final AtomicLong progressCounter = new AtomicLong(0);
+
+    public ReadProgressLogger(long progressInterval, int batchSize, String message) {
+        super(progressInterval, batchSize, message);
+    }
+
+    @Override
+    protected long getNewSum(long itemCount) {
+        return progressCounter.addAndGet(itemCount);
+    }
+}

--- a/src/main/java/com/marklogic/spark/WriteProgressLogger.java
+++ b/src/main/java/com/marklogic/spark/WriteProgressLogger.java
@@ -3,9 +3,13 @@
  */
 package com.marklogic.spark;
 
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+/**
+ * Handles the progress counter for any operation involving writing to MarkLogic. A Spark job/application can only have
+ * one writer, and thus DefaultSource handles resetting this counter before a new write job starts up. A static counter
+ * is used so that all writer partitions in the same JVM can have their progress aggregated and logged.
+ */
 public class WriteProgressLogger extends ProgressLogger {
 
     public static final AtomicLong progressCounter = new AtomicLong(0);

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticReadContext.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticReadContext.java
@@ -65,13 +65,14 @@ public class OpticReadContext extends ContextSupport {
     private StructType schema;
     private long serverTimestamp;
     private List<OpticFilter> opticFilters;
+    private final long batchSize;
 
     public OpticReadContext(Map<String, String> properties, StructType schema, int defaultMinPartitions) {
         super(properties);
         this.schema = schema;
 
         final long partitionCount = getNumericOption(Options.READ_NUM_PARTITIONS, defaultMinPartitions, 1);
-        final long batchSize = getNumericOption(Options.READ_BATCH_SIZE, DEFAULT_BATCH_SIZE, 0);
+        this.batchSize = getNumericOption(Options.READ_BATCH_SIZE, DEFAULT_BATCH_SIZE, 0);
 
         final String dslQuery = properties.get(Options.READ_OPTIC_QUERY);
         if (dslQuery == null || dslQuery.trim().length() < 1) {
@@ -282,5 +283,9 @@ public class OpticReadContext extends ContextSupport {
 
     long getBucketCount() {
         return planAnalysis != null ? planAnalysis.getAllBuckets().size() : 0;
+    }
+
+    long getBatchSize() {
+        return batchSize;
     }
 }

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
@@ -6,6 +6,7 @@ import com.marklogic.client.MarkLogicIOException;
 import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
+import com.marklogic.spark.writer.AbstractWriteTest;
 import org.apache.spark.SparkException;
 import org.apache.spark.sql.DataFrameReader;
 import org.apache.spark.sql.Dataset;
@@ -18,7 +19,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class ReadDocumentRowsTest extends AbstractIntegrationTest {
+class ReadDocumentRowsTest extends AbstractWriteTest {
 
     @Test
     void readByCollection() {
@@ -35,6 +36,20 @@ class ReadDocumentRowsTest extends AbstractIntegrationTest {
         // Verify just a couple fields to ensure the JSON object is correct.
         assertEquals(4, doc.get("CitationID").asInt());
         assertEquals("Vivianne", doc.get("ForeName").asText());
+    }
+
+    @Test
+    void logProgress() {
+        newWriter().save();
+
+        Dataset<Row> rows = startRead()
+            .option(Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST, 1)
+            .option(Options.READ_DOCUMENTS_COLLECTIONS, "write-test")
+            .option(Options.READ_BATCH_SIZE, 10)
+            .option(Options.READ_LOG_PROGRESS, 50)
+            .load();
+
+        assertEquals(200, rows.count());
     }
 
     @Test

--- a/src/test/java/com/marklogic/spark/reader/triples/ReadTriplesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/triples/ReadTriplesTest.java
@@ -90,6 +90,8 @@ class ReadTriplesTest extends AbstractIntegrationTest {
     void twoCollections() {
         long count = startRead()
             .option(Options.READ_TRIPLES_COLLECTIONS, "http://example.org/graph,other-graph")
+            .option(Options.READ_BATCH_SIZE, 5)
+            .option(Options.READ_LOG_PROGRESS, 10)
             .load().count();
 
         assertEquals(32, count, "Since both test triples files belong to 'test-config', and each also belongs to " +


### PR DESCRIPTION
Had to make two separate loggers so we can have a static counter for reading and a static counter for writing. Both get reset when DefaultSource is created. 

Did some quick manual testing of this in Flux, and it "just works". 

Note that progress for reading/writing files is not being addressed yet. Just focusing on progress for reading from MarkLogic and writing to MarkLogic. 