### PR TITLE
MLE-17556 Can now generate embeddings for JSON chunks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ dependencies {
   // Supports splitting documents.
   shadowDependencies "dev.langchain4j:langchain4j:0.35.0"
 
+  // Supports testing the embedder feature.
+  testImplementation "dev.langchain4j:langchain4j-embeddings-all-minilm-l6-v2:0.35.0"
+
   // Needed for constructing XML documents and for splitting them.
   shadowDependencies "org.jdom:jdom2:2.0.6.1"
 
@@ -234,3 +237,15 @@ task gettingStartedZip(type: Zip) {
   archiveFileName = "marklogic-spark-getting-started-${version}.zip"
   destinationDirectory = file("build")
 }
+
+tasks.register("addMarkLogic12SchemasIfNecessary", com.marklogic.gradle.task.MarkLogicTask) {
+  description = "If testing against MarkLogic 12, include schemas that will not work on MarkLogic 11 or earlier."
+  doLast {
+    def version = new com.marklogic.mgmt.resource.clusters.ClusterManager(getManageClient()).getVersion()
+    if (version.startsWith("12.")) {
+      mlAppConfig.getSchemaPaths().add(new File(getProjectDir(), "src/test/ml-schemas-12").getAbsolutePath())
+    }
+  }
+}
+mlDeploy.dependsOn addMarkLogic12SchemasIfNecessary
+mlLoadSchemas.dependsOn addMarkLogic12SchemasIfNecessary

--- a/src/main/java/com/marklogic/spark/Options.java
+++ b/src/main/java/com/marklogic/spark/Options.java
@@ -198,6 +198,8 @@ public abstract class Options {
      */
     public static final String XPATH_NAMESPACE_PREFIX = "spark.marklogic.xpath.";
 
+    public static final String WRITE_EMBEDDER_MODEL_FUNCTION_CLASS_NAME = "spark.marklogic.write.embedder.modelFunction.className";
+
     private Options() {
     }
 }

--- a/src/main/java/com/marklogic/spark/writer/DocumentProcessorFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/DocumentProcessorFactory.java
@@ -3,106 +3,19 @@
  */
 package com.marklogic.spark.writer;
 
-import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.spark.ContextSupport;
-import com.marklogic.spark.Options;
-import com.marklogic.spark.Util;
-import com.marklogic.spark.writer.splitter.*;
-import dev.langchain4j.data.document.DocumentSplitter;
-import org.jdom2.Namespace;
+import com.marklogic.spark.writer.splitter.SplitterDocumentProcessorFactory;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
-/**
- * Only supports building a {@code SplitterDocumentProcessor}, but may later support custom processors as well.
- */
-public abstract class DocumentProcessorFactory {
+abstract class DocumentProcessorFactory {
 
-    public static DocumentProcessor buildDocumentProcessor(ContextSupport context) {
-        if (context.hasOption(Options.WRITE_SPLITTER_XPATH)) {
-            return makeXmlSplitter(context);
-        } else if (context.getProperties().containsKey(Options.WRITE_SPLITTER_JSON_POINTERS)) {
-            // "" is a valid JSON Pointer expression, so we only check to see if the key exists.
-            return makeJsonSplitter(context);
-        } else if (context.getBooleanOption(Options.WRITE_SPLITTER_TEXT, false)) {
-            return makeTextSplitter(context);
+    static DocumentProcessor buildDocumentProcessor(ContextSupport context) {
+        Optional<DocumentProcessor> splitter = SplitterDocumentProcessorFactory.makeSplitter(context);
+        if (splitter.isPresent()) {
+            return splitter.get();
         }
         return null;
-    }
-
-    private static SplitterDocumentProcessor makeXmlSplitter(ContextSupport context) {
-        if (Util.MAIN_LOGGER.isDebugEnabled()) {
-            Util.MAIN_LOGGER.debug("Will split XML documents using XPath: {}",
-                context.getStringOption(Options.WRITE_SPLITTER_XPATH));
-        }
-        TextSelector textSelector = makeXmlTextSelector(context);
-        DocumentSplitter splitter = DocumentSplitterFactory.makeDocumentSplitter(context);
-        ChunkAssembler chunkAssembler = makeChunkAssembler(context);
-        return new SplitterDocumentProcessor(textSelector, splitter, chunkAssembler);
-    }
-
-    private static TextSelector makeXmlTextSelector(ContextSupport context) {
-        String xpath = context.getStringOption(Options.WRITE_SPLITTER_XPATH);
-        List<Namespace> namespaces = context.getProperties().keySet()
-            .stream()
-            .filter(key -> key.startsWith(Options.XPATH_NAMESPACE_PREFIX))
-            .map(key -> {
-                String prefix = key.substring(Options.XPATH_NAMESPACE_PREFIX.length());
-                return Namespace.getNamespace(prefix, context.getStringOption(key));
-            })
-            .collect(Collectors.toList());
-        return new JDOMTextSelector(xpath, namespaces);
-    }
-
-    private static SplitterDocumentProcessor makeJsonSplitter(ContextSupport context) {
-        TextSelector textSelector = makeJsonTextSelector(context);
-        DocumentSplitter splitter = DocumentSplitterFactory.makeDocumentSplitter(context);
-        return new SplitterDocumentProcessor(textSelector, splitter, makeChunkAssembler(context));
-    }
-
-    private static TextSelector makeJsonTextSelector(ContextSupport context) {
-        String value = context.getProperties().get(Options.WRITE_SPLITTER_JSON_POINTERS);
-        String[] pointers = value.split("\n");
-        if (Util.MAIN_LOGGER.isDebugEnabled()) {
-            Util.MAIN_LOGGER.debug("Will split JSON documents using JSON Pointers: {}", Arrays.asList(pointers));
-        }
-        // Need an option other than "join delimiter", which applies to joining split text, not selected text.
-        return new JsonPointerTextSelector(pointers, null);
-    }
-
-    private static SplitterDocumentProcessor makeTextSplitter(ContextSupport context) {
-        if (Util.MAIN_LOGGER.isDebugEnabled()) {
-            Util.MAIN_LOGGER.debug("Will split text documents using all text in each document.");
-        }
-        return new SplitterDocumentProcessor(new AllTextSelector(),
-            DocumentSplitterFactory.makeDocumentSplitter(context), makeChunkAssembler(context)
-        );
-    }
-
-    private static ChunkAssembler makeChunkAssembler(ContextSupport context) {
-        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
-        if (context.hasOption(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS)) {
-            metadata.getCollections().addAll(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS).split(","));
-        }
-        if (context.hasOption(Options.WRITE_SPLITTER_SIDECAR_PERMISSIONS)) {
-            String value = context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_PERMISSIONS);
-            metadata.getPermissions().addFromDelimitedString(value);
-        } else if (context.hasOption(Options.WRITE_PERMISSIONS)) {
-            String value = context.getStringOption(Options.WRITE_PERMISSIONS);
-            metadata.getPermissions().addFromDelimitedString(value);
-        }
-
-        return new DefaultChunkAssembler(new ChunkConfig.Builder()
-            .withMetadata(metadata)
-            .withMaxChunks(context.getIntOption(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 0, 0))
-            .withDocumentType(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_DOCUMENT_TYPE))
-            .withRootName(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_ROOT_NAME))
-            .withUriPrefix(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_URI_PREFIX))
-            .withUriSuffix(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_URI_SUFFIX))
-            .withXmlNamespace(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_XML_NAMESPACE))
-            .build());
     }
 
     private DocumentProcessorFactory() {

--- a/src/main/java/com/marklogic/spark/writer/embedding/Chunk.java
+++ b/src/main/java/com/marklogic/spark/writer/embedding/Chunk.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.embedding;
+
+import dev.langchain4j.data.embedding.Embedding;
+
+/**
+ * Represents a chunk in either a JSON or XML document.
+ */
+public interface Chunk {
+
+    /**
+     * @return the text to be used for generating an embedding.
+     */
+    String getEmbeddingText();
+
+    /**
+     * Add the vector data in the given embedding to the chunk.
+     *
+     * @param embedding
+     */
+    void addEmbedding(Embedding embedding);
+}

--- a/src/main/java/com/marklogic/spark/writer/embedding/EmbedderDocumentProcessorFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/embedding/EmbedderDocumentProcessorFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.embedding;
+
+import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.ContextSupport;
+import com.marklogic.spark.Options;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+// Will add the actual processor in the next PR, when we support embedding after splits have been written already.
+public abstract class EmbedderDocumentProcessorFactory {
+
+    public static Optional<EmbeddingModel> makeEmbeddingModel(ContextSupport context) {
+        if (!context.hasOption(Options.WRITE_EMBEDDER_MODEL_FUNCTION_CLASS_NAME)) {
+            return Optional.empty();
+        }
+
+        final String className = context.getStringOption(Options.WRITE_EMBEDDER_MODEL_FUNCTION_CLASS_NAME);
+
+        try {
+            Object instance = Class.forName(className).getDeclaredConstructor().newInstance();
+            Function<Map<String, String>, EmbeddingModel> modelFunction = (Function<Map<String, String>, EmbeddingModel>) instance;
+            // Will add options once we support Azure.
+            return Optional.of(modelFunction.apply(new HashMap<>()));
+        } catch (Exception ex) {
+            String message = ex.getMessage();
+            if (ex instanceof ClassNotFoundException) {
+                message = "Could not load class " + className;
+            }
+            throw new ConnectorException(String.format("Unable to instantiate class for creating an embedding model; " +
+                "class name: %s; cause: %s", className, message), ex);
+        }
+    }
+
+    private EmbedderDocumentProcessorFactory() {
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/embedding/EmbeddingGenerator.java
+++ b/src/main/java/com/marklogic/spark/writer/embedding/EmbeddingGenerator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.embedding;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+
+import java.util.List;
+
+/**
+ * Knows how to generate and add embeddings for each chunk. Will soon support a batch size so that more than one
+ * chunk can be sent to an embedding model in a single call.
+ */
+public class EmbeddingGenerator {
+
+    private EmbeddingModel embeddingModel;
+
+    public EmbeddingGenerator(EmbeddingModel embeddingModel) {
+        this.embeddingModel = embeddingModel;
+    }
+
+    public void addEmbeddings(List<Chunk> chunks) {
+        if (chunks != null) {
+            chunks.forEach(chunk -> {
+                Response<Embedding> response = embeddingModel.embed(chunk.getEmbeddingText());
+                chunk.addEmbedding(response.content());
+            });
+        }
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/embedding/JsonChunk.java
+++ b/src/main/java/com/marklogic/spark/writer/embedding/JsonChunk.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.embedding;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.data.embedding.Embedding;
+
+/**
+ * Assumes the default structure produced by the connector's splitter feature.
+ */
+public class JsonChunk implements Chunk {
+
+    private ObjectNode chunk;
+
+    public JsonChunk(ObjectNode chunk) {
+        this.chunk = chunk;
+    }
+
+    @Override
+    public String getEmbeddingText() {
+        return chunk.get("text").asText();
+    }
+
+    @Override
+    public void addEmbedding(Embedding embedding) {
+        ArrayNode array = chunk.putArray("embedding");
+        for (float val : embedding.vector()) {
+            array.add(Float.toString(val));
+        }
+    }
+}

--- a/src/main/java/com/marklogic/spark/writer/splitter/DefaultChunkAssembler.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/DefaultChunkAssembler.java
@@ -11,6 +11,7 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.spark.Util;
+import com.marklogic.spark.writer.embedding.EmbeddingGenerator;
 import dev.langchain4j.data.segment.TextSegment;
 
 import java.util.Iterator;
@@ -20,9 +21,22 @@ import java.util.stream.Stream;
 public class DefaultChunkAssembler implements ChunkAssembler {
 
     private final ChunkConfig chunkConfig;
+    private final EmbeddingGenerator embeddingGenerator;
 
     public DefaultChunkAssembler(ChunkConfig chunkConfig) {
+        this(chunkConfig, null);
+    }
+
+    /**
+     * Supports a use case of splitting text in a document and adding embeddings to each chunk before writing the
+     * document to MarkLogic.
+     *
+     * @param chunkConfig
+     * @param embeddingGenerator
+     */
+    public DefaultChunkAssembler(ChunkConfig chunkConfig, EmbeddingGenerator embeddingGenerator) {
         this.chunkConfig = chunkConfig;
+        this.embeddingGenerator = embeddingGenerator;
     }
 
     @Override
@@ -34,9 +48,10 @@ public class DefaultChunkAssembler implements ChunkAssembler {
         }
 
         final Format chunkDocumentFormat = determineChunkDocumentFormat(sourceDocumentFormat);
+
         return Format.XML.equals(chunkDocumentFormat) ?
             new XmlChunkDocumentProducer(sourceDocument, sourceDocumentFormat, textSegments, chunkConfig) :
-            new JsonChunkDocumentProducer(sourceDocument, sourceDocumentFormat, textSegments, chunkConfig);
+            new JsonChunkDocumentProducer(sourceDocument, sourceDocumentFormat, textSegments, chunkConfig, embeddingGenerator);
     }
 
     private Format determineSourceDocumentFormat(DocumentWriteOperation sourceDocument) {

--- a/src/main/java/com/marklogic/spark/writer/splitter/JsonChunkDocumentProducer.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/JsonChunkDocumentProducer.java
@@ -12,8 +12,12 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.spark.writer.JsonUtil;
+import com.marklogic.spark.writer.embedding.Chunk;
+import com.marklogic.spark.writer.embedding.EmbeddingGenerator;
+import com.marklogic.spark.writer.embedding.JsonChunk;
 import dev.langchain4j.data.segment.TextSegment;
 
+import java.util.ArrayList;
 import java.util.List;
 
 class JsonChunkDocumentProducer extends AbstractChunkDocumentProducer {
@@ -21,9 +25,12 @@ class JsonChunkDocumentProducer extends AbstractChunkDocumentProducer {
     private static final String DEFAULT_CHUNKS_ARRAY_NAME = "chunks";
 
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final EmbeddingGenerator embeddingGenerator;
 
-    JsonChunkDocumentProducer(DocumentWriteOperation sourceDocument, Format sourceDocumentFormat, List<TextSegment> textSegments, ChunkConfig chunkConfig) {
+    JsonChunkDocumentProducer(DocumentWriteOperation sourceDocument, Format sourceDocumentFormat,
+                              List<TextSegment> textSegments, ChunkConfig chunkConfig, EmbeddingGenerator embeddingGenerator) {
         super(sourceDocument, sourceDocumentFormat, textSegments, chunkConfig);
+        this.embeddingGenerator = embeddingGenerator;
     }
 
     @Override
@@ -31,11 +38,15 @@ class JsonChunkDocumentProducer extends AbstractChunkDocumentProducer {
         AbstractWriteHandle content = sourceDocument.getContent();
         ObjectNode doc = (ObjectNode) JsonUtil.getJsonFromHandle(content);
 
-        ArrayNode chunks = doc.putArray(determineChunksArrayName(doc));
+        ArrayNode chunksArray = doc.putArray(determineChunksArrayName(doc));
+        List<Chunk> chunks = new ArrayList<>();
         textSegments.forEach(textSegment -> {
             String text = textSegment.text();
-            chunks.addObject().put("text", text);
+            ObjectNode chunk = chunksArray.addObject();
+            chunk.put("text", text);
+            chunks.add(new JsonChunk(chunk));
         });
+        addEmbeddingsToChunks(chunks);
 
         return new DocumentWriteOperationImpl(sourceDocument.getUri(), sourceDocument.getMetadata(), new JacksonHandle(doc));
     }
@@ -50,14 +61,24 @@ class JsonChunkDocumentProducer extends AbstractChunkDocumentProducer {
         String uri = sourceDocument.getUri();
         rootField.put("source-uri", uri);
 
-        ArrayNode chunks = rootField.putArray(DEFAULT_CHUNKS_ARRAY_NAME);
+        ArrayNode chunksArray = rootField.putArray(DEFAULT_CHUNKS_ARRAY_NAME);
+        List<Chunk> chunks = new ArrayList<>();
         for (int i = 0; i < this.maxChunksPerDocument && hasNext(); i++) {
             String text = textSegments.get(listIndex++).text();
-            chunks.addObject().put("text", text);
+            ObjectNode chunk = chunksArray.addObject();
+            chunk.put("text", text);
+            chunks.add(new JsonChunk(chunk));
         }
+        addEmbeddingsToChunks(chunks);
 
         final String chunkDocumentUri = makeChunkDocumentUri(sourceDocument, "json");
         return new DocumentWriteOperationImpl(chunkDocumentUri, chunkConfig.getMetadata(), new JacksonHandle(doc));
+    }
+
+    private void addEmbeddingsToChunks(List<Chunk> chunks) {
+        if (this.embeddingGenerator != null) {
+            this.embeddingGenerator.addEmbeddings(chunks);
+        }
     }
 
     private String determineChunksArrayName(ObjectNode doc) {

--- a/src/main/java/com/marklogic/spark/writer/splitter/SplitterDocumentProcessorFactory.java
+++ b/src/main/java/com/marklogic/spark/writer/splitter/SplitterDocumentProcessorFactory.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.splitter;
+
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.spark.ContextSupport;
+import com.marklogic.spark.Options;
+import com.marklogic.spark.Util;
+import com.marklogic.spark.writer.DocumentProcessor;
+import com.marklogic.spark.writer.embedding.EmbedderDocumentProcessorFactory;
+import com.marklogic.spark.writer.embedding.EmbeddingGenerator;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import org.jdom2.Namespace;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public abstract class SplitterDocumentProcessorFactory {
+
+    public static Optional<DocumentProcessor> makeSplitter(ContextSupport context) {
+        if (context.hasOption(Options.WRITE_SPLITTER_XPATH)) {
+            return Optional.of(makeXmlSplitter(context));
+        } else if (context.getProperties().containsKey(Options.WRITE_SPLITTER_JSON_POINTERS)) {
+            // "" is a valid JSON Pointer expression, so we only check to see if the key exists.
+            return Optional.of(makeJsonSplitter(context));
+        } else if (context.getBooleanOption(Options.WRITE_SPLITTER_TEXT, false)) {
+            return Optional.of(makeTextSplitter(context));
+        }
+        return Optional.empty();
+    }
+
+    private static SplitterDocumentProcessor makeXmlSplitter(ContextSupport context) {
+        if (Util.MAIN_LOGGER.isDebugEnabled()) {
+            Util.MAIN_LOGGER.debug("Will split XML documents using XPath: {}",
+                context.getStringOption(Options.WRITE_SPLITTER_XPATH));
+        }
+        TextSelector textSelector = makeXmlTextSelector(context);
+        DocumentSplitter splitter = DocumentSplitterFactory.makeDocumentSplitter(context);
+        ChunkAssembler chunkAssembler = makeChunkAssembler(context);
+        return new SplitterDocumentProcessor(textSelector, splitter, chunkAssembler);
+    }
+
+    private static TextSelector makeXmlTextSelector(ContextSupport context) {
+        String xpath = context.getStringOption(Options.WRITE_SPLITTER_XPATH);
+        List<Namespace> namespaces = context.getProperties().keySet()
+            .stream()
+            .filter(key -> key.startsWith(Options.XPATH_NAMESPACE_PREFIX))
+            .map(key -> {
+                String prefix = key.substring(Options.XPATH_NAMESPACE_PREFIX.length());
+                return Namespace.getNamespace(prefix, context.getStringOption(key));
+            })
+            .collect(Collectors.toList());
+        return new JDOMTextSelector(xpath, namespaces);
+    }
+
+    private static SplitterDocumentProcessor makeJsonSplitter(ContextSupport context) {
+        TextSelector textSelector = makeJsonTextSelector(context);
+        DocumentSplitter splitter = DocumentSplitterFactory.makeDocumentSplitter(context);
+        return new SplitterDocumentProcessor(textSelector, splitter, makeChunkAssembler(context));
+    }
+
+    private static TextSelector makeJsonTextSelector(ContextSupport context) {
+        String value = context.getProperties().get(Options.WRITE_SPLITTER_JSON_POINTERS);
+        String[] pointers = value.split("\n");
+        if (Util.MAIN_LOGGER.isDebugEnabled()) {
+            Util.MAIN_LOGGER.debug("Will split JSON documents using JSON Pointers: {}", Arrays.asList(pointers));
+        }
+        // Need an option other than "join delimiter", which applies to joining split text, not selected text.
+        return new JsonPointerTextSelector(pointers, null);
+    }
+
+    private static SplitterDocumentProcessor makeTextSplitter(ContextSupport context) {
+        if (Util.MAIN_LOGGER.isDebugEnabled()) {
+            Util.MAIN_LOGGER.debug("Will split text documents using all text in each document.");
+        }
+        return new SplitterDocumentProcessor(new AllTextSelector(),
+            DocumentSplitterFactory.makeDocumentSplitter(context), makeChunkAssembler(context)
+        );
+    }
+
+    private static ChunkAssembler makeChunkAssembler(ContextSupport context) {
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        if (context.hasOption(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS)) {
+            metadata.getCollections().addAll(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS).split(","));
+        }
+        if (context.hasOption(Options.WRITE_SPLITTER_SIDECAR_PERMISSIONS)) {
+            String value = context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_PERMISSIONS);
+            metadata.getPermissions().addFromDelimitedString(value);
+        } else if (context.hasOption(Options.WRITE_PERMISSIONS)) {
+            String value = context.getStringOption(Options.WRITE_PERMISSIONS);
+            metadata.getPermissions().addFromDelimitedString(value);
+        }
+
+        EmbeddingGenerator embeddingGenerator = null;
+        Optional<EmbeddingModel> embeddingModel = EmbedderDocumentProcessorFactory.makeEmbeddingModel(context);
+        if (embeddingModel.isPresent()) {
+            embeddingGenerator = new EmbeddingGenerator(embeddingModel.get());
+        }
+
+        return new DefaultChunkAssembler(new ChunkConfig.Builder()
+            .withMetadata(metadata)
+            .withMaxChunks(context.getIntOption(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 0, 0))
+            .withDocumentType(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_DOCUMENT_TYPE))
+            .withRootName(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_ROOT_NAME))
+            .withUriPrefix(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_URI_PREFIX))
+            .withUriSuffix(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_URI_SUFFIX))
+            .withXmlNamespace(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_XML_NAMESPACE))
+            .build(),
+            embeddingGenerator
+        );
+    }
+
+    private SplitterDocumentProcessorFactory() {
+    }
+}

--- a/src/test/java/com/marklogic/spark/writer/embedding/EmbedderTest.java
+++ b/src/test/java/com/marklogic/spark/writer/embedding/EmbedderTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.embedding;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.client.impl.DocumentWriteOperationImpl;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.writer.JsonUtil;
+import com.marklogic.spark.writer.splitter.ChunkConfig;
+import com.marklogic.spark.writer.splitter.DefaultChunkAssembler;
+import com.marklogic.spark.writer.splitter.JsonPointerTextSelector;
+import com.marklogic.spark.writer.splitter.SplitterDocumentProcessor;
+import dev.langchain4j.data.document.splitter.DocumentSplitters;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the embedder without writing documents to MarkLogic and without using Spark.
+ */
+class EmbedderTest extends AbstractIntegrationTest {
+
+    @Test
+    void defaultPaths() {
+        SplitterDocumentProcessor splitter = newJsonSplitter(500, 2, "/text");
+        Iterator<DocumentWriteOperation> docs = splitter.apply(readJsonDocument());
+
+        // Skip the first doc, which is the source document that doesn't have any chunks.
+        docs.next();
+
+        docs.forEachRemaining(doc -> {
+            JsonNode node = JsonUtil.getJsonFromHandle(doc.getContent());
+            ArrayNode chunks = (ArrayNode) node.get("chunks");
+            assertEquals(2, chunks.size());
+            for (JsonNode chunk : chunks) {
+                assertTrue(chunk.has("text"));
+                assertTrue(chunk.has("embedding"));
+                assertEquals(JsonNodeType.ARRAY, chunk.get("embedding").getNodeType());
+            }
+        });
+    }
+
+    private DocumentWriteOperation readJsonDocument() {
+        final String uri = "/marklogic-docs/java-client-intro.json";
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        JacksonHandle contentHandle = getDatabaseClient().newJSONDocumentManager().read(uri, metadata, new JacksonHandle());
+        return new DocumentWriteOperationImpl(uri, metadata, contentHandle);
+    }
+
+    private SplitterDocumentProcessor newJsonSplitter(int maxChunkSize, int maxChunks, String... jsonPointers) {
+        return new SplitterDocumentProcessor(
+            new JsonPointerTextSelector(jsonPointers, null),
+            DocumentSplitters.recursive(maxChunkSize, 0),
+            new DefaultChunkAssembler(
+                new ChunkConfig.Builder().withMaxChunks(maxChunks).build(),
+                new EmbeddingGenerator(new AllMiniLmL6V2EmbeddingModel())
+            )
+        );
+    }
+}

--- a/src/test/java/com/marklogic/spark/writer/embedding/MinilmEmbeddingModelFunction.java
+++ b/src/test/java/com/marklogic/spark/writer/embedding/MinilmEmbeddingModelFunction.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.embedding;
+
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public class MinilmEmbeddingModelFunction implements Function<Map<String, String>, EmbeddingModel> {
+
+    @Override
+    public EmbeddingModel apply(Map<String, String> options) {
+        return new AllMiniLmL6V2EmbeddingModel();
+    }
+}

--- a/src/test/ml-schemas-12/tde/json-vector-chunks.json
+++ b/src/test/ml-schemas-12/tde/json-vector-chunks.json
@@ -1,0 +1,28 @@
+{
+  "template": {
+    "context": "/chunks",
+    "collections": [
+      "json-vector-chunks"
+    ],
+    "rows": [
+      {
+        "schemaName": "example",
+        "viewName": "json_chunks",
+        "columns": [
+          {
+            "name": "uri",
+            "scalarType": "string",
+            "val": "xdmp:node-uri(.)"
+          },
+          {
+            "name": "embedding",
+            "scalarType": "vector",
+            "val": "vec:vector(embedding)",
+            "dimension": "384",
+            "invalidValues": "reject"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Little bit of refactoring in here - moved all the splitter factory stuff to a new class. Next PR will add support for adding embeddings when the documents have already had chunks written to them.
