### PR TITLE
MLE-17041 Can now stream when writing generic files

### DIFF
--- a/src/main/java/com/marklogic/spark/ContextSupport.java
+++ b/src/main/java/com/marklogic/spark/ContextSupport.java
@@ -25,7 +25,7 @@ public class ContextSupport implements Serializable {
     // client. Those two actions are rarely done, so the cost of synchronization will be negligible.
     private static final Object CLIENT_LOCK = new Object();
 
-    protected ContextSupport(Map<String, String> properties) {
+    public ContextSupport(Map<String, String> properties) {
         this.properties = properties;
         this.configuratorWasAdded = addOkHttpConfiguratorIfNecessary();
     }

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -155,6 +155,10 @@ public abstract class Options {
      * into the content column instead of the contents of the file. When used during the writer phase when writing rows
      * conforming to {@code DocumentRowSchema}, the connector will stream the file using the {@code FileContext} to
      * avoid reading its contents into memory.
+     * <p>
+     * Similarly, when used in the reader phase when reading documents from MarkLogic, the value of the 'content' column
+     * in each row will be null. During the writer phase, the connector will retrieve the document corresponding to the
+     * value in the 'uri' column and stream it to file.
      *
      * @since 2.4.0
      */

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
@@ -43,6 +43,9 @@ class DocumentContext extends ContextSupport {
     }
 
     boolean contentWasRequested() {
+        if ("true".equals(getStringOption(Options.STREAM_FILES))) {
+            return false;
+        }
         if (!hasOption(Options.READ_DOCUMENTS_CATEGORIES)) {
             return true;
         }

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentScanBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentScanBuilder.java
@@ -3,6 +3,8 @@
  */
 package com.marklogic.spark.reader.document;
 
+import com.marklogic.spark.Options;
+import com.marklogic.spark.Util;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.connector.read.SupportsPushDownLimit;
@@ -15,6 +17,9 @@ class DocumentScanBuilder implements ScanBuilder, SupportsPushDownLimit {
 
     DocumentScanBuilder(CaseInsensitiveStringMap options, StructType schema) {
         this.context = new DocumentContext(options, schema);
+        if ("true".equalsIgnoreCase(this.context.getStringOption(Options.STREAM_FILES)) && Util.MAIN_LOGGER.isInfoEnabled()) {
+            Util.MAIN_LOGGER.info("Will defer reading documents from MarkLogic so they can be streamed to files during the writer phase.");
+        }
     }
 
     @Override


### PR DESCRIPTION
Similar approach to importing - defer reading docs from MarkLogic until the writer phase. 