### PR TITLE
Merge release/2.3.1 into master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,7 @@ logs
 .ipynb_checkpoints
 venv
 .venv
-docker
+docker/marklogic
+docker/sonarqube/data
+docker/sonarqube/logs
 export

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,10 @@ you've introduced on the feature branch you're working on. You can then click on
 Note that if you only need results on code smells and vulnerabilities, you can repeatedly run `./gradlew sonar`
 without having to re-run the tests.
 
+Our Sonar instance is also configured to scan for dependency vulnerabilities 
+[via the dependency-check plugin](https://github.com/dependency-check/dependency-check-sonar-plugin). For more 
+information, see the `dependencyCheck` block in this project's `build.gradle` file.
+
 ## Accessing MarkLogic logs in Grafana
 
 This project's `docker-compose-3nodes.yaml` file includes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,10 @@ without having to re-run the tests.
 
 Our Sonar instance is also configured to scan for dependency vulnerabilities 
 [via the dependency-check plugin](https://github.com/dependency-check/dependency-check-sonar-plugin). For more 
-information, see the `dependencyCheck` block in this project's `build.gradle` file.
+information, see the `dependencyCheck` block in this project's `build.gradle` file. To include dependency check results,
+just run the following (it's not included by default when running the `sonar` task):
+
+    ./gradlew dependencyCheckAnalyze sonar
 
 ## Accessing MarkLogic logs in Grafana
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ This will produce a single jar file for the connector in the `./build/libs` dire
 
 You can then launch PySpark with the connector available via:
 
-    pyspark --jars build/libs/marklogic-spark-connector-2.3.0.jar
+    pyspark --jars build/libs/marklogic-spark-connector-2.3-SNAPSHOT.jar
 
 The below command is an example of loading data from the test application deployed via the instructions at the top of 
 this page. 
@@ -192,7 +192,7 @@ The Spark master GUI is at <http://localhost:8080>. You can use this to view det
 
 Now that you have a Spark cluster running, you just need to tell PySpark to connect to it:
 
-    pyspark --master spark://NYWHYC3G0W:7077 --jars build/libs/marklogic-spark-connector-2.3.0.jar
+    pyspark --master spark://NYWHYC3G0W:7077 --jars build/libs/marklogic-spark-connector-2.3-SNAPSHOT.jar
 
 You can then run the same commands as shown in the PySpark section above. The Spark master GUI will allow you to 
 examine details of each of the commands that you run.
@@ -211,12 +211,12 @@ You will need the connector jar available, so run `./gradlew clean shadowJar` if
 You can then run a test Python program in this repository via the following (again, change the master address as 
 needed); note that you run this outside of PySpark, and `spark-submit` is available after having installed PySpark:
 
-    spark-submit --master spark://NYWHYC3G0W:7077 --jars build/libs/marklogic-spark-connector-2.3.0.jar src/test/python/test_program.py
+    spark-submit --master spark://NYWHYC3G0W:7077 --jars build/libs/marklogic-spark-connector-2.3-SNAPSHOT.jar src/test/python/test_program.py
 
 You can also test a Java program. To do so, first move the `com.marklogic.spark.TestProgram` class from `src/test/java`
 to `src/main/java`. Then run `./gradlew clean shadowJar` to rebuild the connector jar. Then run the following:
 
-    spark-submit --master spark://NYWHYC3G0W:7077 --class com.marklogic.spark.TestProgram build/libs/marklogic-spark-connector-2.3.0.jar
+    spark-submit --master spark://NYWHYC3G0W:7077 --class com.marklogic.spark.TestProgram build/libs/marklogic-spark-connector-2.3-SNAPSHOT.jar
 
 Be sure to move `TestProgram` back to `src/test/java` when you are done. 
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright © 2024 MarkLogic Corporation.
+Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,16 +1,12 @@
 MarkLogic® Connector for Spark
 
-Copyright © 2023 MarkLogic Corporation.  MarkLogic and MarkLogic logo are trademarks or registered trademarks of MarkLogic Corporation in the United States and other countries.  All other trademarks are the property of their respective owners.
- 
-This project is licensed under the Apache License, Version 2.0 (the "License"); you may not use this project except in compliance with the License. You may obtain a copy of the License at
+Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
 
-http://www.apache.org/licenses/LICENSE-2.0 
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-
-To the extent required by the applicable open-source license, a complete machine-readable copy of the source code corresponding to such code is available upon request. This offer is valid to anyone in receipt of this information and shall expire three years following the date of the final distribution of this product version by MarkLogic Corporation. To obtain such source code, send an email to Legal-thirdpartyreview@progress.com. Please specify the product and version for which you are requesting source code.
-
-The following software may be included in this project (last updated October 3, 2023):
+To the extent required by the applicable open-source license, a complete machine-readable copy of the source code
+corresponding to such code is available upon request. This offer is valid to anyone in receipt of this information and
+shall expire three years following the date of the final distribution of this product version by
+Progress Software Corporation. To obtain such source code, send an email to Legal-thirdpartyreview@progress.com.
+Please specify the product and version for which you are requesting source code.
 
 -------------------------------------------------------------------------
 Third Party Components
@@ -43,8 +39,8 @@ Apache License
 
    1. Definitions.
 
-      "License" shall mean the terms and conditions for use, 
-       reproduction, and distribution as defined by Sections 1 through 9 
+      "License" shall mean the terms and conditions for use,
+       reproduction, and distribution as defined by Sections 1 through 9
        of this document.
 
       "Licensor" shall mean the copyright owner or entity authorized by
@@ -75,11 +71,11 @@ Apache License
 
       "Derivative Works" shall mean any work, whether in Source or Object
       form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other 
-       modifications represent, as a whole, an original work of 
-       authorship. For the purposes of this License, Derivative Works 
-       shall not include works that remain separable from, or merely link 
-       (or bind by name) to the interfaces of, the Work and Derivative 
+      editorial revisions, annotations, elaborations, or other
+       modifications represent, as a whole, an original work of
+       authorship. For the purposes of this License, Derivative Works
+       shall not include works that remain separable from, or merely link
+       (or bind by name) to the interfaces of, the Work and Derivative
        Works thereof.
 
        "Contribution" shall mean any work of authorship, including the
@@ -87,8 +83,8 @@ Apache License
       to that Work or Derivative Works thereof, that is intentionally
 submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
 
-      "Contributor" shall mean Licensor and any individual or Legal 
-       Entity on behalf of whom a Contribution has been received by 
+      "Contributor" shall mean Licensor and any individual or Legal
+       Entity on behalf of whom a Contribution has been received by
        Licensor and subsequently incorporated within the Work.
 
    2. Grant of Copyright License. Subject to the terms and conditions of
@@ -102,16 +98,16 @@ submitted to Licensor for inclusion in the Work by the copyright owner or by an 
       this License, each Contributor hereby grants to You a perpetual,
       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
       (except as stated in this section) patent license to make, have
-      made, use, offer to sell, sell, import, and otherwise transfer the 
-      Work, where such license applies only to those patent claims 
-      licensable by such Contributor that are necessarily infringed by 
-      their Contribution(s) alone or by combination of their 
-      Contribution(s) with the Work to which such Contribution(s) was 
-      submitted. If You institute patent litigation against any entity 
-      (including a cross-claim or counterclaim in a lawsuit) alleging 
-      that the Work or a Contribution incorporated within the Work 
-      constitutes direct or contributory patent infringement, then any 
-      patent licenses granted to You under this License for that Work 
+      made, use, offer to sell, sell, import, and otherwise transfer the
+      Work, where such license applies only to those patent claims
+      licensable by such Contributor that are necessarily infringed by
+      their Contribution(s) alone or by combination of their
+      Contribution(s) with the Work to which such Contribution(s) was
+      submitted. If You institute patent litigation against any entity
+      (including a cross-claim or counterclaim in a lawsuit) alleging
+      that the Work or a Contribution incorporated within the Work
+      constitutes direct or contributory patent infringement, then any
+      patent licenses granted to You under this License for that Work
       shall terminate as of the date such litigation is filed.
 
    4. Redistribution. You may reproduce and distribute copies of the
@@ -173,11 +169,11 @@ submitted to Licensor for inclusion in the Work by the copyright owner or by an 
       agreed to in writing, Licensor provides the Work (and each
       Contributor provides its Contributions) on an "AS IS" BASIS,
       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or 
-      conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS 
-      FOR A PARTICULAR PURPOSE. You are solely responsible for 
-      determining the appropriateness of using or redistributing the Work 
-      and assume any risks associated with Your exercise of permissions 
+      implied, including, without limitation, any warranties or
+      conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS
+      FOR A PARTICULAR PURPOSE. You are solely responsible for
+      determining the appropriateness of using or redistributing the Work
+      and assume any risks associated with Your exercise of permissions
       under this License.
 
    8. Limitation of Liability. In no event and under no legal theory,

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ java {
 
 repositories {
   mavenCentral()
+  maven {
+    url "https://bed-artifactory.bedford.progress.com:443/artifactory/ml-maven-snapshots/"
+  }
 }
 
 configurations {
@@ -42,7 +45,7 @@ dependencies {
     exclude module: "rocksdbjni"
   }
 
-  shadowDependencies ("com.marklogic:marklogic-client-api:6.6.1") {
+  shadowDependencies ("com.marklogic:marklogic-client-api:7.0-SNAPSHOT") {
     // The Java Client uses Jackson 2.15.2; Scala 3.4.x does not yet support that and will throw the following error:
     // Scala module 2.14.2 requires Jackson Databind version >= 2.14.0 and < 2.15.0 - Found jackson-databind version 2.15.2
     // So the 4 Jackson modules are excluded to allow for Spark's to be used.
@@ -63,13 +66,20 @@ dependencies {
 
   shadowDependencies "org.jdom:jdom2:2.0.6.1"
 
-  testImplementation ('com.marklogic:ml-app-deployer:4.7.0') {
+  testImplementation ('com.marklogic:ml-app-deployer:4.8.0') {
     exclude group: "com.fasterxml.jackson.core"
     exclude group: "com.fasterxml.jackson.dataformat"
+
+    // Use the Java Client declared above.
+    exclude module: "marklogic-client-api"
   }
+
   testImplementation ('com.marklogic:marklogic-junit5:1.4.0') {
     exclude group: "com.fasterxml.jackson.core"
     exclude group: "com.fasterxml.jackson.dataformat"
+
+    // Use the Java Client declared above.
+    exclude module: "marklogic-client-api"
   }
 
   testImplementation "ch.qos.logback:logback-classic:1.3.14"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'com.marklogic'
-version '2.3.0'
+version '2.3-SNAPSHOT'
 
 java {
   // To support reading RDF files, Apache Jena is used - but that requires Java 11. If we want to do a 2.2.0 release

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     exclude module: "rocksdbjni"
   }
 
-  shadowDependencies ("com.marklogic:marklogic-client-api:7.0-SNAPSHOT") {
+  shadowDependencies ("com.marklogic:marklogic-client-api:7.0.0") {
     // The Java Client uses Jackson 2.15.2; Scala 3.4.x does not yet support that and will throw the following error:
     // Scala module 2.14.2 requires Jackson Databind version >= 2.14.0 and < 2.15.0 - Found jackson-databind version 2.15.2
     // So the 4 Jackson modules are excluded to allow for Spark's to be used.

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
   id 'signing'
   id "jacoco"
   id "org.sonarqube" version "4.4.1.3373"
+  id "org.owasp.dependencycheck" version "10.0.3"
 }
 
 group 'com.marklogic'
@@ -88,6 +89,16 @@ dependencies {
   testImplementation "org.skyscreamer:jsonassert:1.5.1"
 }
 
+// See https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html for more information.
+dependencyCheck {
+  // Need a JSON report to integrate with Sonar. And HTML is easier for humans to read.
+  formats = ["HTML", "JSON"]
+  // We don't include compileOnly since that includes Spark, and Spark and its dependencies are not actual dependencies
+  // of our connector.
+  scanConfigurations = ["shadowDependencies"]
+  suppressionFile = "config/dependency-check-suppressions.xml"
+}
+
 test {
   useJUnitPlatform()
   finalizedBy jacocoTestReport
@@ -106,6 +117,8 @@ sonar {
   properties {
     property "sonar.projectKey", "marklogic-spark"
     property "sonar.host.url", "http://localhost:9000"
+    // See https://github.com/dependency-check/dependency-check-sonar-plugin for more information.
+    property "sonar.dependencyCheck.jsonReportPath", "build/reports/dependency-check-report.json"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ java {
 
 repositories {
   mavenCentral()
+  mavenLocal()
   maven {
     url "https://bed-artifactory.bedford.progress.com:443/artifactory/ml-maven-snapshots/"
   }

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group 'com.marklogic'
-version '2.3-SNAPSHOT'
+version '2.3.1'
 
 java {
   // To support reading RDF files, Apache Jena is used - but that requires Java 11. If we want to do a 2.2.0 release

--- a/config/dependency-check-suppressions.xml
+++ b/config/dependency-check-suppressions.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress>
+    <notes><![CDATA[
+   file name: jackson-databind-2.14.3.jar
+
+   See https://nvd.nist.gov/vuln/detail/CVE-2023-35116 and https://github.com/FasterXML/jackson-databind/issues/3972 .
+   The Jackson team heartily refutes that this is a vulnerability, and we agree.
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@.*$</packageUrl>
+    <cve>CVE-2023-35116</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: commons-compress-1.24.0.jar
+   This is brought in by Jena 4.10. It's a medium, and we don't want to interfere with Jena dependencies.
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons-compress@.*$</packageUrl>
+    <cve>CVE-2024-25710</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: commons-compress-1.24.0.jar
+   This is brought in by Jena 4.10. It's a medium, and we don't want to interfere with Jena dependencies.
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons-compress@.*$</packageUrl>
+    <cve>CVE-2024-26308</cve>
+  </suppress>
+</suppressions>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,9 +28,10 @@ services:
       SONAR_JDBC_USERNAME: sonar
       SONAR_JDBC_PASSWORD: sonar
     volumes:
-      - sonarqube_data:/opt/sonarqube/data
-      - sonarqube_extensions:/opt/sonarqube/extensions
-      - sonarqube_logs:/opt/sonarqube/logs
+      - ./docker/sonarqube/data:/opt/sonarqube/data
+      - ./docker/sonarqube/logs:/opt/sonarqube/logs
+      # Allows for Sonar plugins to be installed by including plugin jar files in this directory.
+      - ./docker/sonarqube/extensions:/opt/sonarqube/extensions
     ports:
       - "9000:9000"
 

--- a/docs/getting-started/jupyter.md
+++ b/docs/getting-started/jupyter.md
@@ -32,7 +32,7 @@ connector and also to initialize Spark:
 
 ```
 import os
-os.environ['PYSPARK_SUBMIT_ARGS'] = '--jars "/path/to/marklogic-spark-connector-2.3.0.jar" pyspark-shell'
+os.environ['PYSPARK_SUBMIT_ARGS'] = '--jars "/path/to/marklogic-spark-connector-2.3.1.jar" pyspark-shell'
 
 from pyspark.sql import SparkSession
 spark = SparkSession.builder.master("local[*]").appName('My Notebook').getOrCreate()
@@ -40,7 +40,7 @@ spark.sparkContext.setLogLevel("WARN")
 spark
 ```
 
-The path of `/path/to/marklogic-spark-connector-2.3.0.jar` should be changed to match the location of the connector 
+The path of `/path/to/marklogic-spark-connector-2.3.1.jar` should be changed to match the location of the connector 
 jar on your filesystem. You are free to customize the `spark` variable in any manner you see fit as well. 
 
 Now that you have an initialized Spark session, you can run any of the examples found in the 

--- a/docs/getting-started/jupyter.md
+++ b/docs/getting-started/jupyter.md
@@ -32,7 +32,7 @@ connector and also to initialize Spark:
 
 ```
 import os
-os.environ['PYSPARK_SUBMIT_ARGS'] = '--jars "/path/to/marklogic-spark-connector-2.2.0.jar" pyspark-shell'
+os.environ['PYSPARK_SUBMIT_ARGS'] = '--jars "/path/to/marklogic-spark-connector-2.3.0.jar" pyspark-shell'
 
 from pyspark.sql import SparkSession
 spark = SparkSession.builder.master("local[*]").appName('My Notebook').getOrCreate()
@@ -40,7 +40,7 @@ spark.sparkContext.setLogLevel("WARN")
 spark
 ```
 
-The path of `/path/to/marklogic-spark-connector-2.2.0.jar` should be changed to match the location of the connector 
+The path of `/path/to/marklogic-spark-connector-2.3.0.jar` should be changed to match the location of the connector 
 jar on your filesystem. You are free to customize the `spark` variable in any manner you see fit as well. 
 
 Now that you have an initialized Spark session, you can run any of the examples found in the 

--- a/docs/getting-started/pyspark.md
+++ b/docs/getting-started/pyspark.md
@@ -29,7 +29,7 @@ shell by pressing `ctrl-D`.
 
 Run PySpark from the directory that you downloaded the connector to per the [setup instructions](setup.md):
 
-    pyspark --jars marklogic-spark-connector-2.2.0.jar
+    pyspark --jars marklogic-spark-connector-2.3.0.jar
 
 The `--jars` command line option is PySpark's method for utilizing Spark connectors. Each Spark environment should have
 a similar mechanism for including third party connectors; please see the documentation for your particular Spark

--- a/docs/getting-started/pyspark.md
+++ b/docs/getting-started/pyspark.md
@@ -29,7 +29,7 @@ shell by pressing `ctrl-D`.
 
 Run PySpark from the directory that you downloaded the connector to per the [setup instructions](setup.md):
 
-    pyspark --jars marklogic-spark-connector-2.3.0.jar
+    pyspark --jars marklogic-spark-connector-2.3.1.jar
 
 The `--jars` command line option is PySpark's method for utilizing Spark connectors. Each Spark environment should have
 a similar mechanism for including third party connectors; please see the documentation for your particular Spark

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -31,10 +31,10 @@ have an instance of MarkLogic running, you can skip step 4 below, but ensure tha
 extracted directory contains valid connection properties for your instance of MarkLogic.
 
 1. From [this repository's Releases page](https://github.com/marklogic/marklogic-spark-connector/releases), select 
-   the latest release and download the `marklogic-spark-getting-started-2.3.0.zip` file.
+   the latest release and download the `marklogic-spark-getting-started-2.3.1.zip` file.
 2. Extract the contents of the downloaded zip file. 
 3. Open a terminal window and go to the directory created by extracting the zip file; the directory should have a 
-   name of "marklogic-spark-getting-started-2.3.0".
+   name of "marklogic-spark-getting-started-2.3.1".
 4. Run `docker-compose up -d` to start an instance of MarkLogic
 5. Ensure that the `./gradlew` file is executable; depending on your operating system, you may need to run
    `chmod 755 gradlew` to make the file executable.

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -31,10 +31,10 @@ have an instance of MarkLogic running, you can skip step 4 below, but ensure tha
 extracted directory contains valid connection properties for your instance of MarkLogic.
 
 1. From [this repository's Releases page](https://github.com/marklogic/marklogic-spark-connector/releases), select 
-   the latest release and download the `marklogic-spark-getting-started-2.2.0.zip` file.
+   the latest release and download the `marklogic-spark-getting-started-2.3.0.zip` file.
 2. Extract the contents of the downloaded zip file. 
 3. Open a terminal window and go to the directory created by extracting the zip file; the directory should have a 
-   name of "marklogic-spark-getting-started-2.2.0".
+   name of "marklogic-spark-getting-started-2.3.0".
 4. Run `docker-compose up -d` to start an instance of MarkLogic
 5. Ensure that the `./gradlew` file is executable; depending on your operating system, you may need to run
    `chmod 755 gradlew` to make the file executable.

--- a/examples/entity-aggregation/docker-compose.yml
+++ b/examples/entity-aggregation/docker-compose.yml
@@ -5,7 +5,7 @@ name: entity_aggregation
 services:
 
   marklogic:
-    image: "marklogicdb/marklogic-db:11.1.0-centos-1.1.0"
+    image: "marklogicdb/marklogic-db:latest-11"
     platform: linux/amd64
     environment:
       - MARKLOGIC_INIT=true

--- a/examples/getting-started/docker-compose.yml
+++ b/examples/getting-started/docker-compose.yml
@@ -5,7 +5,7 @@ name: marklogic_spark_getting_started
 services:
 
   marklogic:
-    image: "marklogicdb/marklogic-db:11.1.0-centos-1.1.0"
+    image: "marklogicdb/marklogic-db:latest-11"
     platform: linux/amd64
     environment:
       - MARKLOGIC_INIT=true

--- a/examples/getting-started/marklogic-spark-getting-started.ipynb
+++ b/examples/getting-started/marklogic-spark-getting-started.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# Make the MarkLogic connector available to the underlying PySpark application.\n",
     "import os\n",
-    "os.environ['PYSPARK_SUBMIT_ARGS'] = '--jars \"marklogic-spark-connector-2.2.0.jar\" pyspark-shell'\n",
+    "os.environ['PYSPARK_SUBMIT_ARGS'] = '--jars \"marklogic-spark-connector-2.3.0.jar\" pyspark-shell'\n",
     "\n",
     "# Define the connection details for the getting-started example application.\n",
     "client_uri = \"spark-example-user:password@localhost:8003\"\n",

--- a/examples/getting-started/marklogic-spark-getting-started.ipynb
+++ b/examples/getting-started/marklogic-spark-getting-started.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# Make the MarkLogic connector available to the underlying PySpark application.\n",
     "import os\n",
-    "os.environ['PYSPARK_SUBMIT_ARGS'] = '--jars \"marklogic-spark-connector-2.3.0.jar\" pyspark-shell'\n",
+    "os.environ['PYSPARK_SUBMIT_ARGS'] = '--jars \"marklogic-spark-connector-2.3.1.jar\" pyspark-shell'\n",
     "\n",
     "# Define the connection details for the getting-started example application.\n",
     "client_uri = \"spark-example-user:password@localhost:8003\"\n",

--- a/src/main/java/com/marklogic/spark/ConnectionString.java
+++ b/src/main/java/com/marklogic/spark/ConnectionString.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark;
 
 import java.io.UnsupportedEncodingException;

--- a/src/main/java/com/marklogic/spark/ConnectorException.java
+++ b/src/main/java/com/marklogic/spark/ConnectorException.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark;
 
 public class ConnectorException extends RuntimeException {

--- a/src/main/java/com/marklogic/spark/ContextSupport.java
+++ b/src/main/java/com/marklogic/spark/ContextSupport.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark;
 

--- a/src/main/java/com/marklogic/spark/DefaultSource.java
+++ b/src/main/java/com/marklogic/spark/DefaultSource.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark;
 

--- a/src/main/java/com/marklogic/spark/JsonRowSerializer.java
+++ b/src/main/java/com/marklogic/spark/JsonRowSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark;
 

--- a/src/main/java/com/marklogic/spark/MarkLogicFileTable.java
+++ b/src/main/java/com/marklogic/spark/MarkLogicFileTable.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark;
 
 import com.marklogic.spark.reader.file.FileScanBuilder;

--- a/src/main/java/com/marklogic/spark/MarkLogicTable.java
+++ b/src/main/java/com/marklogic/spark/MarkLogicTable.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark;
 

--- a/src/main/java/com/marklogic/spark/MarkLogicTable.java
+++ b/src/main/java/com/marklogic/spark/MarkLogicTable.java
@@ -3,9 +3,9 @@
  */
 package com.marklogic.spark;
 
-import com.marklogic.spark.reader.optic.OpticScanBuilder;
-import com.marklogic.spark.reader.optic.OpticReadContext;
 import com.marklogic.spark.reader.customcode.CustomCodeScanBuilder;
+import com.marklogic.spark.reader.optic.OpticReadContext;
+import com.marklogic.spark.reader.optic.OpticScanBuilder;
 import com.marklogic.spark.writer.MarkLogicWriteBuilder;
 import com.marklogic.spark.writer.WriteContext;
 import org.apache.spark.sql.SparkSession;

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark;
 

--- a/src/main/java/com/marklogic/spark/ReadProgressLogger.java
+++ b/src/main/java/com/marklogic/spark/ReadProgressLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark;
 

--- a/src/main/java/com/marklogic/spark/Util.java
+++ b/src/main/java/com/marklogic/spark/Util.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark;
 

--- a/src/main/java/com/marklogic/spark/WriteProgressLogger.java
+++ b/src/main/java/com/marklogic/spark/WriteProgressLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark;
 

--- a/src/main/java/com/marklogic/spark/reader/JsonRowDeserializer.java
+++ b/src/main/java/com/marklogic/spark/reader/JsonRowDeserializer.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader;
 
 import com.fasterxml.jackson.core.JsonFactory;

--- a/src/main/java/com/marklogic/spark/reader/customcode/CustomCodeBatch.java
+++ b/src/main/java/com/marklogic/spark/reader/customcode/CustomCodeBatch.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.customcode;
 
 import org.apache.spark.sql.connector.read.Batch;

--- a/src/main/java/com/marklogic/spark/reader/customcode/CustomCodeContext.java
+++ b/src/main/java/com/marklogic/spark/reader/customcode/CustomCodeContext.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.customcode;
 
 import com.marklogic.client.DatabaseClient;

--- a/src/main/java/com/marklogic/spark/reader/customcode/CustomCodeMicroBatchStream.java
+++ b/src/main/java/com/marklogic/spark/reader/customcode/CustomCodeMicroBatchStream.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.customcode;
 
 import com.marklogic.spark.Util;

--- a/src/main/java/com/marklogic/spark/reader/customcode/CustomCodePartition.java
+++ b/src/main/java/com/marklogic/spark/reader/customcode/CustomCodePartition.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.customcode;
 
 import org.apache.spark.sql.connector.read.InputPartition;

--- a/src/main/java/com/marklogic/spark/reader/customcode/CustomCodePartitionReader.java
+++ b/src/main/java/com/marklogic/spark/reader/customcode/CustomCodePartitionReader.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.customcode;
 
 import com.marklogic.client.DatabaseClient;

--- a/src/main/java/com/marklogic/spark/reader/customcode/CustomCodePartitionReaderFactory.java
+++ b/src/main/java/com/marklogic/spark/reader/customcode/CustomCodePartitionReaderFactory.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.customcode;
 
 import org.apache.spark.sql.catalyst.InternalRow;

--- a/src/main/java/com/marklogic/spark/reader/customcode/CustomCodeScan.java
+++ b/src/main/java/com/marklogic/spark/reader/customcode/CustomCodeScan.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.customcode;
 
 import com.marklogic.client.DatabaseClient;

--- a/src/main/java/com/marklogic/spark/reader/customcode/CustomCodeScanBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/customcode/CustomCodeScanBuilder.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.customcode;
 
 import com.marklogic.spark.Options;

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentBatch.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentBatch.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.DatabaseClient;

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.DatabaseClient;

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentRowBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentRowBuilder.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.document.DocumentManager;

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentRowSchema.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentRowSchema.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.io.DocumentMetadataHandle;

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentScan.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentScan.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import org.apache.spark.sql.connector.read.Batch;

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentScanBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentScanBuilder.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import org.apache.spark.sql.connector.read.Scan;

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentTable.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentTable.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import org.apache.spark.sql.connector.catalog.SupportsRead;

--- a/src/main/java/com/marklogic/spark/reader/document/ForestPartition.java
+++ b/src/main/java/com/marklogic/spark/reader/document/ForestPartition.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.datamovement.Forest;

--- a/src/main/java/com/marklogic/spark/reader/document/ForestPartitionPlanner.java
+++ b/src/main/java/com/marklogic/spark/reader/document/ForestPartitionPlanner.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.datamovement.Forest;

--- a/src/main/java/com/marklogic/spark/reader/document/ForestReader.java
+++ b/src/main/java/com/marklogic/spark/reader/document/ForestReader.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.DatabaseClient;

--- a/src/main/java/com/marklogic/spark/reader/document/ForestReaderFactory.java
+++ b/src/main/java/com/marklogic/spark/reader/document/ForestReaderFactory.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.spark.reader.file.TripleRowSchema;

--- a/src/main/java/com/marklogic/spark/reader/document/OpticTriplesReader.java
+++ b/src/main/java/com/marklogic/spark/reader/document/OpticTriplesReader.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.DatabaseClient;

--- a/src/main/java/com/marklogic/spark/reader/document/SearchQueryBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/document/SearchQueryBuilder.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.DatabaseClient;

--- a/src/main/java/com/marklogic/spark/reader/document/UriBatcher.java
+++ b/src/main/java/com/marklogic/spark/reader/document/UriBatcher.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.DatabaseClient;

--- a/src/main/java/com/marklogic/spark/reader/file/ArchiveFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/ArchiveFileReader.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.client.io.DocumentMetadataHandle;

--- a/src/main/java/com/marklogic/spark/reader/file/FileBatch.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FileBatch.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/main/java/com/marklogic/spark/reader/file/FileContext.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FileContext.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/main/java/com/marklogic/spark/reader/file/FileContext.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FileContext.java
@@ -16,12 +16,12 @@ import java.nio.charset.UnsupportedCharsetException;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
-class FileContext extends ContextSupport implements Serializable {
+public class FileContext extends ContextSupport implements Serializable {
 
     private SerializableConfiguration hadoopConfiguration;
     private final String encoding;
 
-    FileContext(Map<String, String> properties, SerializableConfiguration hadoopConfiguration) {
+    public FileContext(Map<String, String> properties, SerializableConfiguration hadoopConfiguration) {
         super(properties);
         this.hadoopConfiguration = hadoopConfiguration;
         this.encoding = getStringOption(Options.READ_FILES_ENCODING);
@@ -42,7 +42,7 @@ class FileContext extends ContextSupport implements Serializable {
         return "gzip".equalsIgnoreCase(getStringOption(Options.READ_FILES_COMPRESSION));
     }
 
-    InputStream openFile(String filePath) {
+    public InputStream openFile(String filePath) {
         try {
             Path hadoopPath = new Path(filePath);
             FileSystem fileSystem = hadoopPath.getFileSystem(hadoopConfiguration.value());
@@ -54,7 +54,7 @@ class FileContext extends ContextSupport implements Serializable {
         }
     }
 
-    boolean isReadAbortOnFailure() {
+    public boolean isReadAbortOnFailure() {
         if (hasOption(Options.READ_FILES_ABORT_ON_FAILURE)) {
             return Boolean.parseBoolean(getStringOption(Options.READ_FILES_ABORT_ON_FAILURE));
         }

--- a/src/main/java/com/marklogic/spark/reader/file/FilePartition.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FilePartition.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import org.apache.spark.sql.connector.read.InputPartition;

--- a/src/main/java/com/marklogic/spark/reader/file/FilePartition.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FilePartition.java
@@ -4,7 +4,7 @@ import org.apache.spark.sql.connector.read.InputPartition;
 
 import java.util.List;
 
-class FilePartition implements InputPartition {
+public class FilePartition implements InputPartition {
 
     static final long serialVersionUID = 1;
 
@@ -14,7 +14,7 @@ class FilePartition implements InputPartition {
         this.paths = paths;
     }
 
-    List<String> getPaths() {
+    public List<String> getPaths() {
         return paths;
     }
 

--- a/src/main/java/com/marklogic/spark/reader/file/FilePartitionReaderFactory.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FilePartitionReaderFactory.java
@@ -1,6 +1,8 @@
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.Options;
+import com.marklogic.spark.reader.file.xml.AggregateXmlFileReader;
+import com.marklogic.spark.reader.file.xml.ZipAggregateXmlFileReader;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReader;

--- a/src/main/java/com/marklogic/spark/reader/file/FilePartitionReaderFactory.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FilePartitionReaderFactory.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.Options;

--- a/src/main/java/com/marklogic/spark/reader/file/FileScan.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FileScan.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.reader.document.DocumentRowSchema;

--- a/src/main/java/com/marklogic/spark/reader/file/FileScanBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FileScanBuilder.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import org.apache.spark.sql.connector.read.Scan;

--- a/src/main/java/com/marklogic/spark/reader/file/FileUtil.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FileUtil.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import java.io.ByteArrayOutputStream;

--- a/src/main/java/com/marklogic/spark/reader/file/GenericFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/GenericFileReader.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/main/java/com/marklogic/spark/reader/file/GzipFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/GzipFileReader.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/main/java/com/marklogic/spark/reader/file/MlcpMetadata.java
+++ b/src/main/java/com/marklogic/spark/reader/file/MlcpMetadata.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.client.io.DocumentMetadataHandle;

--- a/src/main/java/com/marklogic/spark/reader/file/MlcpMetadataConverter.java
+++ b/src/main/java/com/marklogic/spark/reader/file/MlcpMetadataConverter.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.client.io.DocumentMetadataHandle;

--- a/src/main/java/com/marklogic/spark/reader/file/QuadStreamReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/QuadStreamReader.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/main/java/com/marklogic/spark/reader/file/RdfErrorHandler.java
+++ b/src/main/java/com/marklogic/spark/reader/file/RdfErrorHandler.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.Util;

--- a/src/main/java/com/marklogic/spark/reader/file/RdfFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/RdfFileReader.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/main/java/com/marklogic/spark/reader/file/RdfSerializer.java
+++ b/src/main/java/com/marklogic/spark/reader/file/RdfSerializer.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import org.apache.jena.graph.Node;

--- a/src/main/java/com/marklogic/spark/reader/file/RdfStreamReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/RdfStreamReader.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import org.apache.spark.sql.catalyst.InternalRow;

--- a/src/main/java/com/marklogic/spark/reader/file/RdfUtil.java
+++ b/src/main/java/com/marklogic/spark/reader/file/RdfUtil.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import org.apache.jena.riot.Lang;

--- a/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/main/java/com/marklogic/spark/reader/file/TripleRowSchema.java
+++ b/src/main/java/com/marklogic/spark/reader/file/TripleRowSchema.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import org.apache.spark.sql.types.DataTypes;

--- a/src/main/java/com/marklogic/spark/reader/file/TripleStreamReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/TripleStreamReader.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/main/java/com/marklogic/spark/reader/file/xml/AggregateXmlFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/AggregateXmlFileReader.java
@@ -1,14 +1,16 @@
-package com.marklogic.spark.reader.file;
+package com.marklogic.spark.reader.file.xml;
 
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Util;
+import com.marklogic.spark.reader.file.FileContext;
+import com.marklogic.spark.reader.file.FilePartition;
 import org.apache.commons.io.IOUtils;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.PartitionReader;
 
 import java.io.InputStream;
 
-class AggregateXmlFileReader implements PartitionReader<InternalRow> {
+public class AggregateXmlFileReader implements PartitionReader<InternalRow> {
 
     private final FilePartition filePartition;
     private final FileContext fileContext;
@@ -18,7 +20,7 @@ class AggregateXmlFileReader implements PartitionReader<InternalRow> {
     private InternalRow nextRowToReturn;
     private int filePathIndex = 0;
 
-    AggregateXmlFileReader(FilePartition filePartition, FileContext fileContext) {
+    public AggregateXmlFileReader(FilePartition filePartition, FileContext fileContext) {
         this.filePartition = filePartition;
         this.fileContext = fileContext;
     }

--- a/src/main/java/com/marklogic/spark/reader/file/xml/AggregateXmlFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/AggregateXmlFileReader.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file.xml;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/main/java/com/marklogic/spark/reader/file/xml/AggregateXmlSplitter.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/AggregateXmlSplitter.java
@@ -1,9 +1,10 @@
-package com.marklogic.spark.reader.file;
+package com.marklogic.spark.reader.file.xml;
 
 import com.marklogic.client.datamovement.XMLSplitter;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
+import com.marklogic.spark.reader.file.FileContext;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.unsafe.types.ByteArray;

--- a/src/main/java/com/marklogic/spark/reader/file/xml/AggregateXmlSplitter.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/AggregateXmlSplitter.java
@@ -13,7 +13,6 @@ import org.apache.spark.unsafe.types.UTF8String;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
@@ -61,9 +60,13 @@ class AggregateXmlSplitter {
         final String element = fileContext.getStringOption(Options.READ_AGGREGATES_XML_ELEMENT);
         final String encoding = fileContext.getStringOption(Options.READ_FILES_ENCODING);
 
+        final XMLSplitter<StringHandle> splitter = this.uriElement != null ?
+            new XMLSplitter<>(new UriElementExtractingVisitor(namespace, element, uriNamespace, uriElement)) :
+            XMLSplitter.makeSplitter(namespace, element);
+
         try {
             XMLStreamReader reader = xmlInputFactory.createXMLStreamReader(inputStream, encoding);
-            this.contentStream = XMLSplitter.makeSplitter(namespace, element).split(reader).iterator();
+            this.contentStream = splitter.split(reader).iterator();
         } catch (IOException | XMLStreamException e) {
             throw new ConnectorException(
                 String.format("Unable to read XML at %s; cause: %s", this.identifierForErrors, e.getMessage()), e
@@ -81,88 +84,39 @@ class AggregateXmlSplitter {
     }
 
     /**
-     * @param pathPrefix used to construct a path if no uriElement was specified
+     * @param uriPrefix used to construct a URI if no uriElement was specified
      * @return a row corresponding to the {@code DocumentRowSchema}
      */
-    InternalRow nextRow(String pathPrefix) {
-        String xml;
+    InternalRow nextRow(String uriPrefix) {
+        StringHandle stringHandle;
         try {
-            xml = this.contentStream.next().get();
+            stringHandle = this.contentStream.next();
         } catch (RuntimeException ex) {
             String message = String.format("Unable to read XML from %s; cause: %s",
                 this.identifierForErrors, ex.getMessage());
             throw new ConnectorException(message, ex);
         }
 
-        final String path = this.uriElement != null && !this.uriElement.trim().isEmpty() ?
-            extractUriElementValue(xml) :
-            pathPrefix + "-" + rowCounter + ".xml";
-
+        final String initialUri = determineInitialUri(stringHandle, uriPrefix);
         rowCounter++;
-
-        byte[] content = xml.getBytes();
         return new GenericInternalRow(new Object[]{
-            UTF8String.fromString(path),
-            ByteArray.concat(content),
+            UTF8String.fromString(initialUri),
+            ByteArray.concat(stringHandle.get().getBytes()),
             UTF8String.fromString("xml"),
             null, null, null, null, null
         });
     }
 
-    /**
-     * MLCP has undocumented support for attribute references via "@(attribute-name)". We are not supporting this yet
-     * as we are using XMLSplitter to find the user-defined element, and XMLSplitter does not support finding
-     * attributes. Additionally, this feature is still fairly limited in comparison to the "URI template" that the
-     * connector supports. Ultimately, we'd want to support N path expressions against both Spark columns and against
-     * a JSON or XML tree in a single Spark column.
-     *
-     * @param xml
-     * @return
-     */
-    private String extractUriElementValue(String xml) {
-        Iterator<StringHandle> iterator;
-        XMLSplitter<StringHandle> splitter = XMLSplitter.makeSplitter(this.uriNamespace, this.uriElement);
-        splitter.setVisitor(new UriElementVisitor(this.uriNamespace, this.uriElement));
-        try {
-            iterator = splitter.split(new ByteArrayInputStream(xml.getBytes())).iterator();
-        } catch (Exception e) {
-            // We don't expect this to ever occur, as if the XML couldn't be parsed, an error would have been thrown
-            // when the child element was originally extracted. But still have to catch an exception.
-            String message = String.format("Unable to parse XML in aggregate element %d in %s; cause: %s",
-                rowCounter, this.identifierForErrors, e.getMessage());
-            throw new ConnectorException(message, e);
-        }
-
-        if (!iterator.hasNext()) {
-            String message = String.format("No occurrence of URI element '%s' found in aggregate element %d in %s",
-                this.uriElement, rowCounter, this.identifierForErrors);
-            throw new ConnectorException(message);
-        }
-        return iterator.next().get();
-    }
-
-    /**
-     * Extends the Java Client visitor class so that it can return a handle containing the text of the
-     * user-defined URI element.
-     */
-    private class UriElementVisitor extends XMLSplitter.BasicElementVisitor {
-        public UriElementVisitor(String nsUri, String localName) {
-            super(nsUri, localName);
-        }
-
-        @Override
-        public StringHandle makeBufferedHandle(XMLStreamReader xmlStreamReader) {
-            String text;
-            try {
-                text = xmlStreamReader.getElementText();
-            } catch (XMLStreamException e) {
-                String message = String.format(
-                    "Unable to get text from URI element '%s' found in aggregate element %d in %s; cause: %s",
-                    uriElement, rowCounter, identifierForErrors, e.getMessage()
-                );
-                throw new ConnectorException(message, e);
+    private String determineInitialUri(StringHandle stringHandle, String uriPrefix) {
+        if (stringHandle instanceof StringHandleWithUriValue) {
+            String uriValue = ((StringHandleWithUriValue) stringHandle).getUriValue();
+            if (uriValue == null) {
+                String message = String.format("No occurrence of URI element '%s' found in aggregate element %d in %s",
+                    this.uriElement, rowCounter, this.identifierForErrors);
+                throw new ConnectorException(message);
             }
-            return new StringHandle(text);
+            return uriValue;
         }
+        return String.format("%s-%d.xml", uriPrefix, rowCounter);
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/file/xml/AggregateXmlSplitter.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/AggregateXmlSplitter.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file.xml;
 
 import com.marklogic.client.datamovement.XMLSplitter;

--- a/src/main/java/com/marklogic/spark/reader/file/xml/StringHandleWithUriValue.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/StringHandleWithUriValue.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.spark.reader.file.xml;
+
+import com.marklogic.client.io.StringHandle;
+
+/**
+ * Captures a URI value based on the user-defined URI element.
+ */
+class StringHandleWithUriValue extends StringHandle {
+
+    private final String uriValue;
+
+    StringHandleWithUriValue(String content, String uriValue) {
+        super(content);
+        this.uriValue = uriValue;
+    }
+
+    String getUriValue() {
+        return uriValue;
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/file/xml/StringHandleWithUriValue.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/StringHandleWithUriValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.file.xml;
 

--- a/src/main/java/com/marklogic/spark/reader/file/xml/UriElementExtractingReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/UriElementExtractingReader.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.spark.reader.file.xml;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.util.StreamReaderDelegate;
+
+/**
+ * Knows how to extract a URI element value while the XML for an aggregate element is being read and serialized.
+ */
+class UriElementExtractingReader extends StreamReaderDelegate {
+
+    private XMLStreamReader source;
+    private final String uriNamespace;
+    private final String uriElement;
+
+    // Used to track when the URI element is detected.
+    private boolean isReadingUriElement;
+    private String uriValue;
+
+    UriElementExtractingReader(XMLStreamReader source, String uriNamespace, String uriElement) {
+        super(source);
+        this.source = source;
+        this.uriNamespace = uriNamespace;
+        this.uriElement = uriElement;
+    }
+
+    @Override
+    public int next() throws XMLStreamException {
+        int value = source.next();
+        if (value == XMLStreamConstants.START_ELEMENT) {
+            // Only use the first instance of the URI element that is found.
+            if (matchesUriElement() && this.uriValue == null) {
+                this.isReadingUriElement = true;
+                this.uriValue = "";
+            }
+        } else if (value == XMLStreamConstants.CHARACTERS) {
+            if (this.isReadingUriElement) {
+                this.uriValue += source.getText();
+            }
+        } else if (value == XMLStreamConstants.END_ELEMENT && this.isReadingUriElement && matchesUriElement()) {
+            this.isReadingUriElement = false;
+        }
+        return value;
+    }
+
+    private boolean matchesUriElement() {
+        return source.getLocalName().equals(uriElement) &&
+            (this.uriNamespace == null || this.uriNamespace.equals(source.getNamespaceURI()));
+    }
+
+    String getUriValue() {
+        return uriValue;
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/file/xml/UriElementExtractingReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/UriElementExtractingReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.file.xml;
 

--- a/src/main/java/com/marklogic/spark/reader/file/xml/UriElementExtractingVisitor.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/UriElementExtractingVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.file.xml;
 

--- a/src/main/java/com/marklogic/spark/reader/file/xml/UriElementExtractingVisitor.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/UriElementExtractingVisitor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.spark.reader.file.xml;
+
+import com.marklogic.client.datamovement.XMLSplitter;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.StringHandle;
+
+import javax.xml.stream.XMLStreamReader;
+
+/**
+ * Supports extracting a URI element value for each aggregate element.
+ */
+class UriElementExtractingVisitor extends XMLSplitter.BasicElementVisitor {
+
+    private final String uriNamespace;
+    private final String uriElement;
+
+    UriElementExtractingVisitor(String nsUri, String localName, String uriNamespace, String uriElement) {
+        super(nsUri, localName);
+        this.uriNamespace = uriNamespace;
+        this.uriElement = uriElement;
+    }
+
+    @Override
+    public StringHandle makeBufferedHandle(XMLStreamReader xmlStreamReader) {
+        UriElementExtractingReader reader = new UriElementExtractingReader(xmlStreamReader, uriNamespace, uriElement);
+        String content = serialize(reader);
+        String uriValue = reader.getUriValue();
+        return new StringHandleWithUriValue(content, uriValue).withFormat(Format.XML);
+    }
+}

--- a/src/main/java/com/marklogic/spark/reader/file/xml/ZipAggregateXmlFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/ZipAggregateXmlFileReader.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file.xml;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/main/java/com/marklogic/spark/reader/file/xml/ZipAggregateXmlFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/ZipAggregateXmlFileReader.java
@@ -1,7 +1,10 @@
-package com.marklogic.spark.reader.file;
+package com.marklogic.spark.reader.file.xml;
 
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Util;
+import com.marklogic.spark.reader.file.FileContext;
+import com.marklogic.spark.reader.file.FilePartition;
+import com.marklogic.spark.reader.file.FileUtil;
 import org.apache.commons.io.IOUtils;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.PartitionReader;
@@ -12,7 +15,7 @@ import java.io.IOException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-class ZipAggregateXmlFileReader implements PartitionReader<InternalRow> {
+public class ZipAggregateXmlFileReader implements PartitionReader<InternalRow> {
 
     private static final Logger logger = LoggerFactory.getLogger(ZipAggregateXmlFileReader.class);
 
@@ -29,7 +32,7 @@ class ZipAggregateXmlFileReader implements PartitionReader<InternalRow> {
     private String currentFilePath;
     private ZipInputStream currentZipInputStream;
 
-    ZipAggregateXmlFileReader(FilePartition filePartition, FileContext fileContext) {
+    public ZipAggregateXmlFileReader(FilePartition filePartition, FileContext fileContext) {
         this.fileContext = fileContext;
         this.filePartition = filePartition;
         this.openNextFile();

--- a/src/main/java/com/marklogic/spark/reader/filter/FilterFactory.java
+++ b/src/main/java/com/marklogic/spark/reader/filter/FilterFactory.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.filter;
 

--- a/src/main/java/com/marklogic/spark/reader/filter/IsNotNullFilter.java
+++ b/src/main/java/com/marklogic/spark/reader/filter/IsNotNullFilter.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.filter;
 

--- a/src/main/java/com/marklogic/spark/reader/filter/IsNullFilter.java
+++ b/src/main/java/com/marklogic/spark/reader/filter/IsNullFilter.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.filter;
 

--- a/src/main/java/com/marklogic/spark/reader/filter/OpticFilter.java
+++ b/src/main/java/com/marklogic/spark/reader/filter/OpticFilter.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.filter;
 
@@ -45,7 +33,7 @@ public interface OpticFilter extends Serializable {
     /**
      * Allows the filter to determine if - after having been constructed - it's not a valid Optic expression and thus
      * cannot be pushed down to MarkLogic.
-     * 
+     *
      * @return
      */
     default boolean isValid() {

--- a/src/main/java/com/marklogic/spark/reader/filter/ParentFilter.java
+++ b/src/main/java/com/marklogic/spark/reader/filter/ParentFilter.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.filter;
 

--- a/src/main/java/com/marklogic/spark/reader/filter/SingleValueFilter.java
+++ b/src/main/java/com/marklogic/spark/reader/filter/SingleValueFilter.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.filter;
 

--- a/src/main/java/com/marklogic/spark/reader/filter/SqlConditionFilter.java
+++ b/src/main/java/com/marklogic/spark/reader/filter/SqlConditionFilter.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.filter;
 

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticBatch.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticBatch.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticMicroBatchStream.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticMicroBatchStream.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticPartitionReader.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticPartitionReader.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 
 package com.marklogic.spark.reader.optic;

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticPartitionReaderFactory.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticPartitionReaderFactory.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticReadContext.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticReadContext.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticScan.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticScan.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 
 package com.marklogic.spark.reader.optic;

--- a/src/main/java/com/marklogic/spark/reader/optic/OpticScanBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/OpticScanBuilder.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/main/java/com/marklogic/spark/reader/optic/PlanAnalysis.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/PlanAnalysis.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/main/java/com/marklogic/spark/reader/optic/PlanAnalyzer.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/PlanAnalyzer.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/main/java/com/marklogic/spark/reader/optic/PlanUtil.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/PlanUtil.java
@@ -17,7 +17,9 @@ import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 

--- a/src/main/java/com/marklogic/spark/reader/optic/PlanUtil.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/PlanUtil.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/main/java/com/marklogic/spark/reader/optic/SchemaInferrer.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/SchemaInferrer.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/main/java/com/marklogic/spark/reader/optic/SchemaInferrer.java
+++ b/src/main/java/com/marklogic/spark/reader/optic/SchemaInferrer.java
@@ -54,6 +54,7 @@ public abstract class SchemaInferrer {
         COLUMN_INFO_TYPES_TO_SPARK_TYPES.put("yearMonthDuration", DataTypes.StringType);
         COLUMN_INFO_TYPES_TO_SPARK_TYPES.put("dayTimeDuration", DataTypes.StringType);
         COLUMN_INFO_TYPES_TO_SPARK_TYPES.put("string", DataTypes.StringType);
+        COLUMN_INFO_TYPES_TO_SPARK_TYPES.put("collatedString", DataTypes.StringType);
         COLUMN_INFO_TYPES_TO_SPARK_TYPES.put("anyUri", DataTypes.StringType);
         COLUMN_INFO_TYPES_TO_SPARK_TYPES.put("point", DataTypes.StringType);
         COLUMN_INFO_TYPES_TO_SPARK_TYPES.put("boolean", DataTypes.BooleanType);

--- a/src/main/java/com/marklogic/spark/writer/ArbitraryRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/ArbitraryRowConverter.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/com/marklogic/spark/writer/BatchRetrier.java
+++ b/src/main/java/com/marklogic/spark/writer/BatchRetrier.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer;
 
 import com.marklogic.client.datamovement.WriteBatch;

--- a/src/main/java/com/marklogic/spark/writer/CommitMessage.java
+++ b/src/main/java/com/marklogic/spark/writer/CommitMessage.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer;
 
 import org.apache.spark.sql.connector.write.WriterCommitMessage;

--- a/src/main/java/com/marklogic/spark/writer/DocBuilder.java
+++ b/src/main/java/com/marklogic/spark/writer/DocBuilder.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.writer;
 

--- a/src/main/java/com/marklogic/spark/writer/DocBuilderFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/DocBuilderFactory.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.writer;
 

--- a/src/main/java/com/marklogic/spark/writer/DocumentRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/DocumentRowConverter.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/com/marklogic/spark/writer/FileRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/FileRowConverter.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/com/marklogic/spark/writer/MarkLogicWrite.java
+++ b/src/main/java/com/marklogic/spark/writer/MarkLogicWrite.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.writer;
 

--- a/src/main/java/com/marklogic/spark/writer/MarkLogicWriteBuilder.java
+++ b/src/main/java/com/marklogic/spark/writer/MarkLogicWriteBuilder.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.writer;
 

--- a/src/main/java/com/marklogic/spark/writer/RowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/RowConverter.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer;
 
 import org.apache.spark.sql.catalyst.InternalRow;

--- a/src/main/java/com/marklogic/spark/writer/SparkRowUriMaker.java
+++ b/src/main/java/com/marklogic/spark/writer/SparkRowUriMaker.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.writer;
 

--- a/src/main/java/com/marklogic/spark/writer/StandardUriMaker.java
+++ b/src/main/java/com/marklogic/spark/writer/StandardUriMaker.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.writer;
 

--- a/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
@@ -228,7 +228,9 @@ class WriteBatcherDataWriter implements DataWriter<InternalRow> {
 
     private void closeArchiveWriter() {
         if (archiveWriter != null) {
-            Util.MAIN_LOGGER.info("Wrote failed documents to archive file at {}.", archiveWriter.getZipPath());
+            if (failedItemCount.get() > 0) {
+                Util.MAIN_LOGGER.info("Wrote failed documents to archive file at {}.", archiveWriter.getZipPath());
+            }
             archiveWriter.close();
         }
     }

--- a/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriterFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriterFactory.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.writer;
 

--- a/src/main/java/com/marklogic/spark/writer/WriteContext.java
+++ b/src/main/java/com/marklogic/spark/writer/WriteContext.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.writer;
 

--- a/src/main/java/com/marklogic/spark/writer/customcode/CustomCodeWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/customcode/CustomCodeWriter.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.customcode;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/com/marklogic/spark/writer/customcode/CustomCodeWriterFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/customcode/CustomCodeWriterFactory.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.customcode;
 
 import com.marklogic.spark.reader.customcode.CustomCodeContext;

--- a/src/main/java/com/marklogic/spark/writer/file/ContentWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/file/ContentWriter.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/com/marklogic/spark/writer/file/DocumentFileBatch.java
+++ b/src/main/java/com/marklogic/spark/writer/file/DocumentFileBatch.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import com.marklogic.spark.Util;

--- a/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriteBuilder.java
+++ b/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriteBuilder.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import org.apache.spark.sql.connector.write.BatchWrite;

--- a/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriter.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import org.apache.commons.io.IOUtils;

--- a/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriterFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/file/DocumentFileWriterFactory.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import com.marklogic.spark.Options;

--- a/src/main/java/com/marklogic/spark/writer/file/FileCommitMessage.java
+++ b/src/main/java/com/marklogic/spark/writer/file/FileCommitMessage.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import org.apache.spark.sql.connector.write.WriterCommitMessage;

--- a/src/main/java/com/marklogic/spark/writer/file/FileUtil.java
+++ b/src/main/java/com/marklogic/spark/writer/file/FileUtil.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import com.marklogic.spark.Util;

--- a/src/main/java/com/marklogic/spark/writer/file/GzipFileWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/file/GzipFileWriter.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import org.apache.hadoop.fs.Path;

--- a/src/main/java/com/marklogic/spark/writer/file/RdfFileWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/file/RdfFileWriter.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/main/java/com/marklogic/spark/writer/file/ZipCommitMessage.java
+++ b/src/main/java/com/marklogic/spark/writer/file/ZipCommitMessage.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import org.apache.spark.sql.connector.write.WriterCommitMessage;

--- a/src/main/java/com/marklogic/spark/writer/file/ZipFileWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/file/ZipFileWriter.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/main/java/com/marklogic/spark/writer/rdf/GraphWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/rdf/GraphWriter.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.rdf;
 
 import com.marklogic.client.DatabaseClient;

--- a/src/main/java/com/marklogic/spark/writer/rdf/RdfRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/rdf/RdfRowConverter.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.rdf;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/main/java/com/marklogic/spark/writer/rdf/TriplesDocument.java
+++ b/src/main/java/com/marklogic/spark/writer/rdf/TriplesDocument.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.rdf;
 
 import com.marklogic.client.extra.jdom.JDOMHandle;

--- a/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
+++ b/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark;
 

--- a/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
+++ b/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
@@ -120,7 +120,7 @@ public abstract class AbstractIntegrationTest extends AbstractSpringMarkLogicTes
             String version = getDatabaseClient().newServerEval().javascript("xdmp.version()").evalAs(String.class);
             markLogicVersion = new MarkLogicVersion(version);
         }
-        return markLogicVersion.getMajor() == 10;
+        return markLogicVersion.getMajorNumber() == 10;
     }
 
     protected final boolean isSpark340OrHigher() {

--- a/src/test/java/com/marklogic/spark/BuildConnectionPropertiesTest.java
+++ b/src/test/java/com/marklogic/spark/BuildConnectionPropertiesTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark;
 

--- a/src/test/java/com/marklogic/spark/ContextSupportTest.java
+++ b/src/test/java/com/marklogic/spark/ContextSupportTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark;
 
 import com.marklogic.client.DatabaseClient;

--- a/src/test/java/com/marklogic/spark/CopyrightTest.java
+++ b/src/test/java/com/marklogic/spark/CopyrightTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.util.FileCopyUtils;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CopyrightTest {
+
+    /**
+     * You can configure Intellij to include the copyright in each new Java file you create via
+     * Preferences -> Editor -> File and Code Templates. If you choose to modify the "File Header.java"
+     * template under "Includes", you should then modify each of the Java templates - e.g. Class, Interface, etc - to
+     * put the "File Header.java" template at the top of the file and not below the package declaration.
+     */
+    @Test
+    void verifyAllJavaFilesHaveCopyright() throws IOException {
+        Files.walkFileTree(new File("src").toPath(), new FileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                if (file.toFile().getName().endsWith(".java")) {
+                    try (FileReader reader = new FileReader(file.toFile())) {
+                        String content = FileCopyUtils.copyToString(reader);
+                        String message = String.format("Does not start with copyright comment: %s", file.toFile().getAbsolutePath());
+                        assertTrue(content.startsWith("/*"), message);
+                        assertTrue(
+                            content.contains("Copyright © 2024 MarkLogic Corporation. All Rights Reserved."),
+                            message
+                        );
+                    }
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+}

--- a/src/test/java/com/marklogic/spark/MarkLogicVersion.java
+++ b/src/test/java/com/marklogic/spark/MarkLogicVersion.java
@@ -14,8 +14,8 @@ import org.apache.commons.lang3.StringUtils;
  */
 class MarkLogicVersion {
 
-    private int major;
-    private Integer minor;
+    private int majorNumber;
+    private Integer minorNumber;
     private boolean nightly;
 
     private static final String VERSION_WITH_PATCH_PATTERN = "^.*-(.+)\\..*";
@@ -27,28 +27,28 @@ class MarkLogicVersion {
         if (version.matches(nightlyPattern)) {
             this.nightly = true;
         } else if (version.matches(majorWithMinorPattern)) {
-            this.minor = version.matches(VERSION_WITH_PATCH_PATTERN) ?
+            this.minorNumber = version.matches(VERSION_WITH_PATCH_PATTERN) ?
                     parseMinorWithPatch(version) :
                     Integer.parseInt(version.replaceAll(majorWithMinorPattern, "$1") + "00");
         }
-        this.major = major;
+        this.majorNumber = major;
     }
 
     private int parseMinorWithPatch(String version) {
-        final int minorNumber = Integer.parseInt(version.replaceAll(VERSION_WITH_PATCH_PATTERN, "$1"));
+        final int minorValue = Integer.parseInt(version.replaceAll(VERSION_WITH_PATCH_PATTERN, "$1"));
         final int patch = Integer.parseInt(version.replaceAll("^.*-(.+)\\.(.*)", "$2"));
         final String leftPaddedPatchNumber = patch < 10 ?
                 StringUtils.leftPad(String.valueOf(patch), 2, "0") :
                 String.valueOf(patch);
-        return Integer.parseInt(minorNumber + leftPaddedPatchNumber);
+        return Integer.parseInt(minorValue + leftPaddedPatchNumber);
     }
 
-    public int getMajor() {
-        return major;
+    public int getMajorNumber() {
+        return majorNumber;
     }
 
-    public Integer getMinor() {
-        return minor;
+    public Integer getMinorNumber() {
+        return minorNumber;
     }
 
     public boolean isNightly() {

--- a/src/test/java/com/marklogic/spark/MarkLogicVersion.java
+++ b/src/test/java/com/marklogic/spark/MarkLogicVersion.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark;
 

--- a/src/test/java/com/marklogic/spark/SerializeUtil.java
+++ b/src/test/java/com/marklogic/spark/SerializeUtil.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark;
 
 import java.io.ByteArrayInputStream;

--- a/src/test/java/com/marklogic/spark/TestProgram.java
+++ b/src/test/java/com/marklogic/spark/TestProgram.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark;
 
 import org.apache.spark.sql.SparkSession;

--- a/src/test/java/com/marklogic/spark/TestUtil.java
+++ b/src/test/java/com/marklogic/spark/TestUtil.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark;
 
 import com.marklogic.client.DatabaseClient;

--- a/src/test/java/com/marklogic/spark/reader/customcode/ReadStreamWithCustomCodeTest.java
+++ b/src/test/java/com/marklogic/spark/reader/customcode/ReadStreamWithCustomCodeTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.customcode;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/marklogic/spark/reader/customcode/ReadWithCustomCodeTest.java
+++ b/src/test/java/com/marklogic/spark/reader/customcode/ReadWithCustomCodeTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.customcode;
 
 import com.marklogic.client.FailedRequestException;

--- a/src/test/java/com/marklogic/spark/reader/customcode/SerializeCustomCodeReaderTest.java
+++ b/src/test/java/com/marklogic/spark/reader/customcode/SerializeCustomCodeReaderTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.customcode;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/reader/document/BuildSearchQueryTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/BuildSearchQueryTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.DatabaseClient;

--- a/src/test/java/com/marklogic/spark/reader/document/MakeForestPartitionsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/MakeForestPartitionsTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.datamovement.Forest;

--- a/src/test/java/com/marklogic/spark/reader/document/PushDownLimitTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/PushDownLimitTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsByUrisTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsByUrisTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.junit5.XmlNode;

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsByUrisTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsByUrisTest.java
@@ -1,9 +1,12 @@
 package com.marklogic.spark.reader.document;
 
+import com.marklogic.junit5.XmlNode;
 import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.DataFrameReader;
+import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -77,6 +80,35 @@ class ReadDocumentRowsByUrisTest extends AbstractIntegrationTest {
             .count();
 
         assertEquals(0, count, "This verifies that the collection impacts the list of URIs.");
+    }
+
+    @Test
+    void nonUsAsciiUri() {
+        newSparkSession().read().format(CONNECTOR_IDENTIFIER)
+            .load("src/test/resources/encoding/太田佳伸のＸＭＬファイル.xml")
+            .write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
+            .option(Options.WRITE_URI_REPLACE, ".*encoding,''")
+            .mode(SaveMode.Append)
+            .save();
+
+        final String expectedUri = "/太田佳伸のＸＭＬファイル.xml";
+        XmlNode doc = readXmlDocument(expectedUri);
+        doc.assertElementValue("/root/filename", "太田佳伸のＸＭＬファイル");
+
+        Dataset<Row> dataset = sparkSession.read().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_DOCUMENTS_URIS, expectedUri)
+            .load();
+
+        assertEquals(1, dataset.count());
+        Row row = dataset.collectAsList().get(0);
+        assertEquals(expectedUri, row.getString(0),
+            "As of 7.0.0, the Java Client should default to setting mail.mime.allowutf8=true so that the " +
+                "Jakarta Mail library allows UTF-8 characters in the header names of multipart response parts. " +
+                "Normally, it only allows US-ASCII characters. But since MarkLogic allows UTF-8 characters in " +
+                "URIs, we need the Jakarta Mail library (used by the Java Client) to be more permissive.");
     }
 
     private DataFrameReader startRead() {

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsTest.java
@@ -6,7 +6,6 @@ package com.marklogic.spark.reader.document;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.MarkLogicIOException;
-import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
 import com.marklogic.spark.writer.AbstractWriteTest;

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsWithMetadataTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsWithMetadataTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.junit5.XmlNode;

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsWithPartitionCountsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsWithPartitionCountsTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsWithPartitionCountsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadDocumentRowsWithPartitionCountsTest.java
@@ -37,7 +37,7 @@ class ReadDocumentRowsWithPartitionCountsTest extends AbstractIntegrationTest {
     @Test
     void zeroPartitions() {
         Dataset<Row> dataset = readAuthors(0);
-        ConnectorException ex = assertThrows(ConnectorException.class, () -> dataset.count());
+        assertThrows(ConnectorException.class, () -> dataset.count());
     }
 
     @Test

--- a/src/test/java/com/marklogic/spark/reader/document/ReadFilteredDocumentRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/document/ReadFilteredDocumentRowsTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/reader/file/ConvertMlcpMetadataTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ConvertMlcpMetadataTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.client.io.DocumentMetadataHandle;

--- a/src/test/java/com/marklogic/spark/reader/file/MakeFilePartitionsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/MakeFilePartitionsTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/marklogic/spark/reader/file/ReadAggregateXmlFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadAggregateXmlFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.junit5.XmlNode;

--- a/src/test/java/com/marklogic/spark/reader/file/ReadAggregateXmlZipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadAggregateXmlZipFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.junit5.XmlNode;

--- a/src/test/java/com/marklogic/spark/reader/file/ReadAggregateXmlZipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadAggregateXmlZipFilesTest.java
@@ -53,21 +53,17 @@ class ReadAggregateXmlZipFilesTest extends AbstractIntegrationTest {
 
     @Test
     void uriElementHasMixedContent() {
-        Dataset<Row> dataset = newSparkSession().read()
+        List<Row> rows = newSparkSession().read()
             .format(CONNECTOR_IDENTIFIER)
             .option(Options.READ_AGGREGATES_XML_ELEMENT, "Employee")
             .option(Options.READ_AGGREGATES_XML_URI_ELEMENT, "mixed")
             .option(Options.READ_FILES_COMPRESSION, "zip")
-            .load("src/test/resources/aggregate-zips/employee-aggregates.zip");
+            .load("src/test/resources/aggregate-zips/employee-aggregates.zip")
+            .collectAsList();
 
-        ConnectorException ex = assertThrowsConnectorException(() -> dataset.count());
-        String message = ex.getMessage();
-        assertTrue(
-            message.startsWith(
-                "Unable to get text from URI element 'mixed' found in aggregate element 1 in entry employees.xml in file:///"
-            ),
-            "The error should identify the URI element that text could not be retrieved from along with which aggregate " +
-                "element and which zip entry produced the failure; actual message: " + message
+        rows.forEach(row ->
+            assertEquals("has mixed content", row.getString(0),
+                "Mixed content is supported by the connector in a URI element.")
         );
     }
 

--- a/src/test/java/com/marklogic/spark/reader/file/ReadArchiveFileTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadArchiveFileTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.junit5.XmlNode;

--- a/src/test/java/com/marklogic/spark/reader/file/ReadGenericFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadGenericFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/marklogic/spark/reader/file/ReadGzipAggregateXmlFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadGzipAggregateXmlFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.junit5.XmlNode;

--- a/src/test/java/com/marklogic/spark/reader/file/ReadGzipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadGzipFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/reader/file/ReadGzipRdfFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadGzipRdfFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/reader/file/ReadMlcpArchiveFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadMlcpArchiveFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.junit5.XmlNode;

--- a/src/test/java/com/marklogic/spark/reader/file/ReadMlcpArchiveWithNakedPropertiesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadMlcpArchiveWithNakedPropertiesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.junit5.XmlNode;

--- a/src/test/java/com/marklogic/spark/reader/file/ReadRdfFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadRdfFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/reader/file/ReadRdfZipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadRdfZipFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/reader/file/ReadZipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadZipFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.file;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/marklogic/spark/reader/optic/AbstractPushDownTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/AbstractPushDownTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/AnalyzePlanTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/AnalyzePlanTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/DisablePushDownAggregatesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/DisablePushDownAggregatesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.optic;
 
 import com.marklogic.spark.Options;

--- a/src/test/java/com/marklogic/spark/reader/optic/GroupByDuplicateColumnNamesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/GroupByDuplicateColumnNamesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.optic;
 
 import com.marklogic.spark.Options;

--- a/src/test/java/com/marklogic/spark/reader/optic/InferSchemaTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/InferSchemaTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/InferSchemaTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/InferSchemaTest.java
@@ -36,7 +36,7 @@ class InferSchemaTest extends AbstractIntegrationTest {
         String columnInfoResponse = readClasspathFile("allTypes-columnInfo-response.txt");
         StructType schema = SchemaInferrer.inferSchema(columnInfoResponse);
 
-        assertEquals(35, schema.size(), "The TDE has 35 columns, and the hidden 'rowid' column that's returned " +
+        assertEquals(36, schema.size(), "The TDE has 36 columns, and the hidden 'rowid' column that's returned " +
             "by /v1/rows should not be included in the Spark schema, as it will never be populated with a value.");
 
         String actualJson = schema.prettyJson();

--- a/src/test/java/com/marklogic/spark/reader/optic/MergeBucketsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/MergeBucketsTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.optic;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/marklogic/spark/reader/optic/PerformanceTester.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PerformanceTester.java
@@ -22,8 +22,6 @@ class PerformanceTester {
     public static void main(String[] args) {
         final int sparkConcurrentTaskCount = 16;
         final String query = "op.fromView('demo','employee')";
-//        final String query = "op.fromView('demo','employee').where(op.eq(op.col('job_description'), 'Technician'))";
-//        final String query = "op.fromView('demo', 'employee').where(op.le(op.col('person_id'), 8))";
         final long partitionCount = 8;
         final long batchSize = 100000;
 
@@ -48,6 +46,5 @@ class PerformanceTester {
         long duration = System.currentTimeMillis() - now;
         logger.info("Duration: {}; row count: {}; rows per second: {}", duration, count,
             (double) count / ((double) duration / 1000));
-//        rows.forEach(row -> logger.info(row.prettyJson()));
     }
 }

--- a/src/test/java/com/marklogic/spark/reader/optic/PerformanceTester.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PerformanceTester.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/PlanUtilTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PlanUtilTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/PushDownCountTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PushDownCountTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/PushDownFilterTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PushDownFilterTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/PushDownFilterValueTypesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PushDownFilterValueTypesTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByAvgTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByAvgTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.optic;
 
 import com.marklogic.spark.Options;

--- a/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByCountTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByCountTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByCountTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByCountTest.java
@@ -4,7 +4,6 @@
 package com.marklogic.spark.reader.optic;
 
 import com.marklogic.spark.Options;
-import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByManyAggregatesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByManyAggregatesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.optic;
 
 import com.marklogic.spark.Options;

--- a/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByMaxTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByMaxTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.optic;
 
 import com.marklogic.spark.Options;

--- a/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByMaxTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByMaxTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 import static org.apache.spark.sql.functions.max;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PushDownGroupByMaxTest extends AbstractPushDownTest {
 

--- a/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByMeanTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByMeanTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.optic;
 
 import com.marklogic.spark.Options;

--- a/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByMinTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupByMinTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.optic;
 
 import com.marklogic.spark.Options;

--- a/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupBySumTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PushDownGroupBySumTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.optic;
 
 import com.marklogic.spark.Options;

--- a/src/test/java/com/marklogic/spark/reader/optic/PushDownOrderByAndLimitTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PushDownOrderByAndLimitTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/PushDownPivotTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PushDownPivotTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.optic;
 
 import com.marklogic.spark.Options;

--- a/src/test/java/com/marklogic/spark/reader/optic/PushDownRequiredColumnsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/PushDownRequiredColumnsTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadFromNonRestApiServerTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadFromNonRestApiServerTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.optic;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadRowsFromTempViewTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadRowsFromTempViewTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.optic;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadRowsMultipleTimesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadRowsMultipleTimesTest.java
@@ -3,7 +3,6 @@
  */
 package com.marklogic.spark.reader.optic;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.JacksonHandle;
@@ -22,7 +21,7 @@ class ReadRowsMultipleTimesTest extends AbstractIntegrationTest {
      * Log statements are included here so it's easy to see what classes get created based on different Spark API calls.
      */
     @Test
-    void twoReadsWithInsertInBetween() throws Exception {
+    void twoReadsWithInsertInBetween() {
         logger.info("Creating reader");
         Dataset<Row> dataset = newDefaultReader()
             .option(Options.READ_OPTIC_QUERY, "op.fromView('sparkTest', 'allTypes')")

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadRowsMultipleTimesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadRowsMultipleTimesTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadRowsTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 
 package com.marklogic.spark.reader.optic;

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadRowsWithAllSparkDataTypesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadRowsWithAllSparkDataTypesTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadRowsWithAllSparkDataTypesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadRowsWithAllSparkDataTypesTest.java
@@ -16,10 +16,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.TimeZone;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * For more information on Spark data types, see https://spark.apache.org/docs/latest/sql-ref-datatypes.html.

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadRowsWithBasicAuthTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadRowsWithBasicAuthTest.java
@@ -3,7 +3,6 @@
  */
 package com.marklogic.spark.reader.optic;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.mgmt.ManageClient;
 import com.marklogic.mgmt.ManageConfig;
 import com.marklogic.mgmt.resource.appservers.ServerManager;

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadRowsWithBasicAuthTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadRowsWithBasicAuthTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadRowsWithInferredSchemaTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadRowsWithInferredSchemaTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadRowsWithInferredSchemaTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadRowsWithInferredSchemaTest.java
@@ -73,25 +73,26 @@ class ReadRowsWithInferredSchemaTest extends AbstractIntegrationTest {
         assertEquals("P2Y6M", row.getString(14)); // yearMonthDuration
         assertEquals("PT1M", row.getString(15)); // dayTimeDuration
         assertEquals("hello", row.getString(16));
-        assertEquals("http://example.org/", row.getString(17)); // anyURI
-        assertEquals("50,50", row.getString(18)); // point
-        assertEquals("50,50", row.getString(19)); // longLatPoint
-        assertTrue(row.getBoolean(20));
-        assertEquals("c2xpbmdzIGFuZCBhcnJvd3Mgb2Ygb3V0cmFnZW91cyBmb3J0dW5l", row.getString(21)); // base64Binary
-        assertEquals("499602D2", row.getString(22)); // hexBinary
-        assertEquals("1", row.getString(23), "Because MarkLogic defines the type of 'byte' as 'none', the Spark " +
+        assertEquals("hello collated", row.getString(17));
+        assertEquals("http://example.org/", row.getString(18)); // anyURI
+        assertEquals("50,50", row.getString(19)); // point
+        assertEquals("50,50", row.getString(20)); // longLatPoint
+        assertTrue(row.getBoolean(21));
+        assertEquals("c2xpbmdzIGFuZCBhcnJvd3Mgb2Ygb3V0cmFnZW91cyBmb3J0dW5l", row.getString(22)); // base64Binary
+        assertEquals("499602D2", row.getString(23)); // hexBinary
+        assertEquals("1", row.getString(24), "Because MarkLogic defines the type of 'byte' as 'none', the Spark " +
             "connector treats it as a string."); // byte
-        assertEquals("PT1M", row.getString(24)); // duration
-        assertEquals("--04-18", row.getString(25)); // gMonthDay
-        assertEquals(1, row.getInt(26));
-        assertEquals(-1, row.getInt(27)); // negativeInteger
-        assertEquals(11, row.getInt(28)); // nonNegativeInteger
-        assertEquals(-11, row.getInt(29)); // nonPositiveInteger
-        assertEquals(20, row.getInt(30)); // positiveInteger
-        assertEquals(7, row.getInt(31)); // short
-        assertEquals(4, row.getInt(32)); // unsignedByte
-        assertEquals(8, row.getInt(33)); // unsignedShort
-        assertEquals("http://example.org/", row.getString(34)); // IRI
+        assertEquals("PT1M", row.getString(25)); // duration
+        assertEquals("--04-18", row.getString(26)); // gMonthDay
+        assertEquals(1, row.getInt(27));
+        assertEquals(-1, row.getInt(28)); // negativeInteger
+        assertEquals(11, row.getInt(29)); // nonNegativeInteger
+        assertEquals(-11, row.getInt(30)); // nonPositiveInteger
+        assertEquals(20, row.getInt(31)); // positiveInteger
+        assertEquals(7, row.getInt(32)); // short
+        assertEquals(4, row.getInt(33)); // unsignedByte
+        assertEquals(8, row.getInt(34)); // unsignedShort
+        assertEquals("http://example.org/", row.getString(35)); // IRI
     }
 
     @Test
@@ -106,9 +107,9 @@ class ReadRowsWithInferredSchemaTest extends AbstractIntegrationTest {
         assertEquals(1, rows.size());
 
         Row row = rows.get(0);
-        assertEquals(35, row.size(), "Expecting all 35 columns to still exist, even though all but one have a null value");
+        assertEquals(36, row.size(), "Expecting all 36 columns to still exist, even though all but one have a null value");
         assertEquals(2, row.getInt(0));
-        for (int i = 1; i < 35; i++) {
+        for (int i = 1; i < 36; i++) {
             assertNull(row.get(i));
         }
     }

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadStreamOfRowsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadStreamOfRowsTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadWithClientUriTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadWithClientUriTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadWithJoinDocTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadWithJoinDocTest.java
@@ -4,7 +4,6 @@
 package com.marklogic.spark.reader.optic;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.Row;

--- a/src/test/java/com/marklogic/spark/reader/optic/ReadWithJoinDocTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/ReadWithJoinDocTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 

--- a/src/test/java/com/marklogic/spark/reader/optic/SerializeOpticReaderObjectsTest.java
+++ b/src/test/java/com/marklogic/spark/reader/optic/SerializeOpticReaderObjectsTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.optic;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;

--- a/src/test/java/com/marklogic/spark/reader/triples/ReadTriplesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/triples/ReadTriplesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.triples;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/reader/triples/ReadTriplesWithBaseIriTest.java
+++ b/src/test/java/com/marklogic/spark/reader/triples/ReadTriplesWithBaseIriTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.reader.triples;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/writer/AbstractWriteTest.java
+++ b/src/test/java/com/marklogic/spark/writer/AbstractWriteTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.writer;
 

--- a/src/test/java/com/marklogic/spark/writer/IgnoreNullValuesTest.java
+++ b/src/test/java/com/marklogic/spark/writer/IgnoreNullValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.writer;
 

--- a/src/test/java/com/marklogic/spark/writer/SerializeWriterObjectsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/SerializeWriterObjectsTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/writer/WriteArchiveOfFailedDocumentsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteArchiveOfFailedDocumentsTest.java
@@ -21,7 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WriteArchiveOfFailedDocumentsTest extends AbstractWriteTest {
 
@@ -62,6 +63,18 @@ class WriteArchiveOfFailedDocumentsTest extends AbstractWriteTest {
             .sort(new Column("URI"))
             .collectAsList();
         verifyArchiveRows(rows);
+    }
+
+    @Test
+    void noFailures(@TempDir Path tempDir) {
+        newWriter(1)
+            .option(Options.WRITE_ABORT_ON_FAILURE, false)
+            .option(Options.WRITE_ARCHIVE_PATH_FOR_FAILED_DOCUMENTS, tempDir.toFile().getAbsolutePath())
+            .save();
+
+        assertCollectionSize("This test is for manual inspection of the logs to ensure that no message is " +
+                "logged indicating that an archive file of failed documents was written when there are no errors.",
+            COLLECTION, 200);
     }
 
     @Test

--- a/src/test/java/com/marklogic/spark/writer/WriteArchiveOfFailedDocumentsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteArchiveOfFailedDocumentsTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/test/java/com/marklogic/spark/writer/WriteFileRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteFileRowsTest.java
@@ -114,6 +114,7 @@ class WriteFileRowsTest extends AbstractWriteTest {
     }
 
     @Test
+    @Deprecated
     void forceDocumentType() {
         newSparkSession()
             .read()
@@ -137,6 +138,7 @@ class WriteFileRowsTest extends AbstractWriteTest {
     }
 
     @Test
+    @Deprecated
     void invalidDocumentType() {
         DataFrameWriter writer = newSparkSession()
             .read()

--- a/src/test/java/com/marklogic/spark/writer/WriteFileRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteFileRowsTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer;
 
 import com.marklogic.client.DatabaseClient;

--- a/src/test/java/com/marklogic/spark/writer/WritePartialBatchTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WritePartialBatchTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer;
 
 import com.marklogic.spark.ConnectorException;

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.writer;
 

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
@@ -99,7 +99,7 @@ class WriteRowsTest extends AbstractWriteTest {
             .save();
 
         String uri = getUrisInCollection(COLLECTION, 1).get(0);
-        // Temporal doc is written to the temporal collection; "latest" since it's the latest version for that URI;
+        // Temporal doc is written to the temporal collection and 'latest' since it's the latest version for that URI,
         // and to a collection matching the URI of the document.
         assertInCollections(uri, COLLECTION, TEMPORAL_COLLECTION, "latest", uri);
     }

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsWithFilePathTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsWithFilePathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.writer;
 

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsWithJsonRootNameTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsWithJsonRootNameTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsWithTransformTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsWithTransformTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.writer;
 

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsWithTransformTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsWithTransformTest.java
@@ -9,13 +9,9 @@ import com.marklogic.junit5.NamespaceProvider;
 import com.marklogic.junit5.XmlNode;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
-import org.apache.spark.SparkException;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WriteRowsWithTransformTest extends AbstractWriteTest {

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsWithUriTemplateTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsWithUriTemplateTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.writer;
 

--- a/src/test/java/com/marklogic/spark/writer/WriteRowsWithUriTemplateTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteRowsWithUriTemplateTest.java
@@ -8,9 +8,7 @@ import com.marklogic.spark.Options;
 import org.apache.spark.SparkException;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class WriteRowsWithUriTemplateTest extends AbstractWriteTest {
 

--- a/src/test/java/com/marklogic/spark/writer/WriteSparkJsonTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteSparkJsonTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;

--- a/src/test/java/com/marklogic/spark/writer/WriteStreamOfRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteStreamOfRowsTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright 2023 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
 package com.marklogic.spark.writer;
 

--- a/src/test/java/com/marklogic/spark/writer/WriteStreamOfRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteStreamOfRowsTest.java
@@ -4,7 +4,6 @@
 package com.marklogic.spark.writer;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.streaming.DataStreamWriter;
 import org.apache.spark.sql.streaming.StreamingQuery;
@@ -17,9 +16,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Path;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class WriteStreamOfRowsTest extends AbstractWriteTest {
 

--- a/src/test/java/com/marklogic/spark/writer/WriteXmlRowsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/WriteXmlRowsTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer;
 
 import com.marklogic.junit5.XmlNode;

--- a/src/test/java/com/marklogic/spark/writer/customcode/ProcessMultipleRowsWithCustomCodeTest.java
+++ b/src/test/java/com/marklogic/spark/writer/customcode/ProcessMultipleRowsWithCustomCodeTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.customcode;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/marklogic/spark/writer/customcode/ProcessStreamWithCustomCodeTest.java
+++ b/src/test/java/com/marklogic/spark/writer/customcode/ProcessStreamWithCustomCodeTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.customcode;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/marklogic/spark/writer/customcode/ProcessWithCustomCodeTest.java
+++ b/src/test/java/com/marklogic/spark/writer/customcode/ProcessWithCustomCodeTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.customcode;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/marklogic/spark/writer/customcode/SerializeCustomCodeWriterTest.java
+++ b/src/test/java/com/marklogic/spark/writer/customcode/SerializeCustomCodeWriterTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.customcode;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/writer/document/WriteDocumentRowsToMarkLogicTest.java
+++ b/src/test/java/com/marklogic/spark/writer/document/WriteDocumentRowsToMarkLogicTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.document;
 
 import com.marklogic.client.io.DocumentMetadataHandle;

--- a/src/test/java/com/marklogic/spark/writer/document/WriteJsonRowsWithUriTemplateTest.java
+++ b/src/test/java/com/marklogic/spark/writer/document/WriteJsonRowsWithUriTemplateTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.document;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/marklogic/spark/writer/file/FileUtilTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/FileUtilTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/marklogic/spark/writer/file/PrettyPrintFilesTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/PrettyPrintFilesTest.java
@@ -50,7 +50,7 @@ class PrettyPrintFilesTest extends AbstractIntegrationTest {
     }
 
     @Test
-    void zipWithXmlAndJson(@TempDir Path tempDir) throws Exception {
+    void zipWithXmlAndJson(@TempDir Path tempDir) {
         SparkSession session = newSparkSession();
 
         session.read()

--- a/src/test/java/com/marklogic/spark/writer/file/PrettyPrintFilesTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/PrettyPrintFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/writer/file/WriteArchiveTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteArchiveTest.java
@@ -37,7 +37,7 @@ class WriteArchiveTest extends AbstractIntegrationTest {
         "properties",
         "metadatavalues"
     })
-    void writeAllMetadata(String metadata, @TempDir Path tempDir) throws Exception {
+    void writeAllMetadata(String metadata, @TempDir Path tempDir) {
         newSparkSession().read()
             .format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())

--- a/src/test/java/com/marklogic/spark/writer/file/WriteArchiveTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteArchiveTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import com.marklogic.junit5.XmlNode;

--- a/src/test/java/com/marklogic/spark/writer/file/WriteArchiveWithEncodingTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteArchiveWithEncodingTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/marklogic/spark/writer/file/WriteDocumentFilesTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteDocumentFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/marklogic/spark/writer/file/WriteDocumentGzipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteDocumentGzipFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/marklogic/spark/writer/file/WriteDocumentZipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteDocumentZipFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/marklogic/spark/writer/file/WriteFilesWithEncodingTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteFilesWithEncodingTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/marklogic/spark/writer/file/WriteRdfFilesTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteRdfFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/writer/file/WriteRdfGzipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteRdfGzipFilesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.file;
 
 import com.marklogic.spark.AbstractIntegrationTest;

--- a/src/test/java/com/marklogic/spark/writer/rdf/AbstractWriteRdfTest.java
+++ b/src/test/java/com/marklogic/spark/writer/rdf/AbstractWriteRdfTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.rdf;
 
 import com.marklogic.client.io.StringHandle;

--- a/src/test/java/com/marklogic/spark/writer/rdf/WriteQuadsTest.java
+++ b/src/test/java/com/marklogic/spark/writer/rdf/WriteQuadsTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.rdf;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/marklogic/spark/writer/rdf/WriteTriplesTest.java
+++ b/src/test/java/com/marklogic/spark/writer/rdf/WriteTriplesTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
 package com.marklogic.spark.writer.rdf;
 
 import com.marklogic.junit5.PermissionsTester;

--- a/src/test/ml-data/allTypes-data.json
+++ b/src/test/ml-data/allTypes-data.json
@@ -18,6 +18,7 @@
       "yearMonthDurationValue": "P2Y6M",
       "dayTimeDurationValue": "PT1M",
       "stringValue": "hello",
+      "collatedStringValue": "hello collated",
       "anyURIValue": "http://example.org/",
       "pointValue": "50 50",
       "longLatPointValue": "50 50",

--- a/src/test/ml-schemas/tde/allTypes.json
+++ b/src/test/ml-schemas/tde/allTypes.json
@@ -109,6 +109,13 @@
             "nullable": true
           },
           {
+            "name": "collatedStringValue",
+            "scalarType": "string",
+            "collation": "http://marklogic.com/collation/",
+            "val": "collatedStringValue",
+            "nullable": true
+          },
+          {
             "name": "anyURIValue",
             "scalarType": "anyURI",
             "val": "anyURIValue",

--- a/src/test/resources/allTypes-columnInfo-response.txt
+++ b/src/test/resources/allTypes-columnInfo-response.txt
@@ -15,6 +15,7 @@
 {"schema":"sparkTest", "view":"AllTypeRows", "column":"yearMonthDurationValue", "type":"yearMonthDuration", "hidden":false, "nullable":true}
 {"schema":"sparkTest", "view":"AllTypeRows", "column":"dayTimeDurationValue", "type":"dayTimeDuration", "hidden":false, "nullable":true}
 {"schema":"sparkTest", "view":"AllTypeRows", "column":"stringValue", "type":"string", "hidden":false, "nullable":true}
+{"schema":"sparkTest", "view":"AllTypeRows", "column":"collatedStringValue", "type":"collatedString", "hidden":false, "nullable":true}
 {"schema":"sparkTest", "view":"AllTypeRows", "column":"anyURIValue", "type":"anyUri", "hidden":false, "nullable":true}
 {"schema":"sparkTest", "view":"AllTypeRows", "column":"pointValue", "type":"point", "hidden":false, "nullable":true, "coordinate-system":"wgs84"}
 {"schema":"sparkTest", "view":"AllTypeRows", "column":"longLatPointValue", "type":"point", "hidden":false, "nullable":true, "coordinate-system":"wgs84"}

--- a/src/test/resources/allTypes-expected-spark-schema.json
+++ b/src/test/resources/allTypes-expected-spark-schema.json
@@ -104,6 +104,12 @@
       "metadata": {}
     },
     {
+      "name": "sparkTest.AllTypeRows.collatedStringValue",
+      "type": "string",
+      "nullable": true,
+      "metadata": {}
+    },
+    {
       "name": "sparkTest.AllTypeRows.anyURIValue",
       "type": "string",
       "nullable": true,

--- a/src/test/resources/encoding/太田佳伸のＸＭＬファイル.xml
+++ b/src/test/resources/encoding/太田佳伸のＸＭＬファイル.xml
@@ -1,0 +1,3 @@
+<root>
+<filename>太田佳伸のＸＭＬファイル</filename>
+</root>


### PR DESCRIPTION
Most of these changes are copyright updates. 

Draft release notes of the actual changes are at https://github.com/marklogic/marklogic-spark-connector/releases/edit/untagged-1ad369c60275884abe07 . 