### PR TITLE
Refactored RowConverter so that an Iterator is always returned

### DIFF
--- a/src/main/java/com/marklogic/spark/writer/ArbitraryRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/ArbitraryRowConverter.java
@@ -19,9 +19,7 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -108,8 +106,8 @@ class ArbitraryRowConverter implements RowConverter {
     }
 
     @Override
-    public List<DocBuilder.DocumentInputs> getRemainingDocumentInputs() {
-        return new ArrayList<>();
+    public Iterator<DocBuilder.DocumentInputs> getRemainingDocumentInputs() {
+        return Stream.<DocBuilder.DocumentInputs>empty().iterator();
     }
 
     /**

--- a/src/main/java/com/marklogic/spark/writer/DocumentRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/DocumentRowConverter.java
@@ -24,9 +24,7 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -60,8 +58,8 @@ class DocumentRowConverter implements RowConverter {
     }
 
     @Override
-    public List<DocBuilder.DocumentInputs> getRemainingDocumentInputs() {
-        return new ArrayList<>();
+    public Iterator<DocBuilder.DocumentInputs> getRemainingDocumentInputs() {
+        return Stream.<DocBuilder.DocumentInputs>empty().iterator();
     }
 
     private Iterator<DocBuilder.DocumentInputs> readContentFromRow(String uri, InternalRow row) {

--- a/src/main/java/com/marklogic/spark/writer/FileRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/FileRowConverter.java
@@ -13,9 +13,7 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.DataTypes;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -44,8 +42,8 @@ class FileRowConverter implements RowConverter {
     }
 
     @Override
-    public List<DocBuilder.DocumentInputs> getRemainingDocumentInputs() {
-        return new ArrayList<>();
+    public Iterator<DocBuilder.DocumentInputs> getRemainingDocumentInputs() {
+        return Stream.<DocBuilder.DocumentInputs>empty().iterator();
     }
 
     // Telling Sonar to not tell us to remove this code, since we can't until 3.0.

--- a/src/main/java/com/marklogic/spark/writer/RowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/RowConverter.java
@@ -6,7 +6,6 @@ package com.marklogic.spark.writer;
 import org.apache.spark.sql.catalyst.InternalRow;
 
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * Strategy interface for how a Spark row is converted into a set of inputs for writing a document to MarkLogic.
@@ -26,5 +25,5 @@ public interface RowConverter {
      *
      * @return
      */
-    List<DocBuilder.DocumentInputs> getRemainingDocumentInputs();
+    Iterator<DocBuilder.DocumentInputs> getRemainingDocumentInputs();
 }

--- a/src/main/java/com/marklogic/spark/writer/rdf/RdfRowConverter.java
+++ b/src/main/java/com/marklogic/spark/writer/rdf/RdfRowConverter.java
@@ -13,7 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -87,10 +86,10 @@ public class RdfRowConverter implements RowConverter {
      * @return
      */
     @Override
-    public List<DocBuilder.DocumentInputs> getRemainingDocumentInputs() {
+    public Iterator<DocBuilder.DocumentInputs> getRemainingDocumentInputs() {
         return this.triplesDocuments.values().stream()
             .map(TriplesDocument::buildDocument)
-            .collect(Collectors.toList());
+            .iterator();
     }
 
     /**

--- a/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
+++ b/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
@@ -58,6 +58,19 @@ public abstract class AbstractIntegrationTest extends AbstractSpringMarkLogicTes
         if (sparkSession != null) {
             sparkSession.close();
         }
+        smallDelayUntilNextTest();
+    }
+
+    // Tell Sonar not to worry about this for now.
+    @SuppressWarnings({"java:S2925"})
+    private void smallDelayUntilNextTest() {
+        // Hopefully a temporary hack to see if we get fewer random failures on Jenkins due to connectivity issues that
+        // are likely due to Docker restarting MarkLogic due to insufficient memory.
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            // No need to handle.
+        }
     }
 
     @Override


### PR DESCRIPTION
Allows for `buildAndWriteDocuments` to be used both during the connector `write` and `commit` methods. This is primarily in preparation for the next PR, which changes how the embedder batch size works.
