### PR TITLE
MLE-17084 Fix for streaming files with spaces in filename

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/file/ArchiveFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/ArchiveFileReader.java
@@ -87,7 +87,7 @@ class ArchiveFileReader implements PartitionReader<InternalRow> {
     }
 
     private void openNextFile() {
-        this.currentFilePath = fileContext.getDecodedFilePath(filePartition, nextFilePathIndex);
+        this.currentFilePath = fileContext.decodeFilePath(filePartition.getPaths().get(nextFilePathIndex));
         nextFilePathIndex++;
         this.currentZipInputStream = new ZipInputStream(fileContext.openFile(this.currentFilePath));
     }

--- a/src/main/java/com/marklogic/spark/reader/file/FileContext.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FileContext.java
@@ -72,8 +72,7 @@ public class FileContext extends ContextSupport implements Serializable {
         return this.encoding != null ? new String(bytes, this.encoding).getBytes() : bytes;
     }
 
-    public String getDecodedFilePath(FilePartition filePartition, int index) {
-        String path = filePartition.getPaths().get(index);
+    public String decodeFilePath(String path) {
         try {
             if (this.encoding != null) {
                 return URLDecoder.decode(path, this.encoding);

--- a/src/main/java/com/marklogic/spark/reader/file/GenericFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/GenericFileReader.java
@@ -41,7 +41,11 @@ class GenericFileReader implements PartitionReader<InternalRow> {
             return false;
         }
 
-        final String path = fileContext.getDecodedFilePath(filePartition, filePathIndex);
+        // If streaming, we want to put the unaltered file path in the row. The writer can then decode it and also use
+        // its original value as the URI, as the PUT v1/documents endpoint does not allow e.g. spaces.
+        final String originalFilePath = filePartition.getPaths().get(filePathIndex);
+        final String path = this.isStreaming ? originalFilePath : fileContext.decodeFilePath(originalFilePath);
+
         filePathIndex++;
         try {
             byte[] content = this.isStreaming ? serializeFileContext() : readFileIntoByteArray(path);

--- a/src/main/java/com/marklogic/spark/reader/file/GzipFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/GzipFileReader.java
@@ -38,7 +38,7 @@ class GzipFileReader implements PartitionReader<InternalRow> {
             return false;
         }
 
-        String currentFilePath = fileContext.getDecodedFilePath(filePartition, nextFilePathIndex);
+        String currentFilePath = fileContext.decodeFilePath(filePartition.getPaths().get(nextFilePathIndex));
         nextFilePathIndex++;
         InputStream gzipInputStream = null;
         try {

--- a/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
@@ -99,7 +99,7 @@ class MlcpArchiveFileReader implements PartitionReader<InternalRow> {
     }
 
     private void openNextFile() {
-        this.currentFilePath = fileContext.getDecodedFilePath(filePartition, nextFilePathIndex);
+        this.currentFilePath = fileContext.decodeFilePath(filePartition.getPaths().get(nextFilePathIndex));
         nextFilePathIndex++;
         this.currentZipInputStream = new ZipInputStream(fileContext.openFile(this.currentFilePath));
     }

--- a/src/main/java/com/marklogic/spark/reader/file/RdfFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/RdfFileReader.java
@@ -76,7 +76,7 @@ class RdfFileReader implements PartitionReader<InternalRow> {
     }
 
     private boolean initializeRdfStreamReader() {
-        this.currentFilePath = fileContext.getDecodedFilePath(filePartition, nextFilePathIndex);
+        this.currentFilePath = fileContext.decodeFilePath(filePartition.getPaths().get(nextFilePathIndex));
         if (logger.isDebugEnabled()) {
             logger.debug("Reading file {}", this.currentFilePath);
         }

--- a/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
@@ -68,7 +68,7 @@ class RdfZipFileReader implements PartitionReader<InternalRow> {
             }
 
             // Open up the next zip.
-            this.currentFilePath = fileContext.getDecodedFilePath(filePartition, nextFilePathIndex);
+            this.currentFilePath = fileContext.decodeFilePath(filePartition.getPaths().get(nextFilePathIndex));
             nextFilePathIndex++;
             this.currentZipInputStream = new CustomZipInputStream(fileContext.openFile(currentFilePath));
             return next();

--- a/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
@@ -71,7 +71,7 @@ class ZipFileReader implements PartitionReader<InternalRow> {
     }
 
     private void openNextFile() {
-        this.currentFilePath = fileContext.getDecodedFilePath(filePartition, nextFilePathIndex);
+        this.currentFilePath = fileContext.decodeFilePath(filePartition.getPaths().get(nextFilePathIndex));
         nextFilePathIndex++;
         this.currentZipInputStream = new ZipInputStream(fileContext.openFile(this.currentFilePath));
     }

--- a/src/main/java/com/marklogic/spark/reader/file/xml/AggregateXmlFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/AggregateXmlFileReader.java
@@ -53,7 +53,7 @@ public class AggregateXmlFileReader implements PartitionReader<InternalRow> {
             }
 
             try {
-                String path = fileContext.getDecodedFilePath(filePartition, filePathIndex);
+                String path = fileContext.decodeFilePath(filePartition.getPaths().get(filePathIndex));
                 nextRowToReturn = this.aggregateXMLSplitter.nextRow(path);
                 return true;
             } catch (RuntimeException ex) {
@@ -81,7 +81,7 @@ public class AggregateXmlFileReader implements PartitionReader<InternalRow> {
             return false;
         }
 
-        final String filePath = fileContext.getDecodedFilePath(filePartition, filePathIndex);
+        final String filePath = fileContext.decodeFilePath(filePartition.getPaths().get(filePathIndex));
         try {
             this.inputStream = fileContext.openFile(filePath);
             String identifierForError = "file " + filePath;

--- a/src/main/java/com/marklogic/spark/reader/file/xml/ZipAggregateXmlFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/ZipAggregateXmlFileReader.java
@@ -83,7 +83,7 @@ public class ZipAggregateXmlFileReader implements PartitionReader<InternalRow> {
     }
 
     private void openNextFile() {
-        this.currentFilePath = fileContext.getDecodedFilePath(filePartition, nextFilePathIndex);
+        this.currentFilePath = fileContext.decodeFilePath(filePartition.getPaths().get(nextFilePathIndex));
         nextFilePathIndex++;
         this.currentZipInputStream = new ZipInputStream(fileContext.openFile(this.currentFilePath));
     }

--- a/src/test/java/com/marklogic/spark/reader/file/ReadGenericFilesStreamingTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadGenericFilesStreamingTest.java
@@ -10,7 +10,6 @@ import org.apache.spark.sql.DataFrameWriter;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -45,7 +44,6 @@ class ReadGenericFilesStreamingTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @Disabled("Doesn't work yet, will fix as part of MLE-17084 in a follow-up PR")
     void streamFileWithSpacesInFilename() {
         Dataset<Row> dataset = newSparkSession().read().format(CONNECTOR_IDENTIFIER)
             .option(Options.STREAM_FILES, true)
@@ -57,7 +55,9 @@ class ReadGenericFilesStreamingTest extends AbstractIntegrationTest {
             .option(Options.WRITE_URI_REPLACE, ".*/with-spaces,''"));
 
         String uri = getUrisInCollection("streamed-files", 1).get(0);
-        assertEquals("/three uris.csv", uri);
+        assertEquals("/three%20uris.csv", uri, "Due to bug MLE-17088, the PUT v1/documents endpoint is not able to " +
+            "accept a URI with a space in it. So when streaming files with spaces in them, the URIs will have " +
+            "encoded spaces in them.");
     }
 
     @Test


### PR DESCRIPTION
We can't encode the URI due to the PUT bug, but this at least fixes streaming so that it can read and write a file with spaces in its filename. 