### PR TITLE
Renamed options to use "sidecar" instead of "output"

### DIFF
--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -138,14 +138,14 @@ public abstract class Options {
     public static final String WRITE_SPLITTER_JSON_POINTERS = "spark.marklogic.write.splitter.jsonPointers";
     public static final String WRITE_SPLITTER_CUSTOM_CLASS = "spark.marklogic.write.splitter.customClass";
     public static final String WRITE_SPLITTER_CUSTOM_CLASS_OPTION_PREFIX = "spark.marklogic.write.splitter.customClass.option.";
-    public static final String WRITE_SPLITTER_OUTPUT_MAX_CHUNKS = "spark.marklogic.write.splitter.output.maxChunks";
-    public static final String WRITE_SPLITTER_OUTPUT_DOCUMENT_TYPE = "spark.marklogic.write.splitter.output.documentType";
-    public static final String WRITE_SPLITTER_OUTPUT_COLLECTIONS = "spark.marklogic.write.splitter.output.collections";
-    public static final String WRITE_SPLITTER_OUTPUT_PERMISSIONS = "spark.marklogic.write.splitter.output.permissions";
-    public static final String WRITE_SPLITTER_OUTPUT_ROOT_NAME = "spark.marklogic.write.splitter.output.rootName";
-    public static final String WRITE_SPLITTER_OUTPUT_URI_PREFIX = "spark.marklogic.write.splitter.output.uriPrefix";
-    public static final String WRITE_SPLITTER_OUTPUT_URI_SUFFIX = "spark.marklogic.write.splitter.output.uriSuffix";
-    public static final String WRITE_SPLITTER_OUTPUT_XML_NAMESPACE = "spark.marklogic.write.splitter.output.xmlNamespace";
+    public static final String WRITE_SPLITTER_SIDECAR_MAX_CHUNKS = "spark.marklogic.write.splitter.sidecar.maxChunks";
+    public static final String WRITE_SPLITTER_SIDECAR_DOCUMENT_TYPE = "spark.marklogic.write.splitter.sidecar.documentType";
+    public static final String WRITE_SPLITTER_SIDECAR_COLLECTIONS = "spark.marklogic.write.splitter.sidecar.collections";
+    public static final String WRITE_SPLITTER_SIDECAR_PERMISSIONS = "spark.marklogic.write.splitter.sidecar.permissions";
+    public static final String WRITE_SPLITTER_SIDECAR_ROOT_NAME = "spark.marklogic.write.splitter.sidecar.rootName";
+    public static final String WRITE_SPLITTER_SIDECAR_URI_PREFIX = "spark.marklogic.write.splitter.sidecar.uriPrefix";
+    public static final String WRITE_SPLITTER_SIDECAR_URI_SUFFIX = "spark.marklogic.write.splitter.sidecar.uriSuffix";
+    public static final String WRITE_SPLITTER_SIDECAR_XML_NAMESPACE = "spark.marklogic.write.splitter.sidecar.xmlNamespace";
 
     // For writing RDF
     public static final String WRITE_GRAPH = "spark.marklogic.write.graph";

--- a/src/main/java/com/marklogic/spark/writer/DocumentProcessorFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/DocumentProcessorFactory.java
@@ -83,11 +83,11 @@ public abstract class DocumentProcessorFactory {
 
     private static ChunkAssembler makeChunkAssembler(ContextSupport context) {
         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
-        if (context.hasOption(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS)) {
-            metadata.getCollections().addAll(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS).split(","));
+        if (context.hasOption(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS)) {
+            metadata.getCollections().addAll(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS).split(","));
         }
-        if (context.hasOption(Options.WRITE_SPLITTER_OUTPUT_PERMISSIONS)) {
-            String value = context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_PERMISSIONS);
+        if (context.hasOption(Options.WRITE_SPLITTER_SIDECAR_PERMISSIONS)) {
+            String value = context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_PERMISSIONS);
             metadata.getPermissions().addFromDelimitedString(value);
         } else if (context.hasOption(Options.WRITE_PERMISSIONS)) {
             String value = context.getStringOption(Options.WRITE_PERMISSIONS);
@@ -96,12 +96,12 @@ public abstract class DocumentProcessorFactory {
 
         return new DefaultChunkAssembler(new ChunkConfig.Builder()
             .withMetadata(metadata)
-            .withMaxChunks(context.getIntOption(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 0, 0))
-            .withDocumentType(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_DOCUMENT_TYPE))
-            .withRootName(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_ROOT_NAME))
-            .withUriPrefix(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_URI_PREFIX))
-            .withUriSuffix(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_URI_SUFFIX))
-            .withXmlNamespace(context.getStringOption(Options.WRITE_SPLITTER_OUTPUT_XML_NAMESPACE))
+            .withMaxChunks(context.getIntOption(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 0, 0))
+            .withDocumentType(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_DOCUMENT_TYPE))
+            .withRootName(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_ROOT_NAME))
+            .withUriPrefix(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_URI_PREFIX))
+            .withUriSuffix(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_URI_SUFFIX))
+            .withXmlNamespace(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_XML_NAMESPACE))
             .build());
     }
 

