### PR TITLE
Bumping Spark compilation dependency to 3.5.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ dependencies {
     exclude group: "com.fasterxml.jackson.dataformat"
   }
 
-  // Required for converting JSON to XML. Using 2.14.2 to align with Spark 3.4.3.
-  shadowDependencies "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.2"
+  // Required for converting JSON to XML. Using 2.15.2 to align with Spark 3.5.3.
+  shadowDependencies "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2"
 
   // Need this so that an OkHttpClientConfigurator can be created.
   shadowDependencies 'com.squareup.okhttp3:okhttp:4.12.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
-# Staying with 3.4.x for now, as some pushdown tests are failing when using 3.5.x.
-# 3.4.3 release notes - https://spark.apache.org/releases/spark-release-3-4-3.html .
-sparkVersion=3.4.3
+# 3.5.0 caused test failures with our pushdown support, but that is not an issue with 3.5.3 - perhaps a bug fix in
+# the Spark connector plumbing between 3.5.0 and 3.5.3. This also bumps Jackson to 2.15.2.
+# 3.5.3 release notes - https://spark.apache.org/releases/spark-release-3-5-3.html .
+sparkVersion=3.5.3
 
 # Only used for the test app and for running tests.
 mlHost=localhost


### PR DESCRIPTION
3.5.3 is working well with Flux too. 