### PR TITLE
MLE-17059 Changing order of entries in archive

### DIFF
--- a/src/main/java/com/marklogic/spark/writer/file/ZipFileWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/file/ZipFileWriter.java
@@ -58,14 +58,16 @@ public class ZipFileWriter implements DataWriter<InternalRow> {
         }
         final String uri = row.getString(0);
         final String entryName = FileUtil.makePathFromDocumentURI(uri);
-        zipOutputStream.putNextEntry(new ZipEntry(entryName));
-        this.contentWriter.writeContent(row, zipOutputStream);
-        zipEntryCounter++;
+
         if (hasMetadata(row)) {
             zipOutputStream.putNextEntry(new ZipEntry(entryName + ".metadata"));
             this.contentWriter.writeMetadata(row, zipOutputStream);
             zipEntryCounter++;
         }
+
+        zipOutputStream.putNextEntry(new ZipEntry(entryName));
+        this.contentWriter.writeContent(row, zipOutputStream);
+        zipEntryCounter++;
     }
 
     @Override

--- a/src/test/java/com/marklogic/spark/writer/file/WriteArchiveTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteArchiveTest.java
@@ -64,6 +64,12 @@ class WriteArchiveTest extends AbstractIntegrationTest {
 
         assertEquals(4, rows.size(), "Expecting the 2 author JSON entries and 2 entries for metadata.");
 
+        for (int i = 0; i < 4; i += 2) {
+            String entryName = rows.get(i).getString(0);
+            assertTrue(entryName.endsWith(".metadata"), "The metadata should come before the content entry. " +
+                "This allows for the content to later be streamed back into MarkLogic. Entry name: " + entryName);
+        }
+
         final String expectedUriPrefix = "file://" + tempDir.toFile().getAbsolutePath();
         for (Row row : rows) {
             String uri = row.getString(0);


### PR DESCRIPTION
This is a non-breaking change, as the reader will determine based on the first entry name whether it's the "legacy" or the new format. 