### PR TITLE
MLE-17216 Can now split XML documents

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,8 @@ dependencies {
     exclude group: "com.fasterxml.jackson.core"
   }
 
+  shadowDependencies "dev.langchain4j:langchain4j:0.35.0"
+
   // Need this so that an OkHttpClientConfigurator can be created.
   shadowDependencies 'com.squareup.okhttp3:okhttp:4.12.0'
 

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -127,6 +127,10 @@ public abstract class Options {
     // Example - "spark.marklogic.write.json.ignoreNullFields=false.
     public static final String WRITE_JSON_SERIALIZATION_OPTION_PREFIX = "spark.marklogic.write.json.";
 
+    public static final String WRITE_SPLITTER_XML_PATH = "spark.marklogic.write.splitter.xml.path";
+    public static final String WRITE_SPLITTER_XML_NAMESPACE_PREFIX = "spark.marklogic.write.splitter.xml.namespace.";
+    public static final String WRITE_SPLITTER_MAX_CHUNK_SIZE = "spark.marklogic.write.splitter.maxChunkSize";
+    public static final String WRITE_SPLITTER_MAX_OVERLAP_SIZE = "spark.marklogic.write.splitter.maxOverlapSize";
 
     // For writing RDF
     public static final String WRITE_GRAPH = "spark.marklogic.write.graph";

--- a/src/main/java/com/marklogic/spark/writer/DocumentProcessor.java
+++ b/src/main/java/com/marklogic/spark/writer/DocumentProcessor.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer;
+
+import com.marklogic.client.document.DocumentWriteOperation;
+
+import java.util.Iterator;
+import java.util.function.Function;
+
+/**
+ * Extension point for processing documents that have been created based on a Spark row, but before they've been sent
+ * to MarkLogic. Intended to shield {@code WriteBatcherDataWriter} from any sort of document processing that occurs,
+ * including processing provided by our own connector.
+ */
+public interface DocumentProcessor extends Function<DocumentWriteOperation, Iterator<DocumentWriteOperation>> {
+}

--- a/src/main/java/com/marklogic/spark/writer/DocumentProcessorFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/DocumentProcessorFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer;
+
+import com.marklogic.spark.ContextSupport;
+import com.marklogic.spark.Options;
+import com.marklogic.spark.writer.splitter.*;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.splitter.DocumentSplitters;
+import org.jdom2.Namespace;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Only supports building a {@code SplitterDocumentProcessor}, but may later support custom processors as well.
+ */
+public abstract class DocumentProcessorFactory {
+
+    public static DocumentProcessor buildDocumentProcessor(ContextSupport context) {
+        if (context.hasOption(Options.WRITE_SPLITTER_XML_PATH)) {
+            TextSelector textSelector = makeTextSelector(context);
+            DocumentSplitter splitter = makeDefaultSplitter(context);
+            ChunkAssembler chunkAssembler = makeChunkProcessor();
+            return new SplitterDocumentProcessor(textSelector, splitter, chunkAssembler);
+        }
+        return null;
+    }
+
+    private static TextSelector makeTextSelector(ContextSupport context) {
+        String path = context.getStringOption(Options.WRITE_SPLITTER_XML_PATH);
+        List<Namespace> namespaces = context.getProperties().keySet()
+            .stream()
+            .filter(key -> key.startsWith(Options.WRITE_SPLITTER_XML_NAMESPACE_PREFIX))
+            .map(key -> {
+                String prefix = key.substring(Options.WRITE_SPLITTER_XML_NAMESPACE_PREFIX.length());
+                return Namespace.getNamespace(prefix, context.getStringOption(key));
+            })
+            .collect(Collectors.toList());
+        return new JDOMTextSelector(path, namespaces);
+    }
+
+    private static ChunkAssembler makeChunkProcessor() {
+        return new DefaultChunkAssembler();
+    }
+
+    private static DocumentSplitter makeDefaultSplitter(ContextSupport context) {
+        int maxChunkSize = (int) context.getNumericOption(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 1000, 0);
+        int maxOverlapSize = (int) context.getNumericOption(Options.WRITE_SPLITTER_MAX_OVERLAP_SIZE, 0, 0);
+        return DocumentSplitters.recursive(maxChunkSize, maxOverlapSize);
+    }
+
+    private DocumentProcessorFactory() {
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/XmlUtil.java
+++ b/src/main/java/com/marklogic/spark/writer/XmlUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer;
+
+import com.marklogic.client.extra.jdom.JDOMHandle;
+import com.marklogic.client.impl.HandleAccessor;
+import com.marklogic.client.io.marker.AbstractWriteHandle;
+import com.marklogic.spark.ConnectorException;
+import org.jdom2.Document;
+import org.jdom2.input.SAXBuilder;
+
+import java.io.StringReader;
+
+public abstract class XmlUtil {
+
+    private static SAXBuilder saxBuilder;
+
+    static {
+        saxBuilder = new SAXBuilder();
+    }
+
+    public static Document buildDocument(String xml) {
+        try {
+            return saxBuilder.build(new StringReader(xml));
+        } catch (Exception ex) {
+            throw new ConnectorException(String.format("Unable to read XML; cause: %s", ex.getMessage()), ex);
+        }
+    }
+
+    public static Document extractDocument(AbstractWriteHandle handle) {
+        if (handle instanceof JDOMHandle) {
+            return ((JDOMHandle) handle).get();
+        }
+        String xml = HandleAccessor.contentAsString(handle);
+        return buildDocument(xml);
+    }
+
+    private XmlUtil() {
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/splitter/ChunkAssembler.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/ChunkAssembler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.splitter;
+
+import com.marklogic.client.document.DocumentWriteOperation;
+import dev.langchain4j.data.segment.TextSegment;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Defines how chunks are assembled into one or more documents to be written to MarkLogic.
+ */
+public interface ChunkAssembler {
+
+    /**
+     * @param sourceDocument
+     * @param chunks
+     * @return an iterator, which allows for an implementation to lazily construct documents if necessary.
+     */
+    Iterator<DocumentWriteOperation> assembleChunks(
+        DocumentWriteOperation sourceDocument,
+        List<TextSegment> chunks
+    );
+}

--- a/src/main/java/com/marklogic/spark/writer/splitter/DefaultChunkAssembler.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/DefaultChunkAssembler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.splitter;
+
+import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.client.extra.jdom.JDOMHandle;
+import com.marklogic.client.impl.DocumentWriteOperationImpl;
+import com.marklogic.client.impl.HandleAccessor;
+import com.marklogic.spark.writer.XmlUtil;
+import dev.langchain4j.data.segment.TextSegment;
+import org.jdom2.Document;
+import org.jdom2.Element;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Default impl that only supports XML and adding chunks to the source document.
+ * Will expand this via future stories.
+ */
+public class DefaultChunkAssembler implements ChunkAssembler {
+
+    @Override
+    public Iterator<DocumentWriteOperation> assembleChunks(DocumentWriteOperation sourceDocument, List<TextSegment> textSegments) {
+        Document doc;
+        if (sourceDocument.getContent() instanceof JDOMHandle) {
+            doc = ((JDOMHandle) sourceDocument.getContent()).get();
+        } else {
+            String content = HandleAccessor.contentAsString(sourceDocument.getContent());
+            doc = XmlUtil.buildDocument(content);
+        }
+
+        final Element chunks = new Element("chunks");
+        doc.getRootElement().addContent(chunks);
+        textSegments.forEach(textSegment -> chunks
+            .addContent(new Element("chunk").addContent(new Element("text").addContent(textSegment.text())))
+        );
+
+        return Stream.of((DocumentWriteOperation) new DocumentWriteOperationImpl(
+            sourceDocument.getUri(),
+            sourceDocument.getMetadata(),
+            new JDOMHandle(doc)
+        )).iterator();
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/splitter/JDOMTextSelector.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/JDOMTextSelector.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.splitter;
+
+import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.writer.XmlUtil;
+import org.jdom2.*;
+import org.jdom2.filter.Filters;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+import org.jdom2.xpath.XPathExpression;
+import org.jdom2.xpath.XPathFactory;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Uses JDOM to select text in an XML document based on an XPath expression.
+ */
+public class JDOMTextSelector implements TextSelector {
+
+    private final XPathExpression<Object> expression;
+    private final XMLOutputter xmlOutputter;
+
+    // Will make this configurable later.
+    private static final String JOIN_DELIMITER = " ";
+
+    public JDOMTextSelector(String path, Collection<Namespace> namespaces) {
+        this.expression = namespaces != null ?
+            XPathFactory.instance().compile(path, Filters.fpassthrough(), null, namespaces) :
+            XPathFactory.instance().compile(path);
+        this.xmlOutputter = new XMLOutputter(Format.getPrettyFormat());
+    }
+
+    @Override
+    public String selectTextToSplit(DocumentWriteOperation operation) {
+        Document doc = XmlUtil.extractDocument(operation.getContent());
+
+        List<Object> results;
+        try {
+            results = this.expression.evaluate(doc);
+        } catch (Exception e) {
+            throw new ConnectorException(String.format("Unable to split document using XPath expression: %s; cause: %s",
+                expression.getExpression(), e.getMessage()), e);
+        }
+
+        return results.stream().map(this::objectToString).collect(Collectors.joining(JOIN_DELIMITER));
+    }
+
+    private String objectToString(Object object) {
+        if (object instanceof Text) {
+            return ((Text) object).getText();
+        }
+        if (object instanceof Element) {
+            return this.xmlOutputter.outputString((Element) object);
+        }
+        if (object instanceof Attribute) {
+            return ((Attribute) object).getValue();
+        }
+        if (object instanceof Document) {
+            return this.xmlOutputter.outputString((Document) object);
+        }
+        return object.toString();
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/splitter/SplitterDocumentProcessor.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/SplitterDocumentProcessor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.splitter;
+
+import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.spark.writer.DocumentProcessor;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.segment.TextSegment;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Implements the "splitter" capability by delegating to different objects for selecting text to split; splitting
+ * the selected text; and then processing the given chunks
+ */
+public class SplitterDocumentProcessor implements DocumentProcessor {
+
+    private final TextSelector textSelector;
+    private final DocumentSplitter documentSplitter;
+    private final ChunkAssembler chunkAssembler;
+
+    public SplitterDocumentProcessor(TextSelector textSelector, DocumentSplitter documentSplitter, ChunkAssembler chunkAssembler) {
+        this.textSelector = textSelector;
+        this.documentSplitter = documentSplitter;
+        this.chunkAssembler = chunkAssembler;
+    }
+
+    @Override
+    public Iterator<DocumentWriteOperation> apply(DocumentWriteOperation sourceDocument) {
+        String text = textSelector.selectTextToSplit(sourceDocument);
+        if (text == null || text.trim().isEmpty()) {
+            return Stream.of(sourceDocument).iterator();
+        }
+        List<TextSegment> textSegments = documentSplitter.split(new Document(text));
+        return chunkAssembler.assembleChunks(sourceDocument, textSegments);
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/splitter/TextSelector.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/TextSelector.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.splitter;
+
+import com.marklogic.client.document.DocumentWriteOperation;
+
+/**
+ * Defines how text to be split is selected from a document.
+ */
+public interface TextSelector {
+
+    String selectTextToSplit(DocumentWriteOperation operation);
+}

--- a/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
+++ b/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.splitter;
+
+import com.marklogic.junit5.XmlNode;
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.DataFrameWriter;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.jdom2.Namespace;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SplitXmlDocumentTest extends AbstractIntegrationTest {
+
+    @Test
+    void splitXmlDocument() {
+        readDocument("/marklogic-docs/java-client-intro.xml")
+            .write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.WRITE_SPLITTER_XML_PATH, "/root/text/text()")
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
+            .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
+            .option(Options.WRITE_SPLITTER_MAX_OVERLAP_SIZE, 0)
+            .option(Options.WRITE_URI_TEMPLATE, "/split-test.xml")
+            .mode(SaveMode.Append)
+            .save();
+
+        XmlNode doc = readXmlDocument("/split-test.xml");
+        doc.assertElementCount("Expecting 4 chunks based on a max chunk size of 500", "/root/chunks/chunk", 4);
+
+        String firstChunk = doc.getElementValue("/root/chunks/chunk[1]/text");
+        assertTrue(firstChunk.startsWith("When working with the Java API"), "The first chunk should begin with the " +
+            "text in the original 'text' element. Actual chunk: " + firstChunk);
+    }
+
+    @Test
+    void withNamespace() {
+        readDocument("/marklogic-docs/namespaced-java-client-intro.xml")
+            .write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.WRITE_SPLITTER_XML_PATH, "/ex:root/ex:text/text()")
+            .option(Options.WRITE_SPLITTER_XML_NAMESPACE_PREFIX + "ex", "org:example")
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
+            .option(Options.WRITE_URI_TEMPLATE, "/namespace-test.xml")
+            .mode(SaveMode.Append)
+            .save();
+
+        XmlNode doc = readXmlDocument("/namespace-test.xml");
+        doc.setNamespaces(new Namespace[]{Namespace.getNamespace("ex", "org:example")});
+
+        doc.assertElementCount("Expecting 2 chunks based on the default max chunk size of 1000. And the " +
+                "chunks and chunk elements are expected to not be in a namespace. But the user's declaration of " +
+                "the 'ex' prefix should have allowed the XPath statement for selecting text to succeed.",
+            "/ex:root/chunks/chunk", 2);
+    }
+
+    @Test
+    void undeclaredNamespace() {
+        DataFrameWriter writer = readDocument("/marklogic-docs/namespaced-java-client-intro.xml")
+            .write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.WRITE_SPLITTER_XML_PATH, "/ex:root/ex:text/text()")
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
+            .option(Options.WRITE_URI_TEMPLATE, "/namespace-test.xml")
+            .mode(SaveMode.Append);
+
+        ConnectorException ex = assertThrowsConnectorException(() -> writer.save());
+        assertEquals("Unable to split document using XPath expression: /ex:root/ex:text/text(); cause: " +
+                "Namespace with prefix 'ex' has not been declared.",
+            ex.getMessage()
+        );
+    }
+
+    private Dataset<Row> readDocument(String uri) {
+        return newSparkSession().read().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_DOCUMENTS_URIS, uri)
+            .load();
+    }
+}

--- a/src/test/java/com/marklogic/spark/writer/splitter/SplitterTest.java
+++ b/src/test/java/com/marklogic/spark/writer/splitter/SplitterTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.splitter;
+
+import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.client.impl.DocumentWriteOperationImpl;
+import com.marklogic.client.impl.HandleAccessor;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.junit5.XmlNode;
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.writer.DocumentProcessor;
+import dev.langchain4j.data.document.splitter.DocumentSplitters;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This test verifies the SplitterDocumentProcessor without involving Spark at all. The intent is to ensure that all
+ * the splitter plumbing works correctly, while other test will verify that all the splitter-specific Spark options
+ * produce the expected result.
+ */
+class SplitterTest extends AbstractIntegrationTest {
+
+    @Test
+    void textPath() {
+        XmlNode doc = splitTestDocument("/root/text/text()");
+
+        doc.assertElementCount(
+            "Expecting the default splitter to split the 'text' element into 4 chunks, each having its own 'text' element.",
+            "/root/chunks/chunk[text/text()]", 4);
+    }
+
+    @Test
+    void elementPath() {
+        XmlNode doc = splitTestDocument("/root/nested");
+
+        doc.assertElementCount("Only expecting one chunk since the root/nested/text element has very little text",
+            "/root/chunks/chunk", 1);
+
+        String value = doc.getElementValue("/root/chunks/chunk/text");
+        assertTrue(value.startsWith("<nested>"), "When a user selects an element, the expectation is that the " +
+            "entire XML fragment is returned and sent to the splitter. For our default langchain4j splitter, this " +
+            "isn't useful because it doesn't know to do anything useful with XML tags. But this verifies that the " +
+            "splitter did receive the XML fragment, which is then set as the value of the 'text' element " +
+            "in the only chunk. Actual value: " + value);
+    }
+
+    @Test
+    void attributePath() {
+        XmlNode doc = splitTestDocument("/root/attribute-test/@text");
+        doc.assertElementCount("/root/chunks/chunk", 1);
+        doc.assertElementValue("It should be rare that a user wants to split the text in an attribute, but it should " +
+                "be feasible. We don't have a way though of preserving the attribute name in some sort of serialization " +
+                "with JDOM2; we can only get the attribute value.",
+            "/root/chunks/chunk/text",
+            "Some attribute text."
+        );
+    }
+
+    @Test
+    void wholeDocument() {
+        XmlNode doc = splitTestDocument("/");
+
+        doc.assertElementCount(
+            "When the user selects the entire document, it should be serialized into a string that is passed to the " +
+                "splitter. And the default splitter will turn that into 6 chunks.",
+            "/root/chunks/chunk", 6);
+
+        String firstChunk = doc.getElementValue("/root/chunks/chunk[1]/text");
+        assertTrue(firstChunk.startsWith("<?xml version="), "The first chunk is expected to contain the " +
+            "start of the serialized document, which will begin with the XML declaration. Actual chunk: " + firstChunk);
+    }
+
+    @Test
+    void multipleMatchingElements() {
+        XmlNode doc = splitTestDocument("//node()[local-name(.) = 'url' or (local-name(.) = 'text' and ancestor::nested)]/text()");
+
+        doc.assertElementCount(
+            "Should have text from 2 elements, but that's small enough for 1 chunk",
+            "/root/chunks/chunk", 1);
+
+        doc.assertElementValue(
+            "The single chunk should have the concatenation of the two selected elements, joined with a space.",
+            "/root/chunks/chunk/text", "https://docs.marklogic.com/guide/java/intro This is for testing.");
+    }
+
+    @Test
+    void noMatches() {
+        XmlNode doc = splitTestDocument("/doesnt/match/anything");
+        doc.assertElementMissing("When no text is selected, no chunks should be added.", "/root/chunks");
+    }
+
+    private XmlNode splitTestDocument(String xpath) {
+        DocumentWriteOperation sourceDocument = readXmlDocument();
+        DocumentWriteOperation output = newXmlSplitter(xpath).apply(sourceDocument).next();
+        String xml = HandleAccessor.contentAsString(output.getContent());
+        return new XmlNode(xml);
+    }
+
+    private DocumentProcessor newXmlSplitter(String path) {
+        return new SplitterDocumentProcessor(
+            new JDOMTextSelector(path, null),
+            DocumentSplitters.recursive(500, 0),
+            new DefaultChunkAssembler()
+        );
+    }
+
+    private DocumentWriteOperation readXmlDocument() {
+        final String uri = "/marklogic-docs/java-client-intro.xml";
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        StringHandle contentHandle = getDatabaseClient().newXMLDocumentManager().read(uri, metadata, new StringHandle());
+        return new DocumentWriteOperationImpl(uri, metadata, contentHandle);
+    }
+}

--- a/src/test/ml-data/marklogic-docs/collections.properties
+++ b/src/test/ml-data/marklogic-docs/collections.properties
@@ -1,0 +1,1 @@
+*=test-config,marklogic-docs

--- a/src/test/ml-data/marklogic-docs/java-client-intro.xml
+++ b/src/test/ml-data/marklogic-docs/java-client-intro.xml
@@ -1,0 +1,26 @@
+<root>
+  <url>https://docs.marklogic.com/guide/java/intro</url>
+  <text>When working with the Java API, you first create a manager for the type of document or operation you want to
+    perform on the database (for instance, a JSONDocumentManager to write and read JSON documents or a QueryManager to
+    search the database). To write or read the content for a database operation, you use standard Java APIs such as
+    InputStream, DOM, StAX, JAXB, and Transformer as well as Open Source APIs such as JDOM and Jackson.
+
+    The Java API provides a handle (a kind of adapter) as a uniform interface for content representation. As a result,
+    you can use APIs as different as InputStream and DOM to provide content for one read() or write() method. In
+    addition, you can extend the Java API so you can use the existing read() or write() methods with new APIs that
+    provide useful representations for your content.
+
+    This chapter covers a number of basic architecture aspects of the Java API, including fundamental structures such as
+    database clients, managers, and handles used in almost every program you will write with it. Before starting to
+    code, you need to understand these structures and the concepts behind them.
+
+    The MarkLogic Java Client API is built on top of the MarkLogic REST API. The REST API, in turn, is built using
+    XQuery that is evaluated against an HTTP App Server. For this reason, you need a REST API instance on MarkLogic
+    Server to use the Java API. A suitable REST API instance on port 8000 is pre-configured when you install MarkLogic
+    Server. You can also create your own on another port. For details, see Choose a REST API Instance.
+  </text>
+  <nested>
+    <text>This is for testing.</text>
+  </nested>
+  <attribute-test text="Some attribute text."/>
+</root>

--- a/src/test/ml-data/marklogic-docs/namespaced-java-client-intro.xml
+++ b/src/test/ml-data/marklogic-docs/namespaced-java-client-intro.xml
@@ -1,0 +1,22 @@
+<root xmlns="org:example">
+  <url>https://docs.marklogic.com/guide/java/intro</url>
+  <text>When working with the Java API, you first create a manager for the type of document or operation you want to
+    perform on the database (for instance, a JSONDocumentManager to write and read JSON documents or a QueryManager to
+    search the database). To write or read the content for a database operation, you use standard Java APIs such as
+    InputStream, DOM, StAX, JAXB, and Transformer as well as Open Source APIs such as JDOM and Jackson.
+
+    The Java API provides a handle (a kind of adapter) as a uniform interface for content representation. As a result,
+    you can use APIs as different as InputStream and DOM to provide content for one read() or write() method. In
+    addition, you can extend the Java API so you can use the existing read() or write() methods with new APIs that
+    provide useful representations for your content.
+
+    This chapter covers a number of basic architecture aspects of the Java API, including fundamental structures such as
+    database clients, managers, and handles used in almost every program you will write with it. Before starting to
+    code, you need to understand these structures and the concepts behind them.
+
+    The MarkLogic Java Client API is built on top of the MarkLogic REST API. The REST API, in turn, is built using
+    XQuery that is evaluated against an HTTP App Server. For this reason, you need a REST API instance on MarkLogic
+    Server to use the Java API. A suitable REST API instance on port 8000 is pre-configured when you install MarkLogic
+    Server. You can also create your own on another port. For details, see Choose a REST API Instance.
+  </text>
+</root>


### PR DESCRIPTION
This gets the ball rolling by allowing a user to select text in an XML document and add chunks to the same document. Future stories will support JSON, different splitters, and different storage strategies. 

Going to follow this up with a small PR for Flux so that we can immediately have this available in a Flux snapshot build. 