### PR TITLE
Renaming "xml_path" to just "xpath"

### DIFF
--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -128,7 +128,7 @@ public abstract class Options {
     public static final String WRITE_JSON_SERIALIZATION_OPTION_PREFIX = "spark.marklogic.write.json.";
 
     // Add @since annotations before we release.
-    public static final String WRITE_SPLITTER_XML_PATH = "spark.marklogic.write.splitter.xml.path";
+    public static final String WRITE_SPLITTER_XPATH = "spark.marklogic.write.splitter.xpath";
     public static final String WRITE_SPLITTER_MAX_CHUNK_SIZE = "spark.marklogic.write.splitter.maxChunkSize";
     public static final String WRITE_SPLITTER_MAX_OVERLAP_SIZE = "spark.marklogic.write.splitter.maxOverlapSize";
     public static final String WRITE_SPLITTER_TEXT = "spark.marklogic.writer.splitter.text";

--- a/src/main/java/com/marklogic/spark/writer/DocumentProcessorFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/DocumentProcessorFactory.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 public abstract class DocumentProcessorFactory {
 
     public static DocumentProcessor buildDocumentProcessor(ContextSupport context) {
-        if (context.hasOption(Options.WRITE_SPLITTER_XML_PATH)) {
+        if (context.hasOption(Options.WRITE_SPLITTER_XPATH)) {
             return makeXmlSplitter(context);
         } else if (context.getProperties().containsKey(Options.WRITE_SPLITTER_JSON_POINTERS)) {
             // "" is a valid JSON Pointer expression, so we only check to see if the key exists.
@@ -35,7 +35,7 @@ public abstract class DocumentProcessorFactory {
     private static SplitterDocumentProcessor makeXmlSplitter(ContextSupport context) {
         if (Util.MAIN_LOGGER.isDebugEnabled()) {
             Util.MAIN_LOGGER.debug("Will split XML documents using XPath: {}",
-                context.getStringOption(Options.WRITE_SPLITTER_XML_PATH));
+                context.getStringOption(Options.WRITE_SPLITTER_XPATH));
         }
         TextSelector textSelector = makeXmlTextSelector(context);
         DocumentSplitter splitter = DocumentSplitterFactory.makeDocumentSplitter(context);
@@ -44,7 +44,7 @@ public abstract class DocumentProcessorFactory {
     }
 
     private static TextSelector makeXmlTextSelector(ContextSupport context) {
-        String path = context.getStringOption(Options.WRITE_SPLITTER_XML_PATH);
+        String xpath = context.getStringOption(Options.WRITE_SPLITTER_XPATH);
         List<Namespace> namespaces = context.getProperties().keySet()
             .stream()
             .filter(key -> key.startsWith(Options.XPATH_NAMESPACE_PREFIX))
@@ -53,7 +53,7 @@ public abstract class DocumentProcessorFactory {
                 return Namespace.getNamespace(prefix, context.getStringOption(key));
             })
             .collect(Collectors.toList());
-        return new JDOMTextSelector(path, namespaces);
+        return new JDOMTextSelector(xpath, namespaces);
     }
 
     private static SplitterDocumentProcessor makeJsonSplitter(ContextSupport context) {

--- a/src/main/java/com/marklogic/spark/writer/splitter/JDOMTextSelector.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/JDOMTextSelector.java
@@ -22,16 +22,16 @@ import java.util.stream.Collectors;
  */
 public class JDOMTextSelector implements TextSelector {
 
-    private final XPathExpression<Object> expression;
+    private final XPathExpression<Object> xpathExpression;
     private final XMLOutputter xmlOutputter;
 
     // Will make this configurable later.
     private static final String JOIN_DELIMITER = " ";
 
-    public JDOMTextSelector(String path, Collection<Namespace> namespaces) {
-        this.expression = namespaces != null ?
-            XPathFactory.instance().compile(path, Filters.fpassthrough(), null, namespaces) :
-            XPathFactory.instance().compile(path);
+    public JDOMTextSelector(String xpath, Collection<Namespace> namespaces) {
+        this.xpathExpression = namespaces != null ?
+            XPathFactory.instance().compile(xpath, Filters.fpassthrough(), null, namespaces) :
+            XPathFactory.instance().compile(xpath);
         this.xmlOutputter = new XMLOutputter(Format.getPrettyFormat());
     }
 
@@ -41,10 +41,10 @@ public class JDOMTextSelector implements TextSelector {
 
         List<Object> results;
         try {
-            results = this.expression.evaluate(doc);
+            results = this.xpathExpression.evaluate(doc);
         } catch (Exception e) {
             throw new ConnectorException(String.format("Unable to split document using XPath expression: %s; cause: %s",
-                expression.getExpression(), e.getMessage()), e);
+                xpathExpression.getExpression(), e.getMessage()), e);
         }
 
         return results.stream().map(this::objectToString).collect(Collectors.joining(JOIN_DELIMITER));

--- a/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
+++ b/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
@@ -26,7 +26,7 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         readDocument("/marklogic-docs/java-client-intro.xml")
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_XML_PATH, "/root/text/text()")
+            .option(Options.WRITE_SPLITTER_XPATH, "/root/text/text()")
             .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
             .option(Options.WRITE_SPLITTER_MAX_OVERLAP_SIZE, 0)
@@ -47,7 +47,7 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         readDocument("/marklogic-docs/namespaced-java-client-intro.xml")
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_XML_PATH, "/ex:root/ex:text/text()")
+            .option(Options.WRITE_SPLITTER_XPATH, "/ex:root/ex:text/text()")
             .option(Options.XPATH_NAMESPACE_PREFIX + "ex", "org:example")
             .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
             .option(Options.WRITE_URI_TEMPLATE, "/namespace-test.xml")
@@ -68,7 +68,7 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         DataFrameWriter writer = readDocument("/marklogic-docs/namespaced-java-client-intro.xml")
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_XML_PATH, "/ex:root/ex:text/text()")
+            .option(Options.WRITE_SPLITTER_XPATH, "/ex:root/ex:text/text()")
             .mode(SaveMode.Append);
 
         ConnectorException ex = assertThrowsConnectorException(() -> writer.save());
@@ -83,7 +83,7 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         DataFrameWriter writer = readDocument("/marklogic-docs/java-client-intro.xml")
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_XML_PATH, "/root/text/text()")
+            .option(Options.WRITE_SPLITTER_XPATH, "/root/text/text()")
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 200)
             .option(Options.WRITE_SPLITTER_MAX_OVERLAP_SIZE, 300)
             .mode(SaveMode.Append);
@@ -98,7 +98,7 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         DataFrameWriter writer = readDocument("/marklogic-docs/java-client-intro.xml")
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_XML_PATH, "/root/text/text()")
+            .option(Options.WRITE_SPLITTER_XPATH, "/root/text/text()")
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, -1)
             .mode(SaveMode.Append);
 
