### PR TITLE
MLE-17142 Ensuring input streams are closed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,10 @@ you've introduced on the feature branch you're working on. You can then click on
 Note that if you only need results on code smells and vulnerabilities, you can repeatedly run `./gradlew sonar`
 without having to re-run the tests.
 
+You can also force Gradle to run `sonar` if any tests fail:
+
+    ./gradlew clean test sonar --continue
+
 ## Accessing MarkLogic logs in Grafana
 
 This project's `docker-compose-3nodes.yaml` file includes

--- a/src/main/java/com/marklogic/spark/writer/file/ArchiveFileIterator.java
+++ b/src/main/java/com/marklogic/spark/writer/file/ArchiveFileIterator.java
@@ -10,8 +10,10 @@ import com.marklogic.spark.Util;
 import com.marklogic.spark.reader.document.DocumentRowSchema;
 import com.marklogic.spark.reader.file.ArchiveFileReader;
 import com.marklogic.spark.writer.DocBuilder;
+import org.apache.commons.io.IOUtils;
 import org.apache.spark.sql.catalyst.InternalRow;
 
+import java.io.Closeable;
 import java.util.Iterator;
 
 /**
@@ -19,7 +21,7 @@ import java.util.Iterator;
  * {@code DocumentRowConverter} to build sets of document inputs from an archive file without reading any content entry
  * into memory - thus supporting streaming of an archive.
  */
-public class ArchiveFileIterator implements Iterator<DocBuilder.DocumentInputs> {
+public class ArchiveFileIterator implements Iterator<DocBuilder.DocumentInputs>, Closeable {
 
     private final ArchiveFileReader archiveFileReader;
     private final Format documentFormat;
@@ -50,5 +52,10 @@ public class ArchiveFileIterator implements Iterator<DocBuilder.DocumentInputs> 
             contentHandle.withFormat(this.documentFormat);
         }
         return new DocBuilder.DocumentInputs(uri, contentHandle, null, metadata);
+    }
+
+    @Override
+    public void close() {
+        IOUtils.closeQuietly(archiveFileReader);
     }
 }

