### PR TITLE
MLE-17222 Supporting max chunks for XML and Text source documents

### DIFF
--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -142,6 +142,7 @@ public abstract class Options {
     public static final String WRITE_SPLITTER_OUTPUT_ROOT_NAME = "spark.marklogic.write.splitter.output.rootName";
     public static final String WRITE_SPLITTER_OUTPUT_URI_PREFIX = "spark.marklogic.write.splitter.output.uriPrefix";
     public static final String WRITE_SPLITTER_OUTPUT_URI_SUFFIX = "spark.marklogic.write.splitter.output.uriSuffix";
+    public static final String WRITE_SPLITTER_OUTPUT_XML_NAMESPACE = "spark.marklogic.write.splitter.output.xmlNamespace";
 
     // For writing RDF
     public static final String WRITE_GRAPH = "spark.marklogic.write.graph";

--- a/src/main/java/com/marklogic/spark/writer/DocumentProcessorFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/DocumentProcessorFactory.java
@@ -98,6 +98,7 @@ public abstract class DocumentProcessorFactory {
             .withRootName(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_ROOT_NAME))
             .withUriPrefix(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_URI_PREFIX))
             .withUriSuffix(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_URI_SUFFIX))
+            .withXmlNamespace(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_XML_NAMESPACE))
             .build());
     }
 

