### PR TITLE
MLE-17232 Ensuring logging works in Flux

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,14 @@ configurations {
   testImplementation.extendsFrom(compileOnly)
 }
 
+configurations.all {
+  // Ensures that slf4j-api 1.x does not appear on the Flux classpath in particular, which can lead to this
+  // issue - https://www.slf4j.org/codes.html#StaticLoggerBinder .
+  resolutionStrategy {
+    force "org.slf4j:slf4j-api:2.0.13"
+  }
+}
+
 dependencies {
   // This is compileOnly as any environment this is used in will provide the Spark dependencies itself.
   compileOnly ('org.apache.spark:spark-sql_2.12:' + sparkVersion) {
@@ -53,7 +61,10 @@ dependencies {
   }
 
   // Required for converting JSON to XML. Using 2.15.2 to align with Spark 3.5.3.
-  shadowDependencies "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2"
+  shadowDependencies ("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2") {
+    // Not needed, as the modules in this group that this dependency depends on are all provided by Spark.
+    exclude group: "com.fasterxml.jackson.core"
+  }
 
   // Need this so that an OkHttpClientConfigurator can be created.
   shadowDependencies 'com.squareup.okhttp3:okhttp:4.12.0'


### PR DESCRIPTION
slf4j-api 1.7.x was sneaking in from the Java Client. The Java Client will be updated to use 2.x. But this ensures that all dependencies use slf4j-api 2.x, which avoids the logging issue referenced in the comment.

Also made a small optimization in shrinking the shadow jar size - we don't need any of the Jackson core dependencies for dataformat-xml, as Spark provides all of them.
