### PR TITLE
MLE-1722 Now supporting configurable document type for chunks

### DIFF
--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -137,6 +137,7 @@ public abstract class Options {
     public static final String WRITE_SPLITTER_JOIN_DELIMITER = "spark.marklogic.splitter.joinDelimiter";
     public static final String WRITE_SPLITTER_JSON_POINTERS = "spark.marklogic.write.splitter.jsonPointers";
     public static final String WRITE_SPLITTER_OUTPUT_MAX_CHUNKS = "spark.marklogic.write.splitter.output.maxChunks";
+    public static final String WRITE_SPLITTER_OUTPUT_DOCUMENT_TYPE = "spark.marklogic.write.splitter.output.documentType";
     public static final String WRITE_SPLITTER_OUTPUT_COLLECTIONS = "spark.marklogic.write.splitter.output.collections";
     public static final String WRITE_SPLITTER_OUTPUT_PERMISSIONS = "spark.marklogic.write.splitter.output.permissions";
     public static final String WRITE_SPLITTER_OUTPUT_ROOT_NAME = "spark.marklogic.write.splitter.output.rootName";

--- a/src/main/java/com/marklogic/spark/writer/DocumentProcessorFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/DocumentProcessorFactory.java
@@ -95,6 +95,7 @@ public abstract class DocumentProcessorFactory {
         return new DefaultChunkAssembler(new ChunkConfig.Builder()
             .withMetadata(metadata)
             .withMaxChunks(context.getIntOption(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 0, 0))
+            .withDocumentType(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_DOCUMENT_TYPE))
             .withRootName(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_ROOT_NAME))
             .withUriPrefix(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_URI_PREFIX))
             .withUriSuffix(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_URI_SUFFIX))

