### PR TITLE
Updated Sonar to latest version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 This guide covers how to develop and test this project. It assumes that you have cloned this repository to your local
 workstation.
 
-You must use Java 11 or higher for developing, testing, and building this project. 
+You must use Java 11 or higher for developing, testing, and building this project. If you wish to use Sonar as 
+described below, you must use Java 17 or higher.
 
 # Setup
 
@@ -44,8 +45,8 @@ To run the tests against the test application, run the following Gradle task:
 
 ## Generating code quality reports with SonarQube
 
-In order to use SonarQube, you must have used Docker to run this project's `docker-compose.yml` file and you must
-have the services in that file running.
+In order to use SonarQube, you must have used Docker to run this project's `docker-compose.yml` file, and you must
+have the services in that file running and you must use Java 17 to run the Gradle `sonar` task.
 
 To configure the SonarQube service, perform the following steps:
 
@@ -61,8 +62,8 @@ To configure the SonarQube service, perform the following steps:
 10. Add `systemProp.sonar.token=your token pasted here` to `gradle-local.properties` in the root of your project, creating
 that file if it does not exist yet.
 
-To run SonarQube, run the following Gradle tasks, which will run all the tests with code coverage and then generate
-a quality report with SonarQube:
+To run SonarQube, run the following Gradle tasks using Java 17, which will run all the tests with code coverage and 
+then generate a quality report with SonarQube:
 
     ./gradlew test sonar
 
@@ -81,13 +82,6 @@ you've introduced on the feature branch you're working on. You can then click on
 
 Note that if you only need results on code smells and vulnerabilities, you can repeatedly run `./gradlew sonar`
 without having to re-run the tests.