--- a/src/test/java/com/marklogic/spark/writer/splitter/SplitJsonDocumentTest.java
+++ b/src/test/java/com/marklogic/spark/writer/splitter/SplitJsonDocumentTest.java
@@ -144,8 +144,8 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
     void maxChunksOfThree() {
         prepareToWriteChunkDocuments()
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
-            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 3)
-            .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
+            .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 3)
+            .option(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS, "chunks")
             .mode(SaveMode.Append)
             .save();
 
@@ -175,8 +175,8 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
     void maxChunksWithCustomPermissions() {
         prepareToWriteChunkDocuments()
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 1000)
-            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 2)
-            .option(Options.WRITE_SPLITTER_OUTPUT_PERMISSIONS,
+            .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 2)
+            .option(Options.WRITE_SPLITTER_SIDECAR_PERMISSIONS,
                 "spark-user-role,read,spark-user-role,update,qconsole-user,read")
             .mode(SaveMode.Append)
             .save();
@@ -191,10 +191,10 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
     void maxChunksWithCustomUri() {
         prepareToWriteChunkDocuments()
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
-            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 2)
-            .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
-            .option(Options.WRITE_SPLITTER_OUTPUT_URI_PREFIX, "/chunk/")
-            .option(Options.WRITE_SPLITTER_OUTPUT_URI_SUFFIX, ".json")
+            .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 2)
+            .option(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS, "chunks")
+            .option(Options.WRITE_SPLITTER_SIDECAR_URI_PREFIX, "/chunk/")
+            .option(Options.WRITE_SPLITTER_SIDECAR_URI_SUFFIX, ".json")
             .mode(SaveMode.Append)
             .save();
 
@@ -211,9 +211,9 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
     void maxChunksWithCustomRootName() {
         prepareToWriteChunkDocuments()
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
-            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 4)
-            .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
-            .option(Options.WRITE_SPLITTER_OUTPUT_ROOT_NAME, "sidecar")
+            .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 4)
+            .option(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS, "chunks")
+            .option(Options.WRITE_SPLITTER_SIDECAR_ROOT_NAME, "sidecar")
             .mode(SaveMode.Append)
             .save();
 
@@ -232,9 +232,9 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
     void xmlChunks() {
         prepareToWriteChunkDocuments()
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
-            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 2)
-            .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
-            .option(Options.WRITE_SPLITTER_OUTPUT_DOCUMENT_TYPE, "xml")
+            .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 2)
+            .option(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS, "chunks")
+            .option(Options.WRITE_SPLITTER_SIDECAR_DOCUMENT_TYPE, "xml")
             .mode(SaveMode.Append)
             .save();
 