--- a/src/main/java/com/marklogic/spark/writer/splitter/AbstractChunkDocumentProducer.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/AbstractChunkDocumentProducer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.splitter;
+
+import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.client.io.Format;
+import dev.langchain4j.data.segment.TextSegment;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Defines common logic for creating JSON and XML chunk documents.
+ */
+abstract class AbstractChunkDocumentProducer implements Iterator<DocumentWriteOperation> {
+
+    protected final DocumentWriteOperation sourceDocument;
+    protected final List<TextSegment> textSegments;
+    protected final ChunkConfig chunkConfig;
+    protected final int maxChunksPerDocument;
+
+    protected int listIndex = -1;
+    private int chunkDocumentCounter;
+
+    AbstractChunkDocumentProducer(DocumentWriteOperation sourceDocument, Format sourceDocumentFormat, List<TextSegment> textSegments, ChunkConfig chunkConfig) {
+        this.sourceDocument = sourceDocument;
+        this.textSegments = textSegments;
+        this.chunkConfig = chunkConfig;
+
+        // Chunks cannot be written to a TEXT document. So if maxChunks is zero, and we have a text document, we will
+        // instead write all the chunks to a separate document.
+        this.maxChunksPerDocument = Format.TEXT.equals(sourceDocumentFormat) && chunkConfig.getMaxChunks() == 0 ?
+            textSegments.size() :
+            chunkConfig.getMaxChunks();
+    }
+
+    protected abstract DocumentWriteOperation addChunksToSourceDocument();
+
+    protected abstract DocumentWriteOperation makeChunkDocument();
+
+
+    @Override
+    public final boolean hasNext() {
+        return listIndex < textSegments.size();
+    }
+
+    // Sonar complains that a NoSuchElementException should be thrown here, but that would only occur if the
+    // hasNext() implementation has a bug, not if the user calls this too many times.
+    @SuppressWarnings("java:S2272")
+    @Override
+    public DocumentWriteOperation next() {
+        if (listIndex == -1) {
+            listIndex++;
+            if (this.maxChunksPerDocument == 0) {
+                listIndex = textSegments.size();
+                return addChunksToSourceDocument();
+            }
+            return sourceDocument;
+        }
+
+        DocumentWriteOperation writeOp = makeChunkDocument();
+        chunkDocumentCounter++;
+        return writeOp;
+    }
+
+    protected final String makeChunkDocumentUri(DocumentWriteOperation sourceDocument, String defaultUriSuffix) {
+        if (chunkConfig.getUriPrefix() == null && chunkConfig.getUriSuffix() == null) {
+            return String.format("%s-chunks-%d.%s", sourceDocument.getUri(), chunkDocumentCounter, defaultUriSuffix);
+        }
+
+        String uri = UUID.randomUUID().toString();
+        if (chunkConfig.getUriPrefix() != null) {
+            uri = chunkConfig.getUriPrefix() + uri;
+        }
+        if (chunkConfig.getUriSuffix() != null) {
+            uri += chunkConfig.getUriSuffix();
+        }
+        return uri;
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/splitter/ChunkConfig.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/ChunkConfig.java
@@ -9,14 +9,16 @@ public class ChunkConfig {
 
     private final DocumentMetadataHandle metadata;
     private final int maxChunks;
+    private final String documentType;
     private final String rootName;
     private final String xmlNamespace;
     private final String uriPrefix;
     private final String uriSuffix;
 
-    private ChunkConfig(DocumentMetadataHandle metadata, int maxChunks, String rootName, String xmlNamespace, String uriPrefix, String uriSuffix) {
+    private ChunkConfig(DocumentMetadataHandle metadata, int maxChunks, String documentType, String rootName, String xmlNamespace, String uriPrefix, String uriSuffix) {
         this.metadata = metadata;
         this.maxChunks = maxChunks;
+        this.documentType = documentType;
         this.rootName = rootName;
         this.xmlNamespace = xmlNamespace;
         this.uriPrefix = uriPrefix;
@@ -26,13 +28,14 @@ public class ChunkConfig {
     public static class Builder {
         private DocumentMetadataHandle metadata;
         private int maxChunks;
+        private String documentType;
         private String rootName;
         private String xmlNamespace;
         private String uriPrefix;
         private String uriSuffix;
 
         public ChunkConfig build() {
-            return new ChunkConfig(metadata, maxChunks, rootName, xmlNamespace, uriPrefix, uriSuffix);
+            return new ChunkConfig(metadata, maxChunks, documentType, rootName, xmlNamespace, uriPrefix, uriSuffix);
         }
 
         public Builder withMetadata(DocumentMetadataHandle metadata) {
@@ -42,6 +45,11 @@ public class ChunkConfig {
 
         public Builder withMaxChunks(int maxChunks) {
             this.maxChunks = maxChunks;
+            return this;
+        }
+
+        public Builder withDocumentType(String documentType) {
+            this.documentType = documentType;
             return this;
         }
 
@@ -72,6 +80,10 @@ public class ChunkConfig {
 
     public int getMaxChunks() {
         return maxChunks;
+    }
+
+    public String getDocumentType() {
+        return documentType;
     }
 
     public String getRootName() {

--- a/src/main/java/com/marklogic/spark/writer/splitter/JsonChunkDocumentProducer.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/JsonChunkDocumentProducer.java
@@ -8,72 +8,53 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.impl.DocumentWriteOperationImpl;
+import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.io.marker.AbstractWriteHandle;
+import com.marklogic.spark.writer.JsonUtil;
 import dev.langchain4j.data.segment.TextSegment;
 
-import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
 
-class JsonChunkDocumentProducer implements Iterator<DocumentWriteOperation> {
+class JsonChunkDocumentProducer extends AbstractChunkDocumentProducer {
 
-    private final DocumentWriteOperation sourceDocument;
-    private final List<TextSegment> textSegments;
-    private final ChunkConfig chunkConfig;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private int listIndex = -1;
-    private int counter;
-
-    JsonChunkDocumentProducer(DocumentWriteOperation sourceDocument, List<TextSegment> textSegments, ChunkConfig chunkConfig) {
-        this.sourceDocument = sourceDocument;
-        this.textSegments = textSegments;
-        this.chunkConfig = chunkConfig;
+    JsonChunkDocumentProducer(DocumentWriteOperation sourceDocument, Format sourceDocumentFormat, List<TextSegment> textSegments, ChunkConfig chunkConfig) {
+        super(sourceDocument, sourceDocumentFormat, textSegments, chunkConfig);
     }
 
     @Override
-    public boolean hasNext() {
-        return listIndex < textSegments.size();
+    protected DocumentWriteOperation addChunksToSourceDocument() {
+        AbstractWriteHandle content = sourceDocument.getContent();
+        ObjectNode doc = (ObjectNode) JsonUtil.getJsonFromHandle(content);
+
+        ArrayNode chunks = doc.putArray("chunks");
+        textSegments.forEach(textSegment -> {
+            String text = textSegment.text();
+            chunks.addObject().put("text", text);
+        });
+
+        return new DocumentWriteOperationImpl(sourceDocument.getUri(), sourceDocument.getMetadata(), new JacksonHandle(doc));
     }
 
-    // Sonar complains that a NoSuchElementException should be thrown here, but that would only occur if the
-    // hasNext() implementation has a bug, not if the user calls this too many times.
-    @SuppressWarnings("java:S2272")
     @Override
-    public DocumentWriteOperation next() {
-        if (listIndex == -1) {
-            listIndex++;
-            return sourceDocument;
-        }
-
+    protected DocumentWriteOperation makeChunkDocument() {
         ObjectNode doc = objectMapper.createObjectNode();
-        ObjectNode rootElement = doc;
+        ObjectNode rootField = doc;
         if (chunkConfig.getRootName() != null) {
-            rootElement = doc.putObject(chunkConfig.getRootName());
+            rootField = doc.putObject(chunkConfig.getRootName());
         }
-        rootElement.put("source-uri", sourceDocument.getUri());
-        ArrayNode chunks = rootElement.putArray("chunks");
-        for (int i = 0; i < chunkConfig.getMaxChunks() && hasNext(); i++) {
-            chunks.addObject().put("text", textSegments.get(listIndex++).text());
+        String uri = sourceDocument.getUri();
+        rootField.put("source-uri", uri);
+
+        ArrayNode chunks = rootField.putArray("chunks");
+        for (int i = 0; i < this.maxChunksPerDocument && hasNext(); i++) {
+            String text = textSegments.get(listIndex++).text();
+            chunks.addObject().put("text", text);
         }
 
-        final String chunkDocumentUri = makeChunkDocumentUri(sourceDocument);
-        counter++;
+        final String chunkDocumentUri = makeChunkDocumentUri(sourceDocument, "json");
         return new DocumentWriteOperationImpl(chunkDocumentUri, chunkConfig.getMetadata(), new JacksonHandle(doc));
-    }
-
-    private String makeChunkDocumentUri(DocumentWriteOperation sourceDocument) {
-        if (chunkConfig.getUriPrefix() == null && chunkConfig.getUriSuffix() == null) {
-            return String.format("%s-chunks-%d.json", sourceDocument.getUri(), counter);
-        }
-
-        String uri = UUID.randomUUID().toString();
-        if (chunkConfig.getUriPrefix() != null) {
-            uri = chunkConfig.getUriPrefix() + uri;
-        }
-        if (chunkConfig.getUriSuffix() != null) {
-            uri += chunkConfig.getUriSuffix();
-        }
-        return uri;
     }
 }

--- a/src/main/java/com/marklogic/spark/writer/splitter/XmlChunkDocumentProducer.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/XmlChunkDocumentProducer.java
@@ -12,52 +12,17 @@ import dev.langchain4j.data.segment.TextSegment;
 import org.jdom2.Document;
 import org.jdom2.Element;
 
-import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
 
-class XmlChunkDocumentProducer implements Iterator<DocumentWriteOperation> {
-
-    private final DocumentWriteOperation sourceDocument;
-    private final List<TextSegment> textSegments;
-    private final ChunkConfig chunkConfig;
-    private final int maxChunksPerDocument;
-
-    private int listIndex = -1;
-    private int counter;
+class XmlChunkDocumentProducer extends AbstractChunkDocumentProducer {
 
     XmlChunkDocumentProducer(DocumentWriteOperation sourceDocument, Format sourceDocumentFormat,
                              List<TextSegment> textSegments, ChunkConfig chunkConfig) {
-        this.sourceDocument = sourceDocument;
-        this.textSegments = textSegments;
-        this.chunkConfig = chunkConfig;
-
-        // Chunks cannot be written to a TEXT document. So if maxChunks is zero, and we have a text document, we will
-        // instead write all the chunks to a separate document.
-        this.maxChunksPerDocument = Format.TEXT.equals(sourceDocumentFormat) && chunkConfig.getMaxChunks() == 0 ?
-            textSegments.size() :
-            chunkConfig.getMaxChunks();
+        super(sourceDocument, sourceDocumentFormat, textSegments, chunkConfig);
     }
 
     @Override
-    public boolean hasNext() {
-        return listIndex < textSegments.size();
-    }
-
-    // Sonar complains that a NoSuchElementException should be thrown here, but that would only occur if the
-    // hasNext() implementation has a bug, not if the user calls this too many times.
-    @SuppressWarnings("java:S2272")
-    @Override
-    public DocumentWriteOperation next() {
-        if (listIndex == -1) {
-            if (this.maxChunksPerDocument == 0) {
-                listIndex = textSegments.size();
-                return addChunksToSourceDocument();
-            }
-            listIndex++;
-            return sourceDocument;
-        }
-
+    protected DocumentWriteOperation makeChunkDocument() {
         Document doc = new Document();
         Element root = newElement(chunkConfig.getRootName() != null ? chunkConfig.getRootName() : "root");
         doc.addContent(root);
@@ -71,18 +36,13 @@ class XmlChunkDocumentProducer implements Iterator<DocumentWriteOperation> {
                     .addContent(textSegments.get(listIndex++).text())));
         }
 
-        final String chunkDocumentUri = makeChunkDocumentUri(sourceDocument);
-        counter++;
+        final String chunkDocumentUri = makeChunkDocumentUri(sourceDocument, "xml");
         return new DocumentWriteOperationImpl(chunkDocumentUri, chunkConfig.getMetadata(), new JDOMHandle(doc));
     }
 
-    private DocumentWriteOperation addChunksToSourceDocument() {
+    protected DocumentWriteOperation addChunksToSourceDocument() {
         Document doc = XmlUtil.extractDocument(sourceDocument.getContent());
-        addChunksToXmlDocument(doc, textSegments);
-        return new DocumentWriteOperationImpl(sourceDocument.getUri(), sourceDocument.getMetadata(), new JDOMHandle(doc));
-    }
 
-    private void addChunksToXmlDocument(Document doc, List<TextSegment> textSegments) {
         final Element chunks = new Element("chunks");
         doc.getRootElement().addContent(chunks);
         for (TextSegment textSegment : textSegments) {
@@ -90,25 +50,12 @@ class XmlChunkDocumentProducer implements Iterator<DocumentWriteOperation> {
                 .addContent(new Element("text")
                     .addContent(textSegment.text())));
         }
+
+        return new DocumentWriteOperationImpl(sourceDocument.getUri(), sourceDocument.getMetadata(), new JDOMHandle(doc));
     }
 
     private Element newElement(String name) {
         String ns = chunkConfig.getXmlNamespace();
         return ns != null ? new Element(name, ns) : new Element(name);
-    }
-
-    private String makeChunkDocumentUri(DocumentWriteOperation sourceDocument) {
-        if (chunkConfig.getUriPrefix() == null && chunkConfig.getUriSuffix() == null) {
-            return String.format("%s-chunks-%d.xml", sourceDocument.getUri(), counter);
-        }
-
-        String uri = UUID.randomUUID().toString();
-        if (chunkConfig.getUriPrefix() != null) {
-            uri = chunkConfig.getUriPrefix() + uri;
-        }
-        if (chunkConfig.getUriSuffix() != null) {
-            uri += chunkConfig.getUriSuffix();
-        }
-        return uri;
     }
 }

--- a/src/test/java/com/marklogic/spark/writer/splitter/SplitJsonDocumentTest.java
+++ b/src/test/java/com/marklogic/spark/writer/splitter/SplitJsonDocumentTest.java
@@ -6,6 +6,7 @@ package com.marklogic.spark.writer.splitter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.marklogic.junit5.PermissionsTester;
+import com.marklogic.junit5.XmlNode;
 import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
@@ -171,6 +172,28 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
         assertEquals(4, doc.get("sidecar").get("chunks").size(), "The sidecar document should have all 4 chunks in " +
             "it.");
         assertCollectionSize("Should only have one document as all 4 chunks fit in it", "chunks", 1);
+    }
+
+    /**
+     * Demonstrates that XML chunk documents can be written even when the source document is JSON.
+     */
+    @Test
+    void xmlChunks() {
+        prepareToWriteChunkDocuments()
+            .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
+            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 2)
+            .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
+            .option(Options.WRITE_SPLITTER_OUTPUT_DOCUMENT_TYPE, "xml")
+            .mode(SaveMode.Append)
+            .save();
+
+        assertCollectionSize("chunks", 2);
+
+        XmlNode doc = readXmlDocument("/split-test.json-chunks-0.xml");
+        doc.assertElementCount("/root/chunks/chunk", 2);
+
+        doc = readXmlDocument("/split-test.json-chunks-1.xml");
+        doc.assertElementCount("/root/chunks/chunk", 2);
     }
 
     private Dataset<Row> readDocument(String uri) {

--- a/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
+++ b/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
@@ -3,6 +3,7 @@
  */
 package com.marklogic.spark.writer.splitter;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.junit5.PermissionsTester;
 import com.marklogic.junit5.XmlNode;
 import com.marklogic.spark.AbstractIntegrationTest;
@@ -250,6 +251,28 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         doc.assertElementExists("/ex:sidecar");
         doc.assertElementValue("/ex:sidecar/ex:source-uri", "/split-test.xml");
         doc.assertElementCount("/ex:sidecar/ex:chunks/ex:chunk", 4);
+    }
+
+    /**
+     * Demonstrates that JSON chunk documents can be written even when the source document is XML.
+     */
+    @Test
+    void jsonChunks() {
+        prepareToWriteChunkDocuments()
+            .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
+            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 2)
+            .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
+            .option(Options.WRITE_SPLITTER_OUTPUT_DOCUMENT_TYPE, "json")
+            .mode(SaveMode.Append)
+            .save();
+
+        assertCollectionSize("chunks", 2);
+
+        JsonNode doc = readJsonDocument("/split-test.xml-chunks-0.json");
+        assertEquals(2, doc.get("chunks").size());
+
+        doc = readJsonDocument("/split-test.xml-chunks-1.json");
+        assertEquals(2, doc.get("chunks").size());
     }
 
     private Dataset<Row> readDocument(String uri) {


### PR DESCRIPTION
Did some refactoring too - added `AbstractChunkDocumentProducer` to capture common logic between JSON and XML.