--- a/src/main/java/com/marklogic/spark/writer/splitter/ChunkConfig.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/ChunkConfig.java
@@ -10,13 +10,15 @@ public class ChunkConfig {
     private final DocumentMetadataHandle metadata;
     private final int maxChunks;
     private final String rootName;
+    private final String xmlNamespace;
     private final String uriPrefix;
     private final String uriSuffix;
 
-    private ChunkConfig(DocumentMetadataHandle metadata, int maxChunks, String rootName, String uriPrefix, String uriSuffix) {
+    private ChunkConfig(DocumentMetadataHandle metadata, int maxChunks, String rootName, String xmlNamespace, String uriPrefix, String uriSuffix) {
         this.metadata = metadata;
         this.maxChunks = maxChunks;
         this.rootName = rootName;
+        this.xmlNamespace = xmlNamespace;
         this.uriPrefix = uriPrefix;
         this.uriSuffix = uriSuffix;
     }
@@ -25,11 +27,12 @@ public class ChunkConfig {
         private DocumentMetadataHandle metadata;
         private int maxChunks;
         private String rootName;
+        private String xmlNamespace;
         private String uriPrefix;
         private String uriSuffix;
 
         public ChunkConfig build() {
-            return new ChunkConfig(metadata, maxChunks, rootName, uriPrefix, uriSuffix);
+            return new ChunkConfig(metadata, maxChunks, rootName, xmlNamespace, uriPrefix, uriSuffix);
         }
 
         public Builder withMetadata(DocumentMetadataHandle metadata) {
@@ -44,6 +47,11 @@ public class ChunkConfig {
 
         public Builder withRootName(String rootName) {
             this.rootName = rootName;
+            return this;
+        }
+
+        public Builder withXmlNamespace(String xmlNamespace) {
+            this.xmlNamespace = xmlNamespace;
             return this;
         }
 
@@ -76,5 +84,9 @@ public class ChunkConfig {
 
     public String getUriSuffix() {
         return uriSuffix;
+    }
+
+    public String getXmlNamespace() {
+        return xmlNamespace;
     }
 }

--- a/src/main/java/com/marklogic/spark/writer/splitter/DefaultChunkAssembler.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/DefaultChunkAssembler.java
@@ -3,7 +3,6 @@
  */
 package com.marklogic.spark.writer.splitter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.document.DocumentWriteOperation;
@@ -16,19 +15,13 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.spark.Util;
 import com.marklogic.spark.writer.JsonUtil;
-import com.marklogic.spark.writer.XmlUtil;
 import dev.langchain4j.data.segment.TextSegment;
-import org.jdom2.Document;
-import org.jdom2.Element;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 public class DefaultChunkAssembler implements ChunkAssembler {
-
-    private static final String CHUNKS_ARRAY = "chunks";
 
     private final ChunkConfig chunkConfig;
 
@@ -44,10 +37,7 @@ public class DefaultChunkAssembler implements ChunkAssembler {
             return Stream.of(sourceDocument).iterator();
         }
 
-        if (Format.TEXT.equals(format)) {
-            return writeChunksToSeparateDocument(sourceDocument, textSegments);
-        }
-
+        // Will refactor this soon so that it's all in the separate class.
         if (Format.JSON.equals(format)) {
             if (chunkConfig.getMaxChunks() > 0) {
                 return new JsonChunkDocumentProducer(sourceDocument, textSegments, chunkConfig);
@@ -55,12 +45,7 @@ public class DefaultChunkAssembler implements ChunkAssembler {
             return addChunksToJsonDocument(sourceDocument, textSegments);
         }
 
-        // Default to XML for now. We'll add a config option for this soon.
-        Document doc = XmlUtil.extractDocument(sourceDocument.getContent());
-        addChunksToXmlDocument(doc, textSegments);
-        DocumentWriteOperation output = new DocumentWriteOperationImpl(sourceDocument.getUri(),
-            sourceDocument.getMetadata(), new JDOMHandle(doc));
-        return Stream.of(output).iterator();
+        return new XmlChunkDocumentProducer(sourceDocument, format, textSegments, chunkConfig);
     }
 
     private Format determineSourceDocumentFormat(DocumentWriteOperation sourceDocument) {
@@ -78,102 +63,16 @@ public class DefaultChunkAssembler implements ChunkAssembler {
         return null;
     }
 
-    private Iterator<DocumentWriteOperation> writeChunksToSeparateDocument(DocumentWriteOperation sourceDocument, List<TextSegment> textSegments) {
-        Document doc = new Document();
-        Element root = new Element("root");
-        doc.addContent(root);
-        root.addContent(new Element("source-uri").addContent(sourceDocument.getUri()));
-        addChunksToXmlDocument(doc, textSegments);
-
-        // Temporary URI and permissions, will make these nicer later.
-        String uri = sourceDocument.getUri() + "-chunks.xml";
-        return Stream.of(
-            sourceDocument,
-            new DocumentWriteOperationImpl(uri, chunkConfig.getMetadata(), new JDOMHandle(doc))
-        ).iterator();
-    }
-
-    private void addChunksToXmlDocument(Document doc, List<TextSegment> textSegments) {
-        final Element chunks = new Element(CHUNKS_ARRAY);
-        doc.getRootElement().addContent(chunks);
-        textSegments.forEach(textSegment -> chunks
-            .addContent(new Element("chunk").addContent(new Element("text").addContent(textSegment.text())))
-        );
-    }
-
     private Iterator<DocumentWriteOperation> addChunksToJsonDocument(DocumentWriteOperation sourceDocument, List<TextSegment> textSegments) {
         AbstractWriteHandle content = sourceDocument.getContent();
         ObjectNode doc = (ObjectNode) JsonUtil.getJsonFromHandle(content);
 
-        ArrayNode chunks = doc.putArray(CHUNKS_ARRAY);
+        ArrayNode chunks = doc.putArray("chunks");
         textSegments.forEach(textSegment -> chunks.addObject().put("text", textSegment.text()));
 
         DocumentWriteOperation result = new DocumentWriteOperationImpl(sourceDocument.getUri(),
             sourceDocument.getMetadata(), new JacksonHandle(doc));
 
         return Stream.of(result).iterator();
-    }
-
-    // This will likely end up in its own class file, just stashing it here for now.
-    private static class JsonChunkDocumentProducer implements Iterator<DocumentWriteOperation> {
-        private final DocumentWriteOperation sourceDocument;
-        private final List<TextSegment> textSegments;
-        private final ChunkConfig chunkConfig;
-        private final ObjectMapper objectMapper = new ObjectMapper();
-
-        private int listIndex = -1;
-        private int counter;
-
-        JsonChunkDocumentProducer(DocumentWriteOperation sourceDocument, List<TextSegment> textSegments, ChunkConfig chunkConfig) {
-            this.sourceDocument = sourceDocument;
-            this.textSegments = textSegments;
-            this.chunkConfig = chunkConfig;
-        }
-
-        @Override
-        public boolean hasNext() {
-            return listIndex < textSegments.size();
-        }
-
-        // Sonar complains that a NoSuchElementException should be thrown here, but that would only occur if the
-        // hasNext() implementation has a bug, not if the user calls this too many times.
-        @SuppressWarnings("java:S2272")
-        @Override
-        public DocumentWriteOperation next() {
-            if (listIndex == -1) {
-                listIndex++;
-                return sourceDocument;
-            }
-
-            ObjectNode doc = objectMapper.createObjectNode();
-            ObjectNode rootElement = doc;
-            if (chunkConfig.getRootName() != null) {
-                rootElement = doc.putObject(chunkConfig.getRootName());
-            }
-            rootElement.put("source-uri", sourceDocument.getUri());
-            ArrayNode chunks = rootElement.putArray(CHUNKS_ARRAY);
-            for (int i = 0; i < chunkConfig.getMaxChunks() && hasNext(); i++) {
-                chunks.addObject().put("text", textSegments.get(listIndex++).text());
-            }
-
-            final String chunkDocumentUri = makeChunkDocumentUri(sourceDocument);
-            counter++;
-            return new DocumentWriteOperationImpl(chunkDocumentUri, chunkConfig.getMetadata(), new JacksonHandle(doc));
-        }
-
-        private String makeChunkDocumentUri(DocumentWriteOperation sourceDocument) {
-            if (chunkConfig.getUriPrefix() == null && chunkConfig.getUriSuffix() == null) {
-                return String.format("%s-chunks-%d.json", sourceDocument.getUri(), counter);
-            }
-
-            String uri = UUID.randomUUID().toString();
-            if (chunkConfig.getUriPrefix() != null) {
-                uri = chunkConfig.getUriPrefix() + uri;
-            }
-            if (chunkConfig.getUriSuffix() != null) {
-                uri += chunkConfig.getUriSuffix();
-            }
-            return uri;
-        }
     }
 }

--- a/src/main/java/com/marklogic/spark/writer/splitter/JsonChunkDocumentProducer.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/JsonChunkDocumentProducer.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.splitter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.client.impl.DocumentWriteOperationImpl;
+import com.marklogic.client.io.JacksonHandle;
+import dev.langchain4j.data.segment.TextSegment;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+
+class JsonChunkDocumentProducer implements Iterator<DocumentWriteOperation> {
+
+    private final DocumentWriteOperation sourceDocument;
+    private final List<TextSegment> textSegments;
+    private final ChunkConfig chunkConfig;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private int listIndex = -1;
+    private int counter;
+
+    JsonChunkDocumentProducer(DocumentWriteOperation sourceDocument, List<TextSegment> textSegments, ChunkConfig chunkConfig) {
+        this.sourceDocument = sourceDocument;
+        this.textSegments = textSegments;
+        this.chunkConfig = chunkConfig;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return listIndex < textSegments.size();
+    }
+
+    // Sonar complains that a NoSuchElementException should be thrown here, but that would only occur if the
+    // hasNext() implementation has a bug, not if the user calls this too many times.
+    @SuppressWarnings("java:S2272")
+    @Override
+    public DocumentWriteOperation next() {
+        if (listIndex == -1) {
+            listIndex++;
+            return sourceDocument;
+        }
+
+        ObjectNode doc = objectMapper.createObjectNode();
+        ObjectNode rootElement = doc;
+        if (chunkConfig.getRootName() != null) {
+            rootElement = doc.putObject(chunkConfig.getRootName());
+        }
+        rootElement.put("source-uri", sourceDocument.getUri());
+        ArrayNode chunks = rootElement.putArray("chunks");
+        for (int i = 0; i < chunkConfig.getMaxChunks() && hasNext(); i++) {
+            chunks.addObject().put("text", textSegments.get(listIndex++).text());
+        }
+
+        final String chunkDocumentUri = makeChunkDocumentUri(sourceDocument);
+        counter++;
+        return new DocumentWriteOperationImpl(chunkDocumentUri, chunkConfig.getMetadata(), new JacksonHandle(doc));
+    }
+
+    private String makeChunkDocumentUri(DocumentWriteOperation sourceDocument) {
+        if (chunkConfig.getUriPrefix() == null && chunkConfig.getUriSuffix() == null) {
+            return String.format("%s-chunks-%d.json", sourceDocument.getUri(), counter);
+        }
+
+        String uri = UUID.randomUUID().toString();
+        if (chunkConfig.getUriPrefix() != null) {
+            uri = chunkConfig.getUriPrefix() + uri;
+        }
+        if (chunkConfig.getUriSuffix() != null) {
+            uri += chunkConfig.getUriSuffix();
+        }
+        return uri;
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/splitter/XmlChunkDocumentProducer.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/XmlChunkDocumentProducer.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.splitter;
+
+import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.client.extra.jdom.JDOMHandle;
+import com.marklogic.client.impl.DocumentWriteOperationImpl;
+import com.marklogic.client.io.Format;
+import com.marklogic.spark.writer.XmlUtil;
+import dev.langchain4j.data.segment.TextSegment;
+import org.jdom2.Document;
+import org.jdom2.Element;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+
+class XmlChunkDocumentProducer implements Iterator<DocumentWriteOperation> {
+
+    private final DocumentWriteOperation sourceDocument;
+    private final List<TextSegment> textSegments;
+    private final ChunkConfig chunkConfig;
+    private final int maxChunksPerDocument;
+
+    private int listIndex = -1;
+    private int counter;
+
+    XmlChunkDocumentProducer(DocumentWriteOperation sourceDocument, Format sourceDocumentFormat,
+                             List<TextSegment> textSegments, ChunkConfig chunkConfig) {
+        this.sourceDocument = sourceDocument;
+        this.textSegments = textSegments;
+        this.chunkConfig = chunkConfig;
+
+        // Chunks cannot be written to a TEXT document. So if maxChunks is zero, and we have a text document, we will
+        // instead write all the chunks to a separate document.
+        this.maxChunksPerDocument = Format.TEXT.equals(sourceDocumentFormat) && chunkConfig.getMaxChunks() == 0 ?
+            textSegments.size() :
+            chunkConfig.getMaxChunks();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return listIndex < textSegments.size();
+    }
+
+    // Sonar complains that a NoSuchElementException should be thrown here, but that would only occur if the
+    // hasNext() implementation has a bug, not if the user calls this too many times.
+    @SuppressWarnings("java:S2272")
+    @Override
+    public DocumentWriteOperation next() {
+        if (listIndex == -1) {
+            if (this.maxChunksPerDocument == 0) {
+                listIndex = textSegments.size();
+                return addChunksToSourceDocument();
+            }
+            listIndex++;
+            return sourceDocument;
+        }
+
+        Document doc = new Document();
+        Element root = newElement(chunkConfig.getRootName() != null ? chunkConfig.getRootName() : "root");
+        doc.addContent(root);
+        root.addContent(newElement("source-uri").addContent(sourceDocument.getUri()));
+        final Element chunks = newElement("chunks");
+        doc.getRootElement().addContent(chunks);
+
+        for (int i = 0; i < this.maxChunksPerDocument && hasNext(); i++) {
+            chunks.addContent(newElement("chunk")
+                .addContent(newElement("text")
+                    .addContent(textSegments.get(listIndex++).text())));
+        }
+
+        final String chunkDocumentUri = makeChunkDocumentUri(sourceDocument);
+        counter++;
+        return new DocumentWriteOperationImpl(chunkDocumentUri, chunkConfig.getMetadata(), new JDOMHandle(doc));
+    }
+
+    private DocumentWriteOperation addChunksToSourceDocument() {
+        Document doc = XmlUtil.extractDocument(sourceDocument.getContent());
+        addChunksToXmlDocument(doc, textSegments);
+        return new DocumentWriteOperationImpl(sourceDocument.getUri(), sourceDocument.getMetadata(), new JDOMHandle(doc));
+    }
+
+    private void addChunksToXmlDocument(Document doc, List<TextSegment> textSegments) {
+        final Element chunks = new Element("chunks");
+        doc.getRootElement().addContent(chunks);
+        for (TextSegment textSegment : textSegments) {
+            chunks.addContent(new Element("chunk")
+                .addContent(new Element("text")
+                    .addContent(textSegment.text())));
+        }
+    }
+
+    private Element newElement(String name) {
+        String ns = chunkConfig.getXmlNamespace();
+        return ns != null ? new Element(name, ns) : new Element(name);
+    }
+
+    private String makeChunkDocumentUri(DocumentWriteOperation sourceDocument) {
+        if (chunkConfig.getUriPrefix() == null && chunkConfig.getUriSuffix() == null) {
+            return String.format("%s-chunks-%d.xml", sourceDocument.getUri(), counter);
+        }
+
+        String uri = UUID.randomUUID().toString();
+        if (chunkConfig.getUriPrefix() != null) {
+            uri = chunkConfig.getUriPrefix() + uri;
+        }
+        if (chunkConfig.getUriSuffix() != null) {
+            uri += chunkConfig.getUriSuffix();
+        }
+        return uri;
+    }
+}

--- a/src/test/java/com/marklogic/spark/writer/splitter/SplitJsonDocumentTest.java
+++ b/src/test/java/com/marklogic/spark/writer/splitter/SplitJsonDocumentTest.java
@@ -90,12 +90,7 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
 
     @Test
     void maxChunksOfThree() {
-        readDocument("/marklogic-docs/java-client-intro.json")
-            .write().format(CONNECTOR_IDENTIFIER)
-            .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_JSON_POINTERS, "/text")
-            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
-            .option(Options.WRITE_URI_TEMPLATE, "/split-test.json")
+        prepareToWriteChunkDocuments()
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
             .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 3)
             .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
@@ -126,12 +121,7 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
 
     @Test
     void maxChunksWithCustomPermissions() {
-        readDocument("/marklogic-docs/java-client-intro.json")
-            .write().format(CONNECTOR_IDENTIFIER)
-            .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_JSON_POINTERS, "/text")
-            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
-            .option(Options.WRITE_URI_TEMPLATE, "/split-test.json")
+        prepareToWriteChunkDocuments()
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 1000)
             .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 2)
             .option(Options.WRITE_SPLITTER_OUTPUT_PERMISSIONS,
@@ -147,12 +137,7 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
 
     @Test
     void maxChunksWithCustomUri() {
-        readDocument("/marklogic-docs/java-client-intro.json")
-            .write().format(CONNECTOR_IDENTIFIER)
-            .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_JSON_POINTERS, "/text")
-            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
-            .option(Options.WRITE_URI_TEMPLATE, "/split-test.json")
+        prepareToWriteChunkDocuments()
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
             .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 2)
             .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
@@ -172,12 +157,7 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
 
     @Test
     void maxChunksWithCustomRootName() {
-        readDocument("/marklogic-docs/java-client-intro.json")
-            .write().format(CONNECTOR_IDENTIFIER)
-            .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_JSON_POINTERS, "/text")
-            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
-            .option(Options.WRITE_URI_TEMPLATE, "/split-test.json")
+        prepareToWriteChunkDocuments()
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
             .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 4)
             .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
@@ -198,5 +178,14 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.READ_DOCUMENTS_URIS, uri)
             .load();
+    }
+
+    private DataFrameWriter prepareToWriteChunkDocuments() {
+        return readDocument("/marklogic-docs/java-client-intro.json")
+            .write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.WRITE_SPLITTER_JSON_POINTERS, "/text")
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
+            .option(Options.WRITE_URI_TEMPLATE, "/split-test.json");
     }
 }

--- a/src/test/java/com/marklogic/spark/writer/splitter/SplitTextDocumentTest.java
+++ b/src/test/java/com/marklogic/spark/writer/splitter/SplitTextDocumentTest.java
@@ -7,26 +7,22 @@ import com.marklogic.junit5.PermissionsTester;
 import com.marklogic.junit5.XmlNode;
 import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.Options;
+import org.apache.spark.sql.DataFrameWriter;
 import org.apache.spark.sql.SaveMode;
+import org.jdom2.Namespace;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SplitTextDocumentTest extends AbstractIntegrationTest {
 
     @Test
-    void test() {
-        newSparkSession().read().format(CONNECTOR_IDENTIFIER)
-            .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.READ_DOCUMENTS_URIS, "/marklogic-docs/java-client-intro.txt")
-            .load()
-            .write().format(CONNECTOR_IDENTIFIER)
-            .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_TEXT, true)
-            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
-            .option(Options.WRITE_URI_PREFIX, "/test")
+    void chunksInSeparateDocument() {
+        prepareToWriteChunkDocuments()
             .mode(SaveMode.Append)
             .save();
 
-        final String chunksUri = "/test/marklogic-docs/java-client-intro.txt-chunks.xml";
+        final String chunksUri = "/test/marklogic-docs/java-client-intro.txt-chunks-0.xml";
 
         XmlNode doc = readXmlDocument(chunksUri);
         doc.assertElementValue("/root/source-uri", "/test/marklogic-docs/java-client-intro.txt");
@@ -37,5 +33,91 @@ class SplitTextDocumentTest extends AbstractIntegrationTest {
         tester.assertUpdatePermissionExists("This is just a temporary permission until we allow the URI and " +
             "metadata for chunk documents to be configurable", "spark-user-role");
         tester.assertReadPermissionExists("spark-user-role");
+    }
+
+    @Test
+    void maxChunksOfThree() {
+        prepareToWriteChunkDocuments()
+            .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
+            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 3)
+            .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
+            .mode(SaveMode.Append)
+            .save();
+
+        assertCollectionSize("Two chunk documents should have been written, with the first having 3 chunks and " +
+            "the second having 1 chunk.", "chunks", 2);
+
+        XmlNode firstChunkDoc = readXmlDocument("/test/marklogic-docs/java-client-intro.txt-chunks-0.xml");
+        firstChunkDoc.assertElementValue("/root/source-uri", "/test/marklogic-docs/java-client-intro.txt");
+        firstChunkDoc.assertElementCount("/root/chunks/chunk", 3);
+
+        XmlNode secondChunkDoc = readXmlDocument("/test/marklogic-docs/java-client-intro.txt-chunks-1.xml");
+        secondChunkDoc.assertElementValue("/root/source-uri", "/test/marklogic-docs/java-client-intro.txt");
+        secondChunkDoc.assertElementCount("/root/chunks/chunk", 1);
+    }
+
+    @Test
+    void maxChunksWithCustomPermissions() {
+        prepareToWriteChunkDocuments()
+            .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 1000)
+            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 2)
+            .option(Options.WRITE_SPLITTER_OUTPUT_PERMISSIONS,
+                "spark-user-role,read,spark-user-role,update,qconsole-user,read")
+            .mode(SaveMode.Append)
+            .save();
+
+        PermissionsTester tester = readDocumentPermissions("/test/marklogic-docs/java-client-intro.txt-chunks-0.xml");
+        tester.assertReadPermissionExists("spark-user-role");
+        tester.assertUpdatePermissionExists("spark-user-role");
+        tester.assertReadPermissionExists("qconsole-user");
+    }
+
+    @Test
+    void maxChunksWithCustomUri() {
+        prepareToWriteChunkDocuments()
+            .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
+            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 2)
+            .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
+            .option(Options.WRITE_SPLITTER_OUTPUT_URI_PREFIX, "/chunk/")
+            .option(Options.WRITE_SPLITTER_OUTPUT_URI_SUFFIX, ".xml")
+            .mode(SaveMode.Append)
+            .save();
+
+        getUrisInCollection("chunks", 2).forEach(uri -> {
+            assertTrue(uri.startsWith("/chunk/"), "Unexpected URI: " + uri);
+            assertTrue(uri.endsWith(".xml"), "Unexpected URI: " + uri);
+            XmlNode doc = readXmlDocument(uri);
+            doc.assertElementValue("/root/source-uri", "/test/marklogic-docs/java-client-intro.txt");
+            doc.assertElementCount("/root/chunks/chunk", 2);
+        });
+    }
+
+    @Test
+    void maxChunksWithCustomRootNameAndNamespace() {
+        prepareToWriteChunkDocuments()
+            .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
+            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 4)
+            .option(Options.WRITE_SPLITTER_OUTPUT_ROOT_NAME, "sidecar")
+            .option(Options.WRITE_SPLITTER_OUTPUT_XML_NAMESPACE, "org:example")
+            .mode(SaveMode.Append)
+            .save();
+
+        XmlNode doc = readXmlDocument("/test/marklogic-docs/java-client-intro.txt-chunks-0.xml");
+        doc.setNamespaces(new Namespace[]{Namespace.getNamespace("ex", "org:example")});
+        doc.assertElementExists("/ex:sidecar");
+        doc.assertElementValue("/ex:sidecar/ex:source-uri", "/test/marklogic-docs/java-client-intro.txt");
+        doc.assertElementCount("/ex:sidecar/ex:chunks/ex:chunk", 4);
+    }
+
+    private DataFrameWriter prepareToWriteChunkDocuments() {
+        return newSparkSession().read().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_DOCUMENTS_URIS, "/marklogic-docs/java-client-intro.txt")
+            .load()
+            .write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
+            .option(Options.WRITE_SPLITTER_TEXT, true)
+            .option(Options.WRITE_URI_PREFIX, "/test");
     }
 }


### PR DESCRIPTION
Pull the JSON stuff out into `JsonChunkDocumentProcessor`. Added tests for max chunks for XML and Text. 