--- a/src/test/java/com/marklogic/spark/writer/splitter/SplitTextDocumentTest.java
+++ b/src/test/java/com/marklogic/spark/writer/splitter/SplitTextDocumentTest.java
@@ -39,7 +39,7 @@ class SplitTextDocumentTest extends AbstractIntegrationTest {
     @Test
     void xmlChunks() {
         prepareToWriteChunkDocuments()
-            .option(Options.WRITE_SPLITTER_OUTPUT_DOCUMENT_TYPE, "xml")
+            .option(Options.WRITE_SPLITTER_SIDECAR_DOCUMENT_TYPE, "xml")
             .mode(SaveMode.Append)
             .save();
 
@@ -60,9 +60,9 @@ class SplitTextDocumentTest extends AbstractIntegrationTest {
     void maxChunksOfThree() {
         prepareToWriteChunkDocuments()
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
-            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 3)
-            .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
-            .option(Options.WRITE_SPLITTER_OUTPUT_DOCUMENT_TYPE, "xml")
+            .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 3)
+            .option(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS, "chunks")
+            .option(Options.WRITE_SPLITTER_SIDECAR_DOCUMENT_TYPE, "xml")
             .mode(SaveMode.Append)
             .save();
 
@@ -82,9 +82,9 @@ class SplitTextDocumentTest extends AbstractIntegrationTest {
     void maxChunksWithCustomPermissions() {
         prepareToWriteChunkDocuments()
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 1000)
-            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 2)
-            .option(Options.WRITE_SPLITTER_OUTPUT_DOCUMENT_TYPE, "xml")
-            .option(Options.WRITE_SPLITTER_OUTPUT_PERMISSIONS,
+            .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 2)
+            .option(Options.WRITE_SPLITTER_SIDECAR_DOCUMENT_TYPE, "xml")
+            .option(Options.WRITE_SPLITTER_SIDECAR_PERMISSIONS,
                 "spark-user-role,read,spark-user-role,update,qconsole-user,read")
             .mode(SaveMode.Append)
             .save();
@@ -99,11 +99,11 @@ class SplitTextDocumentTest extends AbstractIntegrationTest {
     void maxChunksWithCustomUri() {
         prepareToWriteChunkDocuments()
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
-            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 2)
-            .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
-            .option(Options.WRITE_SPLITTER_OUTPUT_URI_PREFIX, "/chunk/")
-            .option(Options.WRITE_SPLITTER_OUTPUT_URI_SUFFIX, ".xml")
-            .option(Options.WRITE_SPLITTER_OUTPUT_DOCUMENT_TYPE, "xml")
+            .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 2)
+            .option(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS, "chunks")
+            .option(Options.WRITE_SPLITTER_SIDECAR_URI_PREFIX, "/chunk/")
+            .option(Options.WRITE_SPLITTER_SIDECAR_URI_SUFFIX, ".xml")
+            .option(Options.WRITE_SPLITTER_SIDECAR_DOCUMENT_TYPE, "xml")
             .mode(SaveMode.Append)
             .save();
 
@@ -120,10 +120,10 @@ class SplitTextDocumentTest extends AbstractIntegrationTest {
     void maxChunksWithCustomRootNameAndNamespace() {
         prepareToWriteChunkDocuments()
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
-            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 4)
-            .option(Options.WRITE_SPLITTER_OUTPUT_ROOT_NAME, "sidecar")
-            .option(Options.WRITE_SPLITTER_OUTPUT_XML_NAMESPACE, "org:example")
-            .option(Options.WRITE_SPLITTER_OUTPUT_DOCUMENT_TYPE, "xml")
+            .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 4)
+            .option(Options.WRITE_SPLITTER_SIDECAR_ROOT_NAME, "sidecar")
+            .option(Options.WRITE_SPLITTER_SIDECAR_XML_NAMESPACE, "org:example")
+            .option(Options.WRITE_SPLITTER_SIDECAR_DOCUMENT_TYPE, "xml")
             .mode(SaveMode.Append)
             .save();
 

--- a/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
+++ b/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
@@ -177,8 +177,8 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         prepareToWriteChunkDocuments()
             .option(Options.WRITE_URI_TEMPLATE, "/split-test.xml")
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
-            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 3)
-            .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
+            .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 3)
+            .option(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS, "chunks")
             .mode(SaveMode.Append)
             .save();
 
@@ -203,8 +203,8 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         prepareToWriteChunkDocuments()
             .option(Options.WRITE_URI_TEMPLATE, "/split-test.xml")
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 1000)
-            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 2)
-            .option(Options.WRITE_SPLITTER_OUTPUT_PERMISSIONS,
+            .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 2)
+            .option(Options.WRITE_SPLITTER_SIDECAR_PERMISSIONS,
                 "spark-user-role,read,spark-user-role,update,qconsole-user,read")
             .mode(SaveMode.Append)
             .save();
@@ -219,10 +219,10 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
     void maxChunksWithCustomUri() {
         prepareToWriteChunkDocuments()
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
-            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 2)
-            .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
-            .option(Options.WRITE_SPLITTER_OUTPUT_URI_PREFIX, "/chunk/")
-            .option(Options.WRITE_SPLITTER_OUTPUT_URI_SUFFIX, ".xml")
+            .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 2)
+            .option(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS, "chunks")
+            .option(Options.WRITE_SPLITTER_SIDECAR_URI_PREFIX, "/chunk/")
+            .option(Options.WRITE_SPLITTER_SIDECAR_URI_SUFFIX, ".xml")
             .mode(SaveMode.Append)
             .save();
 
@@ -240,9 +240,9 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         prepareToWriteChunkDocuments()
             .option(Options.WRITE_URI_TEMPLATE, "/split-test.xml")
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
-            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 4)
-            .option(Options.WRITE_SPLITTER_OUTPUT_ROOT_NAME, "sidecar")
-            .option(Options.WRITE_SPLITTER_OUTPUT_XML_NAMESPACE, "org:example")
+            .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 4)
+            .option(Options.WRITE_SPLITTER_SIDECAR_ROOT_NAME, "sidecar")
+            .option(Options.WRITE_SPLITTER_SIDECAR_XML_NAMESPACE, "org:example")
             .mode(SaveMode.Append)
             .save();
 
@@ -260,9 +260,9 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
     void jsonChunks() {
         prepareToWriteChunkDocuments()
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
-            .option(Options.WRITE_SPLITTER_OUTPUT_MAX_CHUNKS, 2)
-            .option(Options.WRITE_SPLITTER_OUTPUT_COLLECTIONS, "chunks")
-            .option(Options.WRITE_SPLITTER_OUTPUT_DOCUMENT_TYPE, "json")
+            .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 2)
+            .option(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS, "chunks")
+            .option(Options.WRITE_SPLITTER_SIDECAR_DOCUMENT_TYPE, "json")
             .mode(SaveMode.Append)
             .save();
 


### PR DESCRIPTION
"sidecar" is much more specific and the options are only used for sidecar documents.
