### PR TITLE
MLE-17095 Refactoring; changed row converter to return iterator

### DIFF
--- a/src/main/java/com/marklogic/spark/writer/ArbitraryRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/ArbitraryRowConverter.java
@@ -20,9 +20,10 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 /**
  * Handles building a document from an "arbitrary" row - i.e. one with an unknown schema, where the row will be
@@ -53,7 +54,7 @@ class ArbitraryRowConverter implements RowConverter {
     }
 
     @Override
-    public Optional<DocBuilder.DocumentInputs> convertRow(InternalRow row) {
+    public Iterator<DocBuilder.DocumentInputs> convertRow(InternalRow row) {
         String initialUri = null;
         if (this.filePathIndex > -1) {
             initialUri = row.getString(this.filePathIndex) + "/" + UUID.randomUUID();
@@ -103,7 +104,7 @@ class ArbitraryRowConverter implements RowConverter {
             }
         }
 
-        return Optional.of(new DocBuilder.DocumentInputs(initialUri, contentHandle, uriTemplateValues, null));
+        return Stream.of(new DocBuilder.DocumentInputs(initialUri, contentHandle, uriTemplateValues, null)).iterator();
     }
 
     @Override

--- a/src/main/java/com/marklogic/spark/writer/FileRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/FileRowConverter.java
@@ -14,8 +14,10 @@ import org.apache.spark.sql.types.DataTypes;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Knows how to build a document from a row corresponding to our {@code FileRowSchema}.
@@ -33,12 +35,12 @@ class FileRowConverter implements RowConverter {
     }
 
     @Override
-    public Optional<DocBuilder.DocumentInputs> convertRow(InternalRow row) {
+    public Iterator<DocBuilder.DocumentInputs> convertRow(InternalRow row) {
         final String path = row.getString(writeContext.getFileSchemaPathPosition());
         BytesHandle contentHandle = new BytesHandle(row.getBinary(writeContext.getFileSchemaContentPosition()));
         forceFormatIfNecessary(contentHandle);
         Optional<JsonNode> uriTemplateValues = deserializeContentToJson(path, contentHandle, row);
-        return Optional.of(new DocBuilder.DocumentInputs(path, contentHandle, uriTemplateValues.orElse(null), null));
+        return Stream.of(new DocBuilder.DocumentInputs(path, contentHandle, uriTemplateValues.orElse(null), null)).iterator();
     }
 
     @Override

--- a/src/main/java/com/marklogic/spark/writer/RowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/RowConverter.java
@@ -5,8 +5,8 @@ package com.marklogic.spark.writer;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 
+import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Strategy interface for how a Spark row is converted into a set of inputs for writing a document to MarkLogic.
@@ -14,13 +14,11 @@ import java.util.Optional;
 public interface RowConverter {
 
     /**
-     * An implementation can return an empty Optional, which will happen when the row will be used with other rows to
-     * form a document.
-     *
      * @param row
-     * @return
+     * @return an iterator of inputs for creating documents to write to MarkLogic. An iterator is used to allow the
+     * implementor to return multiple documents if necessary.
      */
-    Optional<DocBuilder.DocumentInputs> convertRow(InternalRow row);
+    Iterator<DocBuilder.DocumentInputs> convertRow(InternalRow row);
 
     /**
      * Called when {@code WriteBatcherDataWriter} has no more rows to send, but the implementation may have one or

--- a/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
@@ -30,8 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -92,9 +92,10 @@ class WriteBatcherDataWriter implements DataWriter<InternalRow> {
     @Override
     public void write(InternalRow row) {
         throwWriteFailureIfExists();
-        Optional<DocBuilder.DocumentInputs> document = rowConverter.convertRow(row);
-        if (document.isPresent()) {
-            DocumentWriteOperation writeOp = this.docBuilder.build(document.get());
+
+        Iterator<DocBuilder.DocumentInputs> iterator = rowConverter.convertRow(row);
+        while (iterator.hasNext()) {
+            DocumentWriteOperation writeOp = this.docBuilder.build(iterator.next());
             if (this.isStreamingFiles) {
                 writeDocumentViaPutOperation(writeOp);
             } else {

--- a/src/main/java/com/marklogic/spark/writer/rdf/RdfRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/rdf/RdfRowConverter.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Converts each row into a sem:triple element, which is then added to a sem:triples XML document associated with a
@@ -60,7 +61,7 @@ public class RdfRowConverter implements RowConverter {
     }
 
     @Override
-    public Optional<DocBuilder.DocumentInputs> convertRow(InternalRow row) {
+    public Iterator<DocBuilder.DocumentInputs> convertRow(InternalRow row) {
         final String graph = determineGraph(row);
         graphs.add(graph);
 
@@ -75,9 +76,9 @@ public class RdfRowConverter implements RowConverter {
         triplesDocument.addTriple(row);
         if (triplesDocument.hasMaxTriples()) {
             triplesDocuments.remove(graph);
-            return Optional.of(triplesDocument.buildDocument());
+            return Stream.of(triplesDocument.buildDocument()).iterator();
         }
-        return Optional.empty();
+        return Stream.<DocBuilder.DocumentInputs>empty().iterator();
     }
 
     /**


### PR DESCRIPTION
This allows for the archive streaming feature to return more than one document per Spark row. Has no effect on existing behavior. 

No longer need the `Content` class, so removed that. 

Also did some refactoring in `ArchiveFileReader` to shorten methods and make it more readable. 