### PR TITLE
MLE-17222 Supporting permissions, root name, and custom URI for chunks

### DIFF
--- a/src/main/java/com/marklogic/spark/ContextSupport.java
+++ b/src/main/java/com/marklogic/spark/ContextSupport.java
@@ -109,6 +109,10 @@ public class ContextSupport implements Serializable {
         }
     }
 
+    public final int getIntOption(String optionName, int defaultValue, int minimumValue) {
+        return (int) getNumericOption(optionName, defaultValue, minimumValue);
+    }
+    
     public final long getNumericOption(String optionName, long defaultValue, long minimumValue) {
         try {
             long value = this.getProperties().containsKey(optionName) ?

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -139,6 +139,9 @@ public abstract class Options {
     public static final String WRITE_SPLITTER_OUTPUT_MAX_CHUNKS = "spark.marklogic.write.splitter.output.maxChunks";
     public static final String WRITE_SPLITTER_OUTPUT_COLLECTIONS = "spark.marklogic.write.splitter.output.collections";
     public static final String WRITE_SPLITTER_OUTPUT_PERMISSIONS = "spark.marklogic.write.splitter.output.permissions";
+    public static final String WRITE_SPLITTER_OUTPUT_ROOT_NAME = "spark.marklogic.write.splitter.output.rootName";
+    public static final String WRITE_SPLITTER_OUTPUT_URI_PREFIX = "spark.marklogic.write.splitter.output.uriPrefix";
+    public static final String WRITE_SPLITTER_OUTPUT_URI_SUFFIX = "spark.marklogic.write.splitter.output.uriSuffix";
 
     // For writing RDF
     public static final String WRITE_GRAPH = "spark.marklogic.write.graph";

--- a/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
+++ b/src/main/java/com/marklogic/spark/reader/document/DocumentContext.java
@@ -91,12 +91,12 @@ class DocumentContext extends ContextSupport {
         // like 1000 or even 10000. 500 is thus used as a default that should still be reasonably performant for larger
         // documents.
         int defaultBatchSize = 500;
-        return (int) getNumericOption(Options.READ_BATCH_SIZE, defaultBatchSize, 1);
+        return getIntOption(Options.READ_BATCH_SIZE, defaultBatchSize, 1);
     }
 
     int getPartitionsPerForest() {
         int defaultPartitionsPerForest = 4;
-        return (int) getNumericOption(Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST, defaultPartitionsPerForest, 1);
+        return getIntOption(Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST, defaultPartitionsPerForest, 1);
     }
 
     boolean isConsistentSnapshot() {

--- a/src/main/java/com/marklogic/spark/writer/DocumentProcessorFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/DocumentProcessorFactory.java
@@ -92,9 +92,13 @@ public abstract class DocumentProcessorFactory {
             metadata.getPermissions().addFromDelimitedString(value);
         }
 
-        int maxChunks = (int) context.getNumericOption(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 0, 0);
-
-        return new DefaultChunkAssembler(metadata, maxChunks);
+        return new DefaultChunkAssembler(new ChunkConfig.Builder()
+            .withMetadata(metadata)
+            .withMaxChunks(context.getIntOption(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 0, 0))
+            .withRootName(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_ROOT_NAME))
+            .withUriPrefix(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_URI_PREFIX))
+            .withUriSuffix(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_URI_SUFFIX))
+            .build());
     }
 
     private DocumentProcessorFactory() {

--- a/src/main/java/com/marklogic/spark/writer/WriteContext.java
+++ b/src/main/java/com/marklogic/spark/writer/WriteContext.java
@@ -40,7 +40,7 @@ public class WriteContext extends ContextSupport {
     public WriteContext(StructType schema, Map<String, String> properties) {
         super(properties);
         this.schema = schema;
-        this.batchSize = (int) getNumericOption(Options.WRITE_BATCH_SIZE, 100, 1);
+        this.batchSize = getIntOption(Options.WRITE_BATCH_SIZE, 100, 1);
 
         // We support the Spark binaryFile schema - https://spark.apache.org/docs/latest/sql-data-sources-binaryFile.html -
         // so that reader can be reused for loading files as-is.
@@ -64,7 +64,7 @@ public class WriteContext extends ContextSupport {
      * hosts are in their MarkLogic cluster and how many threads are available to an app server on each host.
      */
     int getTotalThreadCount() {
-        return (int) getNumericOption(Options.WRITE_THREAD_COUNT, 4, 1);
+        return getIntOption(Options.WRITE_THREAD_COUNT, 4, 1);
     }
 
     /**
@@ -84,7 +84,7 @@ public class WriteContext extends ContextSupport {
      * threads should be used by a partition.
      */
     int getUserDefinedThreadCountPerPartition() {
-        return (int) getNumericOption(Options.WRITE_THREAD_COUNT_PER_PARTITION, 0, 1);
+        return getIntOption(Options.WRITE_THREAD_COUNT_PER_PARTITION, 0, 1);
     }
 
     WriteBatcher newWriteBatcher(DataMovementManager dataMovementManager) {

--- a/src/main/java/com/marklogic/spark/writer/customcode/CustomCodeWriter.java
+++ b/src/main/java/com/marklogic/spark/writer/customcode/CustomCodeWriter.java
@@ -47,7 +47,7 @@ class CustomCodeWriter implements DataWriter<InternalRow> {
         this.databaseClient = customCodeContext.connectToMarkLogic();
         this.jsonRowSerializer = new JsonRowSerializer(customCodeContext.getSchema(), customCodeContext.getProperties());
 
-        this.batchSize = (int) customCodeContext.getNumericOption(Options.WRITE_BATCH_SIZE, 1, 1);
+        this.batchSize = customCodeContext.getIntOption(Options.WRITE_BATCH_SIZE, 1, 1);
 
         this.externalVariableDelimiter = customCodeContext.optionExists(Options.WRITE_EXTERNAL_VARIABLE_DELIMITER) ?
             customCodeContext.getProperties().get(Options.WRITE_EXTERNAL_VARIABLE_DELIMITER) : ",";

--- a/src/main/java/com/marklogic/spark/writer/splitter/ChunkConfig.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/ChunkConfig.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.splitter;
+
+import com.marklogic.client.io.DocumentMetadataHandle;
+
+public class ChunkConfig {
+
+    private final DocumentMetadataHandle metadata;
+    private final int maxChunks;
+    private final String rootName;
+    private final String uriPrefix;
+    private final String uriSuffix;
+
+    private ChunkConfig(DocumentMetadataHandle metadata, int maxChunks, String rootName, String uriPrefix, String uriSuffix) {
+        this.metadata = metadata;
+        this.maxChunks = maxChunks;
+        this.rootName = rootName;
+        this.uriPrefix = uriPrefix;
+        this.uriSuffix = uriSuffix;
+    }
+
+    public static class Builder {
+        private DocumentMetadataHandle metadata;
+        private int maxChunks;
+        private String rootName;
+        private String uriPrefix;
+        private String uriSuffix;
+
+        public ChunkConfig build() {
+            return new ChunkConfig(metadata, maxChunks, rootName, uriPrefix, uriSuffix);
+        }
+
+        public Builder withMetadata(DocumentMetadataHandle metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        public Builder withMaxChunks(int maxChunks) {
+            this.maxChunks = maxChunks;
+            return this;
+        }
+
+        public Builder withRootName(String rootName) {
+            this.rootName = rootName;
+            return this;
+        }
+
+        public Builder withUriPrefix(String uriPrefix) {
+            this.uriPrefix = uriPrefix;
+            return this;
+        }
+
+        public Builder withUriSuffix(String uriSuffix) {
+            this.uriSuffix = uriSuffix;
+            return this;
+        }
+    }
+
+    public DocumentMetadataHandle getMetadata() {
+        return metadata;
+    }
+
+    public int getMaxChunks() {
+        return maxChunks;
+    }
+
+    public String getRootName() {
+        return rootName;
+    }
+
+    public String getUriPrefix() {
+        return uriPrefix;
+    }
+
+    public String getUriSuffix() {
+        return uriSuffix;
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/splitter/DocumentSplitterFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/DocumentSplitterFactory.java
@@ -51,11 +51,11 @@ public abstract class DocumentSplitterFactory {
     }
 
     private static int getMaxChunkSize(ContextSupport context) {
-        return (int) context.getNumericOption(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 1000, 0);
+        return context.getIntOption(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 1000, 0);
     }
 
     private static int getMaxOverlapSize(ContextSupport context) {
-        return (int) context.getNumericOption(Options.WRITE_SPLITTER_MAX_OVERLAP_SIZE, 0, 0);
+        return context.getIntOption(Options.WRITE_SPLITTER_MAX_OVERLAP_SIZE, 0, 0);
     }
 
     /**

--- a/src/test/java/com/marklogic/spark/writer/splitter/SplitterTest.java
+++ b/src/test/java/com/marklogic/spark/writer/splitter/SplitterTest.java
@@ -135,7 +135,7 @@ class SplitterTest extends AbstractIntegrationTest {
         return new SplitterDocumentProcessor(
             new JSONPointerTextSelector(jsonPointers, null),
             DocumentSplitters.recursive(500, 0),
-            new DefaultChunkAssembler(null, 0)
+            new DefaultChunkAssembler(new ChunkConfig.Builder().build())
         );
     }
 
@@ -143,7 +143,7 @@ class SplitterTest extends AbstractIntegrationTest {
         return new SplitterDocumentProcessor(
             new JDOMTextSelector(path, null),
             DocumentSplitters.recursive(500, 0),
-            new DefaultChunkAssembler(null, 0)
+            new DefaultChunkAssembler(new ChunkConfig.Builder().build())
         );
     }
 


### PR DESCRIPTION
Added ChunkConfig to pass all the chunk config around. Added getIntOption to avoid annoying casts to int. 

Going to support XML next, will then refactor a bit. 