### PR TITLE
MLE-17730 Fixed file path encoding issues

### DIFF
--- a/src/main/java/com/marklogic/spark/reader/file/ArchiveFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/ArchiveFileReader.java
@@ -189,9 +189,7 @@ public class ArchiveFileReader implements PartitionReader<InternalRow> {
 
     private void openNextFile() {
         final boolean isStreamingDuringRead = StreamingMode.STREAM_DURING_READER_PHASE.equals(this.streamingMode);
-        final String nextFilePath = filePartition.getPaths().get(nextFilePathIndex);
-
-        this.currentFilePath = isStreamingDuringRead ? nextFilePath : fileContext.decodeFilePath(nextFilePath);
+        this.currentFilePath = filePartition.getPaths().get(nextFilePathIndex);
         nextFilePathIndex++;
 
         if (!isStreamingDuringRead) {

--- a/src/main/java/com/marklogic/spark/reader/file/GenericFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/GenericFileReader.java
@@ -38,12 +38,9 @@ class GenericFileReader implements PartitionReader<InternalRow> {
             return false;
         }
 
-        // If streaming, we want to put the unaltered file path in the row. The writer can then decode it and also use
-        // its original value as the URI, as the PUT v1/documents endpoint does not allow e.g. spaces.
-        final String originalFilePath = filePartition.getPaths().get(filePathIndex);
-        final String path = this.isStreaming ? originalFilePath : fileContext.decodeFilePath(originalFilePath);
-
+        final String path = filePartition.getPaths().get(filePathIndex);
         filePathIndex++;
+
         try {
             byte[] content = this.isStreaming ?
                 FileUtil.serializeFileContext(fileContext, path) :

--- a/src/main/java/com/marklogic/spark/reader/file/GzipFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/GzipFileReader.java
@@ -48,7 +48,7 @@ public class GzipFileReader implements PartitionReader<InternalRow> {
             return false;
         }
 
-        String currentFilePath = fileContext.decodeFilePath(filePartition.getPaths().get(nextFilePathIndex));
+        String currentFilePath = filePartition.getPaths().get(nextFilePathIndex);
         nextFilePathIndex++;
         String uri = makeURI(currentFilePath);
 

--- a/src/main/java/com/marklogic/spark/reader/file/JsonLinesFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/JsonLinesFileReader.java
@@ -61,8 +61,7 @@ class JsonLinesFileReader implements PartitionReader<InternalRow> {
     }
 
     private void openNextFile() {
-        final String originalFilePath = filePartition.getPaths().get(filePathIndex);
-        this.currentFilePath = fileContext.decodeFilePath(originalFilePath);
+        this.currentFilePath = filePartition.getPaths().get(filePathIndex);
         this.lineCounter = 1;
         this.filePathIndex++;
         // To mimic the behavior of the Spark JSON data source, this will guess if the file is gzipped based on its

--- a/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
@@ -99,7 +99,7 @@ class MlcpArchiveFileReader implements PartitionReader<InternalRow> {
     }
 
     private void openNextFile() {
-        this.currentFilePath = fileContext.decodeFilePath(filePartition.getPaths().get(nextFilePathIndex));
+        this.currentFilePath = filePartition.getPaths().get(nextFilePathIndex);
         nextFilePathIndex++;
         this.currentZipInputStream = new ZipInputStream(fileContext.openFile(this.currentFilePath));
     }

--- a/src/main/java/com/marklogic/spark/reader/file/RdfFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/RdfFileReader.java
@@ -76,7 +76,7 @@ class RdfFileReader implements PartitionReader<InternalRow> {
     }
 
     private boolean initializeRdfStreamReader() {
-        this.currentFilePath = fileContext.decodeFilePath(filePartition.getPaths().get(nextFilePathIndex));
+        this.currentFilePath = filePartition.getPaths().get(nextFilePathIndex);
         if (logger.isDebugEnabled()) {
             logger.debug("Reading file {}", this.currentFilePath);
         }

--- a/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
@@ -68,7 +68,7 @@ class RdfZipFileReader implements PartitionReader<InternalRow> {
             }
 
             // Open up the next zip.
-            this.currentFilePath = fileContext.decodeFilePath(filePartition.getPaths().get(nextFilePathIndex));
+            this.currentFilePath = filePartition.getPaths().get(nextFilePathIndex);
             nextFilePathIndex++;
             this.currentZipInputStream = new CustomZipInputStream(fileContext.openFile(currentFilePath));
             return next();

--- a/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
@@ -122,7 +122,7 @@ public class ZipFileReader implements PartitionReader<InternalRow> {
     }
 
     private void openNextFile() {
-        this.currentFilePath = fileContext.decodeFilePath(filePartition.getPaths().get(nextFilePathIndex));
+        this.currentFilePath = filePartition.getPaths().get(nextFilePathIndex);
         nextFilePathIndex++;
         this.currentZipInputStream = new ZipInputStream(fileContext.openFile(this.currentFilePath));
     }

--- a/src/main/java/com/marklogic/spark/reader/file/xml/AggregateXmlFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/AggregateXmlFileReader.java
@@ -53,7 +53,7 @@ public class AggregateXmlFileReader implements PartitionReader<InternalRow> {
             }
 
             try {
-                String path = fileContext.decodeFilePath(filePartition.getPaths().get(filePathIndex));
+                String path = filePartition.getPaths().get(filePathIndex);
                 nextRowToReturn = this.aggregateXMLSplitter.nextRow(path);
                 return true;
             } catch (RuntimeException ex) {
@@ -81,7 +81,7 @@ public class AggregateXmlFileReader implements PartitionReader<InternalRow> {
             return false;
         }
 
-        final String filePath = fileContext.decodeFilePath(filePartition.getPaths().get(filePathIndex));
+        final String filePath = filePartition.getPaths().get(filePathIndex);
         try {
             this.inputStream = fileContext.openFile(filePath);
             String identifierForError = "file " + filePath;

--- a/src/main/java/com/marklogic/spark/reader/file/xml/ZipAggregateXmlFileReader.java
+++ b/src/main/java/com/marklogic/spark/reader/file/xml/ZipAggregateXmlFileReader.java
@@ -83,7 +83,7 @@ public class ZipAggregateXmlFileReader implements PartitionReader<InternalRow> {
     }
 
     private void openNextFile() {
-        this.currentFilePath = fileContext.decodeFilePath(filePartition.getPaths().get(nextFilePathIndex));
+        this.currentFilePath = filePartition.getPaths().get(nextFilePathIndex);
         nextFilePathIndex++;
         this.currentZipInputStream = new ZipInputStream(fileContext.openFile(this.currentFilePath));
     }

--- a/src/main/java/com/marklogic/spark/writer/DocumentRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/DocumentRowConverter.java
@@ -137,8 +137,7 @@ class DocumentRowConverter implements RowConverter {
     }
 
     private Iterator<DocBuilder.DocumentInputs> buildIteratorForGenericFile(InternalRow row, String filePath, FileContext fileContext) {
-        final String decodedPath = fileContext.decodeFilePath(filePath);
-        InputStreamHandle contentHandle = new InputStreamHandle(fileContext.openFile(decodedPath));
+        InputStreamHandle contentHandle = new InputStreamHandle(fileContext.openFile(filePath));
         if (this.documentFormat != null) {
             contentHandle.withFormat(this.documentFormat);
         }

--- a/src/test/java/com/marklogic/spark/reader/file/ReadAggregateXmlZipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadAggregateXmlZipFilesTest.java
@@ -82,7 +82,7 @@ class ReadAggregateXmlZipFilesTest extends AbstractIntegrationTest {
         ConnectorException ex = assertThrowsConnectorException(() -> dataset.count());
         String message = ex.getMessage();
         assertTrue(
-            message.startsWith("No occurrence of URI element 'elementDoesntExist' found in aggregate element 1 in entry employees.xml in file:///"),
+            message.startsWith("No occurrence of URI element 'elementDoesntExist' found in aggregate element 1 in entry employees.xml in file:/"),
             "The error should identify which aggregate element did not contain the URI element; actual error: " + message
         );
     }
@@ -112,7 +112,7 @@ class ReadAggregateXmlZipFilesTest extends AbstractIntegrationTest {
 
         ConnectorException ex = assertThrowsConnectorException(() -> dataset.count());
         String message = ex.getMessage();
-        assertTrue(message.startsWith("Unable to read XML from entry 500-employees.json in file:///"),
+        assertTrue(message.startsWith("Unable to read XML from entry 500-employees.json in file:/"),
             "The error should identify the file and the entry name; actual error: " + message);
         assertTrue(message.endsWith("json-employees.zip; cause: Failed to traverse document"),
             "The error should identify the file and the root cause; actual error: " + message);

--- a/src/test/java/com/marklogic/spark/reader/file/ReadGenericFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadGenericFilesTest.java
@@ -189,4 +189,14 @@ class ReadGenericFilesTest extends AbstractIntegrationTest {
         assertEquals(3, rows.size(), "This doesn't test our connector, but rather demonstrates that the OOTB " +
             "Spark file data sources correctly handle file paths with spaces in them.");
     }
+
+    @Test
+    void jsonFileWithPlusSign() {
+        List<Row> rows = newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .load("src/test/resources/generic-files/has+plus.json")
+            .collectAsList();
+
+        assertEquals(1, rows.size());
+    }
 }

--- a/src/test/java/com/marklogic/spark/reader/file/ReadGzipAggregateXmlFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadGzipAggregateXmlFilesTest.java
@@ -45,7 +45,7 @@ class ReadGzipAggregateXmlFilesTest extends AbstractIntegrationTest {
 
         ConnectorException ex = assertThrowsConnectorException(() -> dataset.count());
         String message = ex.getMessage();
-        assertTrue(message.startsWith("Unable to read file at file:///"), "Unexpected error: " + message);
+        assertTrue(message.startsWith("Unable to read file at file:/"), "Unexpected error: " + message);
         assertTrue(message.endsWith("cause: Not in GZIP format"), "Unexpected error: " + message);
     }
 

--- a/src/test/java/com/marklogic/spark/reader/file/ReadGzipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/reader/file/ReadGzipFilesTest.java
@@ -55,7 +55,7 @@ class ReadGzipFilesTest extends AbstractIntegrationTest {
 
         SparkException ex = assertThrows(SparkException.class, () -> dataset.count());
         assertTrue(ex.getCause() instanceof ConnectorException);
-        assertTrue(ex.getCause().getMessage().startsWith("Unable to read file at file:///"),
+        assertTrue(ex.getCause().getMessage().startsWith("Unable to read file at file:/"),
             "Unexpected error message: " + ex.getCause().getMessage());
     }
 

--- a/src/test/java/com/marklogic/spark/writer/file/WriteArchiveTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteArchiveTest.java
@@ -104,7 +104,7 @@ class WriteArchiveTest extends AbstractIntegrationTest {
                 "This allows for the content to later be streamed back into MarkLogic. Entry name: " + entryName);
         }
 
-        final String expectedUriPrefix = "file://" + tempDir.toFile().getAbsolutePath();
+        final String expectedUriPrefix = "file:" + tempDir.toFile().getAbsolutePath();
         for (Row row : rows) {
             String uri = row.getString(0);
             assertTrue(uri.startsWith(expectedUriPrefix), "Unexpected URI, which is expected to start with the " +

--- a/src/test/java/com/marklogic/spark/writer/file/WriteDocumentZipFilesTest.java
+++ b/src/test/java/com/marklogic/spark/writer/file/WriteDocumentZipFilesTest.java
@@ -158,7 +158,7 @@ class WriteDocumentZipFilesTest extends AbstractIntegrationTest {
         assertEquals(15, rows.size());
 
         // Verify each row was read correctly.
-        final String expectedUriPrefix = "file://" + tempDir.toFile().getAbsolutePath();
+        final String expectedUriPrefix = "file:" + tempDir.toFile().getAbsolutePath();
         for (Row row : rows) {
             String uri = row.getString(0);
             assertTrue(uri.startsWith(expectedUriPrefix), "Unexpected URI, which is expected to start with the " +

--- a/src/test/resources/generic-files/has+plus.json
+++ b/src/test/resources/generic-files/has+plus.json
@@ -1,0 +1,1 @@
+{"hello": "world"}


### PR DESCRIPTION
Turns out we needed to use a different Spark API to get a list of files - the one we were using was surprisingly URL encoding all the file paths.