@@ -111,7 +111,7 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         DataFrameWriter writer = readDocument("/marklogic-docs/java-client-intro.xml")
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_XML_PATH, "/root/text/text()")
+            .option(Options.WRITE_SPLITTER_XPATH, "/root/text/text()")
             .option(Options.WRITE_SPLITTER_MAX_OVERLAP_SIZE, -1)
             .mode(SaveMode.Append);
 
@@ -124,7 +124,7 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         readDocument("/marklogic-docs/java-client-intro.xml")
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_XML_PATH, "/root/text/text()")
+            .option(Options.WRITE_SPLITTER_XPATH, "/root/text/text()")
             .option(Options.WRITE_SPLITTER_REGEX, "basic architecture")
             .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
             .option(Options.WRITE_URI_TEMPLATE, "/split-test.xml")
@@ -145,7 +145,7 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         DataFrameWriter writer = readDocument("/marklogic-docs/java-client-intro.xml")
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_XML_PATH, "/root/text/text()")
+            .option(Options.WRITE_SPLITTER_XPATH, "/root/text/text()")
             .option(Options.WRITE_SPLITTER_REGEX, ".*(not valid")
             .mode(SaveMode.Append);
 
@@ -159,7 +159,7 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         DataFrameWriter writer = readDocument("/marklogic-docs/java-client-intro.xml")
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_XML_PATH, "/root/text/text()")
+            .option(Options.WRITE_SPLITTER_XPATH, "/root/text/text()")
             .option(Options.WRITE_SPLITTER_REGEX, "basic architecture")
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 100)
             .mode(SaveMode.Append);
@@ -280,7 +280,7 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         readDocument("/marklogic-docs/has-chunks-already.xml")
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_XML_PATH, "/root/text/text()")
+            .option(Options.WRITE_SPLITTER_XPATH, "/root/text/text()")
             .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
             .option(Options.WRITE_URI_TEMPLATE, "/split-test.xml")
             .mode(SaveMode.Append)
@@ -305,7 +305,7 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
         return readDocument("/marklogic-docs/java-client-intro.xml")
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
-            .option(Options.WRITE_SPLITTER_XML_PATH, "/root/text/text()")
+            .option(Options.WRITE_SPLITTER_XPATH, "/root/text/text()")
             .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
             .option(Options.WRITE_URI_TEMPLATE, "/split-test.xml");
     }


### PR DESCRIPTION
Should be obvious for most users that it's specific to XML documents.
