### PR TITLE
MLE-17141 Can now stream normal zip files into MarkLogic

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/file/FileContext.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FileContext.java
@@ -40,7 +40,7 @@ public class FileContext extends ContextSupport implements Serializable {
         }
     }
 
-    boolean isZip() {
+    public boolean isZip() {
         return "zip".equalsIgnoreCase(getStringOption(Options.READ_FILES_COMPRESSION));
     }
 

--- a/src/main/java/com/marklogic/spark/reader/file/FileUtil.java
+++ b/src/main/java/com/marklogic/spark/reader/file/FileUtil.java
@@ -3,9 +3,12 @@
  */
 package com.marklogic.spark.reader.file;
 
+import com.marklogic.spark.ConnectorException;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipEntry;
@@ -63,5 +66,18 @@ public interface FileUtil {
             partitions[partitionIndex] = new FilePartition(currentPartition);
         }
         return partitions;
+    }
+
+    static byte[] serializeFileContext(FileContext fileContext, String currentFilePath) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(fileContext);
+            oos.flush();
+            return baos.toByteArray();
+        } catch (Exception ex) {
+            String message = String.format("Unable to build row for file at %s; cause: %s",
+                currentFilePath, ex.getMessage());
+            throw new ConnectorException(message, ex);
+        }
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/file/GenericFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/GenericFileReader.java
@@ -11,10 +11,8 @@ import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.unsafe.types.ByteArray;
 import org.apache.spark.unsafe.types.UTF8String;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectOutputStream;
 
 /**
  * "Generic" = read each file as-is with no special processing.
@@ -47,7 +45,9 @@ class GenericFileReader implements PartitionReader<InternalRow> {
 
         filePathIndex++;
         try {
-            byte[] content = this.isStreaming ? serializeFileContext() : readFileIntoByteArray(path);
+            byte[] content = this.isStreaming ?
+                FileUtil.serializeFileContext(fileContext, path) :
+                readFileIntoByteArray(path);
 
             nextRowToReturn = new GenericInternalRow(new Object[]{
                 UTF8String.fromString(path),
@@ -79,13 +79,5 @@ class GenericFileReader implements PartitionReader<InternalRow> {
         try (InputStream inputStream = fileContext.openFile(path)) {
             return fileContext.readBytes(inputStream);
         }
-    }
-
-    private byte[] serializeFileContext() throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
-            oos.writeObject(fileContext);
-        }
-        return baos.toByteArray();
     }
 }

--- a/src/main/java/com/marklogic/spark/reader/file/StreamingMode.java
+++ b/src/main/java/com/marklogic/spark/reader/file/StreamingMode.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.reader.file;
+
+/**
+ * Used when streaming from a zip file or archive file.
+ */
+public enum StreamingMode {
+
+    STREAM_DURING_READER_PHASE,
+    STREAM_DURING_WRITER_PHASE
+    
+}

--- a/src/main/java/com/marklogic/spark/writer/file/ArchiveFileIterator.java
+++ b/src/main/java/com/marklogic/spark/writer/file/ArchiveFileIterator.java
@@ -6,6 +6,7 @@ package com.marklogic.spark.writer.file;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.InputStreamHandle;
+import com.marklogic.spark.Util;
 import com.marklogic.spark.reader.document.DocumentRowSchema;
 import com.marklogic.spark.reader.file.ArchiveFileReader;
 import com.marklogic.spark.writer.DocBuilder;
@@ -20,8 +21,8 @@ import java.util.Iterator;
  */
 public class ArchiveFileIterator implements Iterator<DocBuilder.DocumentInputs> {
 
-    private ArchiveFileReader archiveFileReader;
-    private Format documentFormat;
+    private final ArchiveFileReader archiveFileReader;
+    private final Format documentFormat;
 
     public ArchiveFileIterator(ArchiveFileReader archiveFileReader, Format documentFormat) {
         this.archiveFileReader = archiveFileReader;
@@ -39,9 +40,12 @@ public class ArchiveFileIterator implements Iterator<DocBuilder.DocumentInputs> 
     @SuppressWarnings("java:S2272")
     public DocBuilder.DocumentInputs next() {
         InternalRow row = archiveFileReader.get();
+        String uri = row.getString(0);
+        if (Util.MAIN_LOGGER.isDebugEnabled()) {
+            Util.MAIN_LOGGER.debug("Creating input stream for entry {}", uri);
+        }
         InputStreamHandle contentHandle = archiveFileReader.getContentHandleForCurrentZipEntry();
         DocumentMetadataHandle metadata = DocumentRowSchema.makeDocumentMetadata(row);
-        String uri = row.getString(0);
         if (this.documentFormat != null) {
             contentHandle.withFormat(this.documentFormat);
         }

--- a/src/main/java/com/marklogic/spark/writer/file/ZipFileIterator.java
+++ b/src/main/java/com/marklogic/spark/writer/file/ZipFileIterator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.file;
+
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.InputStreamHandle;
+import com.marklogic.spark.Util;
+import com.marklogic.spark.reader.file.ZipFileReader;
+import com.marklogic.spark.writer.DocBuilder;
+import org.apache.spark.sql.catalyst.InternalRow;
+
+import java.util.Iterator;
+
+public class ZipFileIterator implements Iterator<DocBuilder.DocumentInputs> {
+
+    private final ZipFileReader zipFileReader;
+    private final Format documentFormat;
+
+    public ZipFileIterator(ZipFileReader zipFileReader, Format documentFormat) {
+        this.zipFileReader = zipFileReader;
+        this.documentFormat = documentFormat;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return zipFileReader.next();
+    }
+
+    @Override
+    // Suppressing sonar warning about throwing a NoSuchElementException. We know this is only used by
+    // DocumentRowConverter, which properly calls hasNext() before calling next().
+    @SuppressWarnings("java:S2272")
+    public DocBuilder.DocumentInputs next() {
+        InternalRow row = zipFileReader.get();
+        String uri = row.getString(0);
+        if (Util.MAIN_LOGGER.isDebugEnabled()) {
+            Util.MAIN_LOGGER.debug("Creating input stream for entry {}", uri);
+        }
+        InputStreamHandle contentHandle = zipFileReader.getContentHandleForCurrentZipEntry();
+        if (this.documentFormat != null) {
+            contentHandle.withFormat(this.documentFormat);
+        }
+        return new DocBuilder.DocumentInputs(uri, contentHandle, null, null);
+    }
+}


### PR DESCRIPTION
Going to do export next - which may "just work", will add a test first. 

This is similar to archive streaming where it may ultimately be better to make a separate file reader. It's a tradeoff of duplicating some logic into separate readers vs having more conditionals in one reader. 