-
-Our Sonar instance is also configured to scan for dependency vulnerabilities 
-[via the dependency-check plugin](https://github.com/dependency-check/dependency-check-sonar-plugin). For more 
-information, see the `dependencyCheck` block in this project's `build.gradle` file. To include dependency check results,
-just run the following (it's not included by default when running the `sonar` task):
-
-    ./gradlew dependencyCheckAnalyze sonar
 
 ## Accessing MarkLogic logs in Grafana
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline{
     buildDiscarder logRotator(artifactDaysToKeepStr: '7', artifactNumToKeepStr: '', daysToKeepStr: '30', numToKeepStr: '')
   }
   environment{
-    JAVA11_HOME_DIR="/home/builder/java/jdk-11.0.2"
+    JAVA17_HOME_DIR="/home/builder/java/jdk-17.0.2"
     GRADLE_DIR   =".gradle"
     DMC_USER     = credentials('MLBUILD_USER')
     DMC_PASSWORD = credentials('MLBUILD_PASSWORD')
@@ -61,9 +61,9 @@ pipeline{
             docker-compose down -v || true
             docker-compose up -d --build
           '''
-        runtests('JAVA11_HOME_DIR')
+        runtests('JAVA17_HOME_DIR')
         withSonarQubeEnv('SONAR_Progress') {
-          runSonarScan('JAVA11_HOME_DIR')
+          runSonarScan('JAVA17_HOME_DIR')
         }
       }
       post{
@@ -83,7 +83,7 @@ pipeline{
       }
       steps{
       	sh label:'publish', script: '''#!/bin/bash
-          export JAVA_HOME=$JAVA11_HOME_DIR
+          export JAVA_HOME=$JAVA17_HOME_DIR
           export GRADLE_USER_HOME=$WORKSPACE/$GRADLE_DIR
           export PATH=$GRADLE_USER_HOME:$JAVA_HOME/bin:$PATH
           cp ~/.gradle/gradle.properties $GRADLE_USER_HOME;
@@ -110,7 +110,7 @@ pipeline{
                 docker-compose down -v || true
                 MARKLOGIC_TAG=latest-10.0 docker-compose up -d --build
             '''
-            runtests('JAVA11_HOME_DIR')
+            runtests('JAVA17_HOME_DIR')
       }
       post{
         always{

--- a/build.gradle
+++ b/build.gradle
@@ -2,20 +2,17 @@ plugins {
   id 'java-library'
   id 'net.saliman.properties' version '1.5.2'
   id 'com.github.johnrengelman.shadow' version '8.1.1'
-  id "com.marklogic.ml-gradle" version "4.7.0"
+  id "com.marklogic.ml-gradle" version "5.0.0"
   id 'maven-publish'
-  id 'signing'
   id "jacoco"
-  id "org.sonarqube" version "4.4.1.3373"
-  id "org.owasp.dependencycheck" version "10.0.3"
+  id "org.sonarqube" version "5.1.0.4882"
 }
 
 group 'com.marklogic'
 version '2.4-SNAPSHOT'
 
 java {
-  // To support reading RDF files, Apache Jena is used - but that requires Java 11. If we want to do a 2.2.0 release
-  // without requiring Java 11, we'll remove the support for reading RDF files along with the Jena dependency.
+  // To support reading RDF files, Apache Jena is used - but that requires Java 11.
   sourceCompatibility = 11
   targetCompatibility = 11
 }
@@ -55,7 +52,7 @@ dependencies {
     exclude group: "com.fasterxml.jackson.dataformat"
   }
 
-  // Required for converting JSON to XML. Using 2.14.2 to align with Spark 3.4.1.
+  // Required for converting JSON to XML. Using 2.14.2 to align with Spark 3.4.3.
   shadowDependencies "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.2"
 
   // Need this so that an OkHttpClientConfigurator can be created.
@@ -68,7 +65,7 @@ dependencies {
 
   shadowDependencies "org.jdom:jdom2:2.0.6.1"
 
-  testImplementation ('com.marklogic:ml-app-deployer:4.8.0') {
+  testImplementation ('com.marklogic:ml-app-deployer:5.0.0') {
     exclude group: "com.fasterxml.jackson.core"
     exclude group: "com.fasterxml.jackson.dataformat"
 
@@ -85,18 +82,8 @@ dependencies {
   }
 
   testImplementation "ch.qos.logback:logback-classic:1.3.14"
-  testImplementation "org.slf4j:jcl-over-slf4j:1.7.36"
+  testImplementation "org.slf4j:jcl-over-slf4j:2.0.13"
   testImplementation "org.skyscreamer:jsonassert:1.5.1"
-}
-
-// See https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html for more information.
-dependencyCheck {
-  // Need a JSON report to integrate with Sonar. And HTML is easier for humans to read.
-  formats = ["HTML", "JSON"]
-  // We don't include compileOnly since that includes Spark, and Spark and its dependencies are not actual dependencies
-  // of our connector.
-  scanConfigurations = ["shadowDependencies"]
-  suppressionFile = "config/dependency-check-suppressions.xml"
 }
 
 test {
@@ -136,7 +123,8 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
     // for an explanation of why these are needed when running the tests on Java 17.
     jvmArgs = [
       '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED',
-      '--add-opens=java.base/sun.util.calendar=ALL-UNNAMED'
+      '--add-opens=java.base/sun.util.calendar=ALL-UNNAMED',
+      '--add-opens=java.base/sun.security.action=ALL-UNNAMED'
     ]
   }
 }
@@ -177,9 +165,6 @@ javadoc.options.addStringOption('Xdoclint:none', '-quiet')
 
 artifacts {
   archives javadocJar, sourcesJar
-}
-signing {
-  sign configurations.archives
 }
 
 publishing {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,8 +19,7 @@ services:
 
   # Copied from https://docs.sonarsource.com/sonarqube/latest/setup-and-upgrade/install-the-server/#example-docker-compose-configuration .
   sonarqube:
-    # Using 10.2 to avoid requiring Java 17 for now.
-    image: sonarqube:10.2.1-community
+    image: sonarqube:10.6.0-community
     depends_on:
       - postgres
     environment:
@@ -28,15 +27,12 @@ services:
       SONAR_JDBC_USERNAME: sonar
       SONAR_JDBC_PASSWORD: sonar
     volumes:
-      - ./docker/sonarqube/data:/opt/sonarqube/data
-      - ./docker/sonarqube/logs:/opt/sonarqube/logs
-      # Allows for Sonar plugins to be installed by including plugin jar files in this directory.
-      - ./docker/sonarqube/extensions:/opt/sonarqube/extensions
+      - sonarqube_data:/opt/sonarqube/data
     ports:
       - "9000:9000"
 
   postgres:
-    image: postgres:12
+    image: postgres:15
     environment:
       POSTGRES_USER: sonar
       POSTGRES_PASSWORD: sonar
@@ -46,7 +42,5 @@ services:
 
 volumes:
   sonarqube_data:
-  sonarqube_extensions:
-  sonarqube_logs:
   postgresql:
   postgresql_data:

--- a/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
@@ -55,8 +55,9 @@ public class ZipFileReader implements PartitionReader<InternalRow> {
             currentZipEntry = FileUtil.findNextFileEntry(currentZipInputStream);
         } catch (IOException e) {
             throw new ConnectorException(String.format(
-                "Unable to read from zip file %s; cause: %s", currentFilePath, e.getMessage(), e));
+                "Unable to read from zip file %s; cause: %s", currentFilePath, e.getMessage()), e);
         }
+
         if (currentZipEntry != null) {
             return true;
         }


### PR DESCRIPTION
My local Sonar on 10.2-1 crapped out locally. Couldn't revive it. But then found that the latest sonarqube - 10.6 - is running just fine, though it requires Java 17.

Bumped up some test dependencies and removed the "signing" plugin which is no longer needed. 

Also removed the dependency check plug-in, as we're not making use of it yet. 
