### PR TITLE
Chunk document URIs start at 1 instead of 0 now

### DIFF
--- a/src/main/java/com/marklogic/spark/writer/splitter/AbstractChunkDocumentProducer.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/AbstractChunkDocumentProducer.java
@@ -22,7 +22,7 @@ abstract class AbstractChunkDocumentProducer implements Iterator<DocumentWriteOp
     protected final int maxChunksPerDocument;
 
     protected int listIndex = -1;
-    private int chunkDocumentCounter;
+    private int chunkDocumentCounter = 1;
 
     AbstractChunkDocumentProducer(DocumentWriteOperation sourceDocument, Format sourceDocumentFormat, List<TextSegment> textSegments, ChunkConfig chunkConfig) {
         this.sourceDocument = sourceDocument;

--- a/src/test/java/com/marklogic/spark/writer/splitter/SplitJsonDocumentTest.java
+++ b/src/test/java/com/marklogic/spark/writer/splitter/SplitJsonDocumentTest.java
@@ -157,15 +157,15 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
             "the max chunk count per document is 3. So the first chunk doc should have 3 chunks, and the second " +
             "should have 1 chunk.", "chunks", 2);
 
-        JsonNode firstChunkDoc = readJsonDocument("/split-test.json-chunks-0.json");
+        JsonNode firstChunkDoc = readJsonDocument("/split-test.json-chunks-1.json");
         assertEquals("/split-test.json", firstChunkDoc.get("source-uri").asText());
         assertEquals(3, firstChunkDoc.get("chunks").size());
 
-        JsonNode secondChunkDoc = readJsonDocument("/split-test.json-chunks-1.json");
+        JsonNode secondChunkDoc = readJsonDocument("/split-test.json-chunks-2.json");
         assertEquals("/split-test.json", secondChunkDoc.get("source-uri").asText());
         assertEquals(1, secondChunkDoc.get("chunks").size());
 
-        PermissionsTester tester = readDocumentPermissions("/split-test.json-chunks-0.json");
+        PermissionsTester tester = readDocumentPermissions("/split-test.json-chunks-1.json");
         tester.assertReadPermissionExists("The chunk documents should default to the permissions specified " +
             "via Options.WRITE_PERMISSIONS", "spark-user-role");
         tester.assertUpdatePermissionExists("spark-user-role");
@@ -181,7 +181,7 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        PermissionsTester tester = readDocumentPermissions("/split-test.json-chunks-0.json");
+        PermissionsTester tester = readDocumentPermissions("/split-test.json-chunks-1.json");
         tester.assertReadPermissionExists("spark-user-role");
         tester.assertUpdatePermissionExists("spark-user-role");
         tester.assertReadPermissionExists("qconsole-user");
@@ -217,7 +217,7 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        JsonNode doc = readJsonDocument("/split-test.json-chunks-0.json");
+        JsonNode doc = readJsonDocument("/split-test.json-chunks-1.json");
         assertTrue(doc.has("sidecar"));
         assertEquals("/split-test.json", doc.get("sidecar").get("source-uri").asText());
         assertEquals(4, doc.get("sidecar").get("chunks").size(), "The sidecar document should have all 4 chunks in " +
@@ -240,10 +240,10 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
 
         assertCollectionSize("chunks", 2);
 
-        XmlNode doc = readXmlDocument("/split-test.json-chunks-0.xml");
+        XmlNode doc = readXmlDocument("/split-test.json-chunks-1.xml");
         doc.assertElementCount("/root/chunks/chunk", 2);
 
-        doc = readXmlDocument("/split-test.json-chunks-1.xml");
+        doc = readXmlDocument("/split-test.json-chunks-2.xml");
         doc.assertElementCount("/root/chunks/chunk", 2);
     }
 

--- a/src/test/java/com/marklogic/spark/writer/splitter/SplitTextDocumentTest.java
+++ b/src/test/java/com/marklogic/spark/writer/splitter/SplitTextDocumentTest.java
@@ -24,7 +24,7 @@ class SplitTextDocumentTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        final String chunksUri = "/test/marklogic-docs/java-client-intro.txt-chunks-0.json";
+        final String chunksUri = "/test/marklogic-docs/java-client-intro.txt-chunks-1.json";
 
         JsonNode doc = readJsonDocument(chunksUri);
         assertEquals("/test/marklogic-docs/java-client-intro.txt", doc.get("source-uri").asText());
@@ -43,7 +43,7 @@ class SplitTextDocumentTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        final String chunksUri = "/test/marklogic-docs/java-client-intro.txt-chunks-0.xml";
+        final String chunksUri = "/test/marklogic-docs/java-client-intro.txt-chunks-1.xml";
 
         XmlNode doc = readXmlDocument(chunksUri);
         doc.assertElementValue("/root/source-uri", "/test/marklogic-docs/java-client-intro.txt");
