### PR TITLE
MLE-17469 Defaulting document type to JSON for JSON Lines documents

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/file/JsonLinesFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/JsonLinesFileReader.java
@@ -79,7 +79,8 @@ class JsonLinesFileReader implements PartitionReader<InternalRow> {
         return new GenericInternalRow(new Object[]{
             UTF8String.fromString(uri),
             ByteArray.concat(line.getBytes()),
-            null, null, null, null, null, null
+            UTF8String.fromString("JSON"),
+            null, null, null, null, null
         });
     }
 }

--- a/src/main/java/com/marklogic/spark/writer/DocumentRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/DocumentRowConverter.java
@@ -87,7 +87,7 @@ class DocumentRowConverter implements RowConverter {
         } else if (!row.isNullAt(2)) {
             String format = row.getString(2);
             try {
-                bytesHandle.withFormat(Format.valueOf(format));
+                bytesHandle.withFormat(Format.valueOf(format.toUpperCase()));
             } catch (IllegalArgumentException e) {
                 // We don't ever expect this to happen, but in case it does - we'll proceed with a null format
                 // on the handle, as it's not essential that it be set.


### PR DESCRIPTION
The "toUpperCase" doesn't fix an immediate bug, but prevents possible future bugs since Format requires the value to be upper-case.
