### PR TITLE
MLE-17095 Can now stream when exporting an archive

### DIFF
--- a/src/main/java/com/marklogic/spark/Util.java
+++ b/src/main/java/com/marklogic/spark/Util.java
@@ -3,6 +3,7 @@
  */
 package com.marklogic.spark;
 
+import com.marklogic.client.document.DocumentManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,5 +72,22 @@ public interface Util {
         ResourceBundle bundle = ResourceBundle.getBundle("marklogic-spark-messages", Locale.getDefault());
         String optionName = bundle.getString(option);
         return optionName != null && optionName.trim().length() > 0 ? optionName.trim() : option;
+    }
+
+    static Set<DocumentManager.Metadata> getRequestedMetadata(ContextSupport context) {
+        Set<DocumentManager.Metadata> set = new HashSet<>();
+        if (context.hasOption(Options.READ_DOCUMENTS_CATEGORIES)) {
+            for (String category : context.getStringOption(Options.READ_DOCUMENTS_CATEGORIES).split(",")) {
+                if ("content".equalsIgnoreCase(category)) {
+                    continue;
+                }
+                if ("metadata".equalsIgnoreCase(category)) {
+                    set.add(DocumentManager.Metadata.ALL);
+                } else {
+                    set.add(DocumentManager.Metadata.valueOf(category.toUpperCase()));
+                }
+            }
+        }
+        return set;
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
@@ -4,16 +4,13 @@
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.document.DocumentManager;
 import com.marklogic.client.query.SearchQueryDefinition;
 import com.marklogic.spark.ContextSupport;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 class DocumentContext extends ContextSupport {
 
@@ -23,23 +20,6 @@ class DocumentContext extends ContextSupport {
     DocumentContext(CaseInsensitiveStringMap options, StructType schema) {
         super(options.asCaseSensitiveMap());
         this.schema = schema;
-    }
-
-    Set<DocumentManager.Metadata> getRequestedMetadata() {
-        Set<DocumentManager.Metadata> set = new HashSet<>();
-        if (hasOption(Options.READ_DOCUMENTS_CATEGORIES)) {
-            for (String category : getStringOption(Options.READ_DOCUMENTS_CATEGORIES).split(",")) {
-                if ("content".equalsIgnoreCase(category)) {
-                    continue;
-                }
-                if ("metadata".equalsIgnoreCase(category)) {
-                    set.add(DocumentManager.Metadata.ALL);
-                } else {
-                    set.add(DocumentManager.Metadata.valueOf(category.toUpperCase()));
-                }
-            }
-        }
-        return set;
     }
 
     boolean contentWasRequested() {

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentScanBuilder.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentScanBuilder.java
@@ -3,7 +3,6 @@
  */
 package com.marklogic.spark.reader.document;
 
-import com.marklogic.spark.Options;
 import com.marklogic.spark.Util;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;

--- a/src/main/java/com/marklogic/spark/reader/document/ForestReader.java
+++ b/src/main/java/com/marklogic/spark/reader/document/ForestReader.java
@@ -16,6 +16,7 @@ import com.marklogic.client.query.SearchQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.spark.Options;
 import com.marklogic.spark.ReadProgressLogger;
+import com.marklogic.spark.Util;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.PartitionReader;
 import org.slf4j.Logger;
@@ -74,7 +75,7 @@ class ForestReader implements PartitionReader<InternalRow> {
         this.documentManager = client.newDocumentManager();
         this.documentManager.setReadTransform(query.getResponseTransform());
         this.contentWasRequested = context.contentWasRequested();
-        this.requestedMetadata = context.getRequestedMetadata();
+        this.requestedMetadata = Util.getRequestedMetadata(context);
         this.documentManager.setMetadataCategories(this.requestedMetadata);
         this.queryBuilder = client.newQueryManager().newStructuredQueryBuilder();
     }

--- a/src/main/java/com/marklogic/spark/reader/file/GenericFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/GenericFileReader.java
@@ -4,7 +4,6 @@
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;
-import com.marklogic.spark.Options;
 import com.marklogic.spark.Util;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;

--- a/src/test/java/com/marklogic/spark/writer/file/WriteArchiveTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteArchiveTest.java
@@ -7,10 +7,13 @@ import com.marklogic.junit5.XmlNode;
 import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.Options;
 import com.marklogic.spark.TestUtil;
+import com.marklogic.spark.reader.document.DocumentRowSchema;
+import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.jdom2.Namespace;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -18,8 +21,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.nio.file.Path;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class WriteArchiveTest extends AbstractIntegrationTest {
 
@@ -53,6 +55,38 @@ class WriteArchiveTest extends AbstractIntegrationTest {
 
         assertEquals(1, tempDir.toFile().listFiles().length, "Expecting 1 zip since repartition created 1 partition writer.");
         verifyMetadataFiles(tempDir, metadata);
+    }
+
+    @Test
+    void streaming(@TempDir Path tempDir) {
+        Dataset<Row> dataset = newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_DOCUMENTS_COLLECTIONS, "collection1")
+            .option(Options.STREAM_FILES, true)
+            .load();
+
+        dataset.collectAsList().forEach(row -> {
+            assertNotNull(row.getString(0), "The URI column should have the URI of the document to retrieve during the writer phase.");
+            for (int i = 1; i < DocumentRowSchema.SCHEMA.size(); i++) {
+                assertTrue(row.isNullAt(i), "Every other column in the row should be null. We don't want the content, " +
+                    "as that will be retrieved by the writer. And we unfortunately can't get the metadata without " +
+                    "getting the content as well via a POST to v1/documents. So the writer will get the metadata " +
+                    "as well.");
+            }
+        });
+
+        dataset.repartition(1)
+            .write()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.WRITE_FILES_COMPRESSION, "zip")
+            .option(Options.READ_DOCUMENTS_CATEGORIES, "content,collections")
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.STREAM_FILES, true)
+            .mode(SaveMode.Append)
+            .save(tempDir.toFile().getAbsolutePath());
+
+        verifyMetadataFiles(tempDir, "collections");
     }
 
     private void verifyMetadataFiles(Path tempDir, String metadataValue) {
@@ -96,18 +130,22 @@ class WriteArchiveTest extends AbstractIntegrationTest {
         switch (metadataValue) {
             case "collections":
                 verifyCollections(metadata);
+                verifyPermissionsMissing(metadata);
                 break;
             case "permissions":
                 verifyPermissions(metadata);
                 break;
             case "quality":
                 verifyQuality(metadata);
+                verifyPermissionsMissing(metadata);
                 break;
             case "properties":
                 verifyProperties(metadata);
+                verifyPermissionsMissing(metadata);
                 break;
             case "metadatavalues":
                 verifyMetadataValues(metadata);
+                verifyPermissionsMissing(metadata);
                 break;
             case "metadata":
                 verifyCollections(metadata);
@@ -129,6 +167,11 @@ class WriteArchiveTest extends AbstractIntegrationTest {
         metadata.assertElementExists(path + "[rapi:role-name = 'spark-user-role' and rapi:capability='update']");
         metadata.assertElementExists(path + "[rapi:role-name = 'spark-user-role' and rapi:capability='read']");
         metadata.assertElementExists(path + "[rapi:role-name = 'qconsole-user' and rapi:capability='read']");
+    }
+
+    private void verifyPermissionsMissing(XmlNode metadata) {
+        metadata.assertElementMissing("Permissions should not exist since they were not in the set of " +
+            "metadata categories.", "/rapi:metadata/rapi:permissions");
     }
 
     private void verifyQuality(XmlNode metadata) {


### PR DESCRIPTION
Was fairly simple, since `ContentWriter` already supported streaming normal documents. 