@@ -69,11 +69,11 @@ class SplitTextDocumentTest extends AbstractIntegrationTest {
         assertCollectionSize("Two chunk documents should have been written, with the first having 3 chunks and " +
             "the second having 1 chunk.", "chunks", 2);
 
-        XmlNode firstChunkDoc = readXmlDocument("/test/marklogic-docs/java-client-intro.txt-chunks-0.xml");
+        XmlNode firstChunkDoc = readXmlDocument("/test/marklogic-docs/java-client-intro.txt-chunks-1.xml");
         firstChunkDoc.assertElementValue("/root/source-uri", "/test/marklogic-docs/java-client-intro.txt");
         firstChunkDoc.assertElementCount("/root/chunks/chunk", 3);
 
-        XmlNode secondChunkDoc = readXmlDocument("/test/marklogic-docs/java-client-intro.txt-chunks-1.xml");
+        XmlNode secondChunkDoc = readXmlDocument("/test/marklogic-docs/java-client-intro.txt-chunks-2.xml");
         secondChunkDoc.assertElementValue("/root/source-uri", "/test/marklogic-docs/java-client-intro.txt");
         secondChunkDoc.assertElementCount("/root/chunks/chunk", 1);
     }
@@ -89,7 +89,7 @@ class SplitTextDocumentTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        PermissionsTester tester = readDocumentPermissions("/test/marklogic-docs/java-client-intro.txt-chunks-0.xml");
+        PermissionsTester tester = readDocumentPermissions("/test/marklogic-docs/java-client-intro.txt-chunks-1.xml");
         tester.assertReadPermissionExists("spark-user-role");
         tester.assertUpdatePermissionExists("spark-user-role");
         tester.assertReadPermissionExists("qconsole-user");
@@ -127,7 +127,7 @@ class SplitTextDocumentTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        XmlNode doc = readXmlDocument("/test/marklogic-docs/java-client-intro.txt-chunks-0.xml");
+        XmlNode doc = readXmlDocument("/test/marklogic-docs/java-client-intro.txt-chunks-1.xml");
         doc.setNamespaces(new Namespace[]{Namespace.getNamespace("ex", "org:example")});
         doc.assertElementExists("/ex:sidecar");
         doc.assertElementValue("/ex:sidecar/ex:source-uri", "/test/marklogic-docs/java-client-intro.txt");

--- a/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
+++ b/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
@@ -189,11 +189,11 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         assertCollectionSize("Two chunk documents should have been written, with the first having 3 chunks and " +
             "the second having 1 chunk.", "chunks", 2);
 
-        XmlNode firstChunkDoc = readXmlDocument("/split-test.xml-chunks-0.xml");
+        XmlNode firstChunkDoc = readXmlDocument("/split-test.xml-chunks-1.xml");
         firstChunkDoc.assertElementValue("/root/source-uri", "/split-test.xml");
         firstChunkDoc.assertElementCount("/root/chunks/chunk", 3);
 
-        XmlNode secondChunkDoc = readXmlDocument("/split-test.xml-chunks-1.xml");
+        XmlNode secondChunkDoc = readXmlDocument("/split-test.xml-chunks-2.xml");
         secondChunkDoc.assertElementValue("/root/source-uri", "/split-test.xml");
         secondChunkDoc.assertElementCount("/root/chunks/chunk", 1);
     }
@@ -209,7 +209,7 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        PermissionsTester tester = readDocumentPermissions("/split-test.xml-chunks-0.xml");
+        PermissionsTester tester = readDocumentPermissions("/split-test.xml-chunks-1.xml");
         tester.assertReadPermissionExists("spark-user-role");
         tester.assertUpdatePermissionExists("spark-user-role");
         tester.assertReadPermissionExists("qconsole-user");
@@ -246,7 +246,7 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        XmlNode doc = readXmlDocument("/split-test.xml-chunks-0.xml");
+        XmlNode doc = readXmlDocument("/split-test.xml-chunks-1.xml");
         doc.setNamespaces(new Namespace[]{Namespace.getNamespace("ex", "org:example")});
         doc.assertElementExists("/ex:sidecar");
         doc.assertElementValue("/ex:sidecar/ex:source-uri", "/split-test.xml");
@@ -268,10 +268,10 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
 
         assertCollectionSize("chunks", 2);
 
-        JsonNode doc = readJsonDocument("/split-test.xml-chunks-0.json");
+        JsonNode doc = readJsonDocument("/split-test.xml-chunks-1.json");
         assertEquals(2, doc.get("chunks").size());
 
-        doc = readJsonDocument("/split-test.xml-chunks-1.json");
+        doc = readJsonDocument("/split-test.xml-chunks-2.json");
         assertEquals(2, doc.get("chunks").size());
     }
 


### PR DESCRIPTION
1 seems more expected. Makes it easy to count how many chunk documents you have too.