--- a/src/main/java/com/marklogic/spark/writer/file/FileIterator.java
+++ b/src/main/java/com/marklogic/spark/writer/file/FileIterator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.file;
+
+import com.marklogic.client.io.InputStreamHandle;
+import com.marklogic.spark.writer.DocBuilder;
+import org.apache.commons.io.IOUtils;
+
+import java.io.Closeable;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+/**
+ * Exists solely to provide an implementation of {@code Closeable} so that the {@code InputStreamHandle} can be closed
+ * after the corresponding document is written to MarkLogic.
+ */
+public class FileIterator implements Iterator<DocBuilder.DocumentInputs>, Closeable {
+
+    private final InputStreamHandle contentHandle;
+    private final Iterator<DocBuilder.DocumentInputs> iterator;
+
+    public FileIterator(InputStreamHandle contentHandle, DocBuilder.DocumentInputs inputs) {
+        this.contentHandle = contentHandle;
+        this.iterator = Stream.of(inputs).iterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.iterator.hasNext();
+    }
+
+    @Override
+    public DocBuilder.DocumentInputs next() {
+        return this.iterator.next();
+    }
+
+    @Override
+    public void close() {
+        IOUtils.closeQuietly(contentHandle);
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/file/GzipFileIterator.java
+++ b/src/main/java/com/marklogic/spark/writer/file/GzipFileIterator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.file;
+
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.InputStreamHandle;
+import com.marklogic.spark.reader.file.GzipFileReader;
+import com.marklogic.spark.writer.DocBuilder;
+import org.apache.commons.io.IOUtils;
+
+import java.io.Closeable;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+/**
+ * Exists solely to provide an implementation of {@code Closeable} so that the {@code GzipFileReader} can be closed
+ * after the corresponding document is written to MarkLogic.
+ */
+public class GzipFileIterator implements Iterator<DocBuilder.DocumentInputs>, Closeable {
+
+    private final GzipFileReader gzipFileReader;
+    private Iterator<DocBuilder.DocumentInputs> iterator;
+
+    public GzipFileIterator(GzipFileReader reader, Format documentFormat) {
+        this.gzipFileReader = reader;
+        reader.next();
+        String uri = reader.get().getString(0);
+        InputStreamHandle contentHandle = reader.getStreamingContentHandle();
+        if (documentFormat != null) {
+            contentHandle.withFormat(documentFormat);
+        }
+        this.iterator = Stream.of(new DocBuilder.DocumentInputs(uri, contentHandle, null, null)).iterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.iterator.hasNext();
+    }
+
+    @Override
+    public DocBuilder.DocumentInputs next() {
+        return this.iterator.next();
+    }
+
+    @Override
+    public void close() {
+        IOUtils.closeQuietly(gzipFileReader);
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/file/ZipFileIterator.java
+++ b/src/main/java/com/marklogic/spark/writer/file/ZipFileIterator.java
@@ -8,11 +8,13 @@ import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.spark.Util;
 import com.marklogic.spark.reader.file.ZipFileReader;
 import com.marklogic.spark.writer.DocBuilder;
+import org.apache.commons.crypto.utils.IoUtils;
 import org.apache.spark.sql.catalyst.InternalRow;
 
+import java.io.Closeable;
 import java.util.Iterator;
 
-public class ZipFileIterator implements Iterator<DocBuilder.DocumentInputs> {
+public class ZipFileIterator implements Iterator<DocBuilder.DocumentInputs>, Closeable {
 
     private final ZipFileReader zipFileReader;
     private final Format documentFormat;
@@ -42,5 +44,10 @@ public class ZipFileIterator implements Iterator<DocBuilder.DocumentInputs> {
             contentHandle.withFormat(this.documentFormat);
         }
         return new DocBuilder.DocumentInputs(uri, contentHandle, null, null);
+    }
+
+    @Override
+    public void close() {
+        IoUtils.closeQuietly(zipFileReader);
     }
 }

--- a/src/test/java/com/marklogic/spark/reader/file/ReadGzipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadGzipFilesTest.java
@@ -3,19 +3,14 @@
  */
 package com.marklogic.spark.reader.file;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.marklogic.junit5.XmlNode;
 import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
 import org.apache.spark.SparkException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SaveMode;
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ObjectInputStream;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -76,46 +71,6 @@ class ReadGzipFilesTest extends AbstractIntegrationTest {
 
         assertEquals(3, rows.size(), "Expecting to get the 3 files back from the gzip-files directory, with the " +
             "error for the non-gzipped mixed-files.zip file being logged as a warning but not causing a failure.");
-    }
-
-    @Test
-    void streamThreeGZIPFiles() throws Exception {
-        Dataset<Row> dataset = newSparkSession().read()
-            .format(CONNECTOR_IDENTIFIER)
-            .option(Options.READ_FILES_COMPRESSION, "gzip")
-            .option("recursiveFileLookup", "true")
-            .option(Options.STREAM_FILES, true)
-            .load("src/test/resources/gzip-files");
-
-        List<Row> rows = dataset.collectAsList();
-        assertEquals(3, rows.size());
-        for (Row row : rows) {
-            assertFalse(row.isNullAt(0), "The URI column should be populated.");
-            byte[] content = (byte[]) row.get(1);
-            try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(content))) {
-                FileContext fileContext = (FileContext) ois.readObject();
-                assertNotNull(fileContext);
-            }
-        }
-
-        // Write the streaming files to MarkLogic.
-        dataset.write().format(CONNECTOR_IDENTIFIER)
-            .option(Options.STREAM_FILES, true)
-            .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
-            .option(Options.WRITE_COLLECTIONS, "streamed-files")
-            .option(Options.WRITE_URI_REPLACE, ".*gzip-files,'/gzip-files'")
-            .mode(SaveMode.Append)
-            .save();
-
-        assertCollectionSize("streamed-files", 3);
-        XmlNode doc = readXmlDocument("/gzip-files/hello.xml");
-        doc.assertElementValue("/hello", "world");
-
-        // Because each streamed file has to be sent via a PUT request, and the PUT endpoint does not allow spaces -
-        // see MLE-17088 - the URI will be encoded.
-        JsonNode node = readJsonDocument("/gzip-files/level1/level2/hello%20world.json");
-        assertEquals("world", node.get("hello").asText());
     }
 
     private void verifyRow(Row row, String expectedUriSuffix, String expectedContent) {

--- a/src/test/java/com/marklogic/spark/reader/file/StreamGenericFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/StreamGenericFilesTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * into memory by postponing reading of the file until the writer phase, where it can then be streamed from disk into
  * MarkLogic.
  */
-class ReadGenericFilesStreamingTest extends AbstractIntegrationTest {
+class StreamGenericFilesTest extends AbstractIntegrationTest {
 
     @Test
     void stream() throws Exception {

--- a/src/test/java/com/marklogic/spark/reader/file/StreamGzipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/StreamGzipFilesTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.reader.file;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.junit5.XmlNode;
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ObjectInputStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StreamGzipFilesTest extends AbstractIntegrationTest {
+
+    @Test
+    void streamThreeGZIPFiles() throws Exception {
+        Dataset<Row> dataset = newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.READ_FILES_COMPRESSION, "gzip")
+            .option("recursiveFileLookup", "true")
+            .option(Options.STREAM_FILES, true)
+            .load("src/test/resources/gzip-files");
+
+        List<Row> rows = dataset.collectAsList();
+        assertEquals(3, rows.size());
+        for (Row row : rows) {
+            assertFalse(row.isNullAt(0), "The URI column should be populated.");
+            byte[] content = (byte[]) row.get(1);
+            try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(content))) {
+                FileContext fileContext = (FileContext) ois.readObject();
+                assertNotNull(fileContext);
+            }
+        }
+
+        // Write the streaming files to MarkLogic.
+        dataset.write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.STREAM_FILES, true)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
+            .option(Options.WRITE_COLLECTIONS, "streamed-files")
+            .option(Options.WRITE_URI_REPLACE, ".*gzip-files,'/gzip-files'")
+            .mode(SaveMode.Append)
+            .save();
+
+        assertCollectionSize("streamed-files", 3);
+        XmlNode doc = readXmlDocument("/gzip-files/hello.xml");
+        doc.assertElementValue("/hello", "world");
+
+        // Because each streamed file has to be sent via a PUT request, and the PUT endpoint does not allow spaces -
+        // see MLE-17088 - the URI will be encoded.
+        JsonNode node = readJsonDocument("/gzip-files/level1/level2/hello%20world.json");
+        assertEquals("world", node.get("hello").asText());
+    }
+}


### PR DESCRIPTION
Sonar flagged the fact that the GZip streaming support was resulting in an unclosed stream. Reworked the internal API a bit so that each iterator can now be Closeable as well.
