### PR TITLE
Refactor: Removed Spark connector references from langchain package

### DIFF
--- a/src/main/java/com/marklogic/langchain4j/MarkLogicLangchainException.java
+++ b/src/main/java/com/marklogic/langchain4j/MarkLogicLangchainException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.langchain4j;
+
+public class MarkLogicLangchainException extends RuntimeException {
+
+    public MarkLogicLangchainException(String message) {
+        super(message);
+    }
+
+    public MarkLogicLangchainException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/com/marklogic/langchain4j/Util.java
+++ b/src/main/java/com/marklogic/langchain4j/Util.java
@@ -9,9 +9,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.impl.HandleAccessor;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
-import com.marklogic.spark.ConnectorException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public interface JsonUtil {
+public interface Util {
+
+    /**
+     * Intended for log messages pertaining to the embedder feature. Uses a separate logger so that it can be enabled
+     * at the info/debug level without enabling any other log messages.
+     */
+    Logger LANGCHAIN4J_LOGGER = LoggerFactory.getLogger("com.marklogic.langchain4j");
 
     static JsonNode getJsonFromHandle(AbstractWriteHandle writeHandle) {
         if (writeHandle instanceof JacksonHandle) {
@@ -21,7 +28,7 @@ public interface JsonUtil {
             try {
                 return new ObjectMapper().readTree(json);
             } catch (JsonProcessingException e) {
-                throw new ConnectorException(String.format(
+                throw new MarkLogicLangchainException(String.format(
                     "Unable to read JSON from content handle; cause: %s", e.getMessage()), e);
             }
         }

--- a/src/main/java/com/marklogic/langchain4j/dom/DOMHelper.java
+++ b/src/main/java/com/marklogic/langchain4j/dom/DOMHelper.java
@@ -7,7 +7,7 @@ import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.impl.HandleAccessor;
 import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
-import com.marklogic.spark.ConnectorException;
+import com.marklogic.langchain4j.MarkLogicLangchainException;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -50,7 +50,7 @@ public class DOMHelper {
         try {
             return getDocumentBuilder().parse(new InputSource(new StringReader(xml)));
         } catch (Exception e) {
-            throw new ConnectorException(String.format("Unable to parse XML for document with URI: %s; cause: %s",
+            throw new MarkLogicLangchainException(String.format("Unable to parse XML for document with URI: %s; cause: %s",
                 sourceDocument.getUri(), e.getMessage()), e);
         }
     }
@@ -69,7 +69,7 @@ public class DOMHelper {
             return xpath.compile(xpathExpression);
         } catch (XPathExpressionException e) {
             String message = massageXPathCompilationError(e.getMessage());
-            throw new ConnectorException(String.format(
+            throw new MarkLogicLangchainException(String.format(
                 "Unable to compile XPath expression for %s: %s; cause: %s",
                 purposeForErrorMessage, xpathExpression, message), e
             );
@@ -89,7 +89,7 @@ public class DOMHelper {
             try {
                 this.documentBuilder = this.documentBuilderFactory.newDocumentBuilder();
             } catch (ParserConfigurationException e) {
-                throw new ConnectorException(String.format("Unable to create XML document; cause: %s", e.getMessage()), e);
+                throw new MarkLogicLangchainException(String.format("Unable to create XML document; cause: %s", e.getMessage()), e);
             }
         }
         return this.documentBuilder;

--- a/src/main/java/com/marklogic/langchain4j/dom/XPathNamespaceContext.java
+++ b/src/main/java/com/marklogic/langchain4j/dom/XPathNamespaceContext.java
@@ -3,11 +3,8 @@
  */
 package com.marklogic.langchain4j.dom;
 
-import com.marklogic.spark.Options;
-
 import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -15,15 +12,8 @@ public class XPathNamespaceContext implements NamespaceContext {
 
     private final Map<String, String> prefixesToNamespaces;
 
-    public XPathNamespaceContext(Map<String, String> properties) {
-        prefixesToNamespaces = new HashMap<>();
-        properties.keySet().stream()
-            .filter(key -> key.startsWith(Options.XPATH_NAMESPACE_PREFIX))
-            .forEach(key -> {
-                String prefix = key.substring(Options.XPATH_NAMESPACE_PREFIX.length());
-                String namespace = properties.get(key);
-                prefixesToNamespaces.put(prefix, namespace);
-            });
+    public XPathNamespaceContext(Map<String, String> prefixesToNamespaces) {
+        this.prefixesToNamespaces = prefixesToNamespaces;
     }
 
     @Override

--- a/src/main/java/com/marklogic/langchain4j/embedding/DOMChunk.java
+++ b/src/main/java/com/marklogic/langchain4j/embedding/DOMChunk.java
@@ -3,7 +3,7 @@
  */
 package com.marklogic.langchain4j.embedding;
 
-import com.marklogic.spark.ConnectorException;
+import com.marklogic.langchain4j.MarkLogicLangchainException;
 import dev.langchain4j.data.embedding.Embedding;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -48,7 +48,7 @@ public class DOMChunk implements Chunk {
         try {
             embeddingTextNodes = (NodeList) xpath.evaluate(textExpression, chunkElement, XPathConstants.NODESET);
         } catch (XPathExpressionException e) {
-            throw new ConnectorException(String.format("Unable to evaluate XPath expression: %s; cause: %s",
+            throw new MarkLogicLangchainException(String.format("Unable to evaluate XPath expression: %s; cause: %s",
                 textExpression, e.getMessage()), e);
         }
 

--- a/src/main/java/com/marklogic/langchain4j/embedding/DOMChunkSelector.java
+++ b/src/main/java/com/marklogic/langchain4j/embedding/DOMChunkSelector.java
@@ -6,8 +6,8 @@ package com.marklogic.langchain4j.embedding;
 import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.impl.DocumentWriteOperationImpl;
 import com.marklogic.client.io.DOMHandle;
+import com.marklogic.langchain4j.MarkLogicLangchainException;
 import com.marklogic.langchain4j.dom.DOMHelper;
-import com.marklogic.spark.ConnectorException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -55,7 +55,7 @@ public class DOMChunkSelector implements ChunkSelector {
         try {
             return (NodeList) chunksExpression.evaluate(doc, XPathConstants.NODESET);
         } catch (XPathExpressionException e) {
-            throw new ConnectorException(String.format(
+            throw new MarkLogicLangchainException(String.format(
                 "Unable to evaluate XPath expression for selecting chunks: %s; cause: %s", chunksExpression, e.getMessage()), e);
         }
     }
@@ -65,7 +65,7 @@ public class DOMChunkSelector implements ChunkSelector {
         for (int i = 0; i < chunkNodes.getLength(); i++) {
             Node node = chunkNodes.item(i);
             if (node.getNodeType() != Node.ELEMENT_NODE) {
-                throw new ConnectorException(String.format("XPath expression for selecting chunks must only " +
+                throw new MarkLogicLangchainException(String.format("XPath expression for selecting chunks must only " +
                     "select elements; XPath: %s; document URI: %s", chunksExpression, sourceDocument.getUri()));
             }
             chunks.add(new DOMChunk(sourceDocument.getUri(), document, (Element) node, xmlChunkConfig, xpathFactory));

--- a/src/main/java/com/marklogic/langchain4j/embedding/EmbeddingAdder.java
+++ b/src/main/java/com/marklogic/langchain4j/embedding/EmbeddingAdder.java
@@ -4,8 +4,8 @@
 package com.marklogic.langchain4j.embedding;
 
 import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.langchain4j.Util;
 import com.marklogic.langchain4j.splitter.DocumentTextSplitter;
-import com.marklogic.spark.Util;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -56,8 +56,8 @@ public class EmbeddingAdder implements Function<DocumentWriteOperation, Iterator
         // Return any pending source documents - i.e. those with chunks that didn't add up to the embedding generator's
         // batch size, and thus embeddings haven't been added.
         if (pendingSourceDocuments != null && !pendingSourceDocuments.isEmpty()) {
-            if (Util.EMBEDDER_LOGGER.isInfoEnabled()) {
-                Util.EMBEDDER_LOGGER.info("Pending source document count: {}; generating embeddings for each document.",
+            if (Util.LANGCHAIN4J_LOGGER.isInfoEnabled()) {
+                Util.LANGCHAIN4J_LOGGER.info("Pending source document count: {}; generating embeddings for each document.",
                     pendingSourceDocuments.size());
             }
             embeddingGenerator.generateEmbeddingsForPendingChunks();

--- a/src/main/java/com/marklogic/langchain4j/embedding/EmbeddingGenerator.java
+++ b/src/main/java/com/marklogic/langchain4j/embedding/EmbeddingGenerator.java
@@ -3,7 +3,7 @@
  */
 package com.marklogic.langchain4j.embedding;
 
-import com.marklogic.spark.Util;
+import com.marklogic.langchain4j.Util;
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
@@ -68,8 +68,8 @@ public class EmbeddingGenerator {
 
     void generateEmbeddingsForPendingChunks() {
         if (!pendingChunks.isEmpty()) {
-            if (Util.EMBEDDER_LOGGER.isDebugEnabled()) {
-                Util.EMBEDDER_LOGGER.debug("Generating embeddings for pending chunks; count: {}.", pendingChunks.size());
+            if (Util.LANGCHAIN4J_LOGGER.isDebugEnabled()) {
+                Util.LANGCHAIN4J_LOGGER.debug("Generating embeddings for pending chunks; count: {}.", pendingChunks.size());
             }
             addEmbeddingsToChunks(pendingChunks);
             pendingChunks.clear();
@@ -80,8 +80,8 @@ public class EmbeddingGenerator {
         String text = chunk.getEmbeddingText();
         if (text != null && text.trim().length() > 0) {
             pendingChunks.add(chunk);
-        } else if (Util.EMBEDDER_LOGGER.isDebugEnabled()) {
-            Util.EMBEDDER_LOGGER.debug("Not generating embedding for chunk in URI {}; could not find text to use for generating an embedding.",
+        } else if (Util.LANGCHAIN4J_LOGGER.isDebugEnabled()) {
+            Util.LANGCHAIN4J_LOGGER.debug("Not generating embedding for chunk in URI {}; could not find text to use for generating an embedding.",
                 chunk.getDocumentUri());
         }
     }
@@ -92,7 +92,7 @@ public class EmbeddingGenerator {
         logResponse(response, textSegments);
 
         if (response.content() == null) {
-            Util.EMBEDDER_LOGGER.warn("Sent {} chunks; no embeddings were returned; finish reason: {}",
+            Util.LANGCHAIN4J_LOGGER.warn("Sent {} chunks; no embeddings were returned; finish reason: {}",
                 textSegments.size(), response.finishReason());
         } else {
             List<Embedding> embeddings = response.content();
@@ -109,22 +109,22 @@ public class EmbeddingGenerator {
     }
 
     private void logResponse(Response<List<Embedding>> response, List<TextSegment> textSegments) {
-        if (Util.EMBEDDER_LOGGER.isInfoEnabled()) {
+        if (Util.LANGCHAIN4J_LOGGER.isInfoEnabled()) {
             // Not every embedding model provides token usage.
             if (response.tokenUsage() != null) {
-                Util.EMBEDDER_LOGGER.info("Sent {} chunks; token usage: {}", textSegments.size(), response.tokenUsage());
+                Util.LANGCHAIN4J_LOGGER.info("Sent {} chunks; token usage: {}", textSegments.size(), response.tokenUsage());
             } else {
-                Util.EMBEDDER_LOGGER.info("Sent {} chunks", textSegments.size());
+                Util.LANGCHAIN4J_LOGGER.info("Sent {} chunks", textSegments.size());
             }
 
-            if (Util.EMBEDDER_LOGGER.isDebugEnabled()) {
+            if (Util.LANGCHAIN4J_LOGGER.isDebugEnabled()) {
                 long totalRequests = requestCount.incrementAndGet();
                 if (response.tokenUsage() != null) {
-                    Util.EMBEDDER_LOGGER.debug("Requests: {}; tokens: {}", totalRequests,
+                    Util.LANGCHAIN4J_LOGGER.debug("Requests: {}; tokens: {}", totalRequests,
                         tokenCount.addAndGet(response.tokenUsage().inputTokenCount())
                     );
                 } else {
-                    Util.EMBEDDER_LOGGER.debug("Requests: {}", totalRequests);
+                    Util.LANGCHAIN4J_LOGGER.debug("Requests: {}", totalRequests);
                 }
             }
         }

--- a/src/main/java/com/marklogic/langchain4j/embedding/JsonChunkSelector.java
+++ b/src/main/java/com/marklogic/langchain4j/embedding/JsonChunkSelector.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.impl.DocumentWriteOperationImpl;
 import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.langchain4j.JsonUtil;
+import com.marklogic.langchain4j.Util;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,7 +60,7 @@ public class JsonChunkSelector implements ChunkSelector {
 
     @Override
     public DocumentAndChunks selectChunks(DocumentWriteOperation sourceDocument) {
-        JsonNode doc = JsonUtil.getJsonFromHandle(sourceDocument.getContent());
+        JsonNode doc = Util.getJsonFromHandle(sourceDocument.getContent());
 
         JsonNode chunksNode = doc.at(chunksPointer);
         if (chunksNode == null || (!(chunksNode instanceof ArrayNode) && !(chunksNode instanceof ObjectNode))) {

--- a/src/main/java/com/marklogic/langchain4j/splitter/DOMTextSelector.java
+++ b/src/main/java/com/marklogic/langchain4j/splitter/DOMTextSelector.java
@@ -4,9 +4,9 @@
 package com.marklogic.langchain4j.splitter;
 
 import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.langchain4j.MarkLogicLangchainException;
+import com.marklogic.langchain4j.Util;
 import com.marklogic.langchain4j.dom.DOMHelper;
-import com.marklogic.spark.ConnectorException;
-import com.marklogic.spark.Util;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
@@ -33,7 +33,7 @@ public class DOMTextSelector implements TextSelector {
         try {
             doc = domHelper.extractDocument(sourceDocument);
         } catch (Exception ex) {
-            Util.MAIN_LOGGER.warn("Unable to select text to split in document: {}; cause: {}", sourceDocument.getUri(), ex.getMessage());
+            Util.LANGCHAIN4J_LOGGER.warn("Unable to select text to split in document: {}; cause: {}", sourceDocument.getUri(), ex.getMessage());
             return null;
         }
 
@@ -41,7 +41,7 @@ public class DOMTextSelector implements TextSelector {
         try {
             items = (NodeList) this.textExpression.evaluate(doc, XPathConstants.NODESET);
         } catch (XPathExpressionException e) {
-            throw new ConnectorException(String.format(
+            throw new MarkLogicLangchainException(String.format(
                 "Unable to evaluate XPath expression for selecting text to split: %s; cause: %s", textExpression, e.getMessage()), e);
         }
 

--- a/src/main/java/com/marklogic/langchain4j/splitter/DefaultChunkAssembler.java
+++ b/src/main/java/com/marklogic/langchain4j/splitter/DefaultChunkAssembler.java
@@ -10,7 +10,7 @@ import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
-import com.marklogic.spark.Util;
+import com.marklogic.langchain4j.Util;
 import dev.langchain4j.data.segment.TextSegment;
 
 import java.util.Iterator;
@@ -29,7 +29,7 @@ public class DefaultChunkAssembler implements ChunkAssembler {
     public Iterator<DocumentWriteOperation> assembleChunks(DocumentWriteOperation sourceDocument, List<TextSegment> textSegments) {
         final Format sourceDocumentFormat = determineSourceDocumentFormat(sourceDocument);
         if (sourceDocumentFormat == null) {
-            Util.MAIN_LOGGER.warn("Cannot split document with URI {}; cannot determine the document format.", sourceDocument.getUri());
+            Util.LANGCHAIN4J_LOGGER.warn("Cannot split document with URI {}; cannot determine the document format.", sourceDocument.getUri());
             return Stream.of(sourceDocument).iterator();
         }
 

--- a/src/main/java/com/marklogic/langchain4j/splitter/DocumentTextSplitter.java
+++ b/src/main/java/com/marklogic/langchain4j/splitter/DocumentTextSplitter.java
@@ -4,7 +4,7 @@
 package com.marklogic.langchain4j.splitter;
 
 import com.marklogic.client.document.DocumentWriteOperation;
-import com.marklogic.spark.ConnectorException;
+import com.marklogic.langchain4j.MarkLogicLangchainException;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentSplitter;
 import dev.langchain4j.data.segment.TextSegment;
@@ -41,7 +41,7 @@ public class DocumentTextSplitter implements Function<DocumentWriteOperation, It
         try {
             textSegments = documentSplitter.split(new Document(text));
         } catch (Exception e) {
-            throw new ConnectorException(String.format("Unable to split document with URI: %s; cause: %s",
+            throw new MarkLogicLangchainException(String.format("Unable to split document with URI: %s; cause: %s",
                 sourceDocument.getUri(), e.getMessage()), e);
         }
 

--- a/src/main/java/com/marklogic/langchain4j/splitter/JsonChunkDocumentProducer.java
+++ b/src/main/java/com/marklogic/langchain4j/splitter/JsonChunkDocumentProducer.java
@@ -11,7 +11,7 @@ import com.marklogic.client.impl.DocumentWriteOperationImpl;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
-import com.marklogic.langchain4j.JsonUtil;
+import com.marklogic.langchain4j.Util;
 import com.marklogic.langchain4j.embedding.Chunk;
 import com.marklogic.langchain4j.embedding.DocumentAndChunks;
 import com.marklogic.langchain4j.embedding.JsonChunk;
@@ -34,7 +34,7 @@ class JsonChunkDocumentProducer extends AbstractChunkDocumentProducer {
     @Override
     protected DocumentWriteOperation addChunksToSourceDocument() {
         AbstractWriteHandle content = sourceDocument.getContent();
-        ObjectNode doc = (ObjectNode) JsonUtil.getJsonFromHandle(content);
+        ObjectNode doc = (ObjectNode) Util.getJsonFromHandle(content);
 
         ArrayNode chunksArray = doc.putArray(determineChunksArrayName(doc));
         List<Chunk> chunks = new ArrayList<>();

--- a/src/main/java/com/marklogic/langchain4j/splitter/JsonPointerTextSelector.java
+++ b/src/main/java/com/marklogic/langchain4j/splitter/JsonPointerTextSelector.java
@@ -6,9 +6,8 @@ package com.marklogic.langchain4j.splitter;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.client.document.DocumentWriteOperation;
-import com.marklogic.langchain4j.JsonUtil;
-import com.marklogic.spark.ConnectorException;
-import com.marklogic.spark.Util;
+import com.marklogic.langchain4j.MarkLogicLangchainException;
+import com.marklogic.langchain4j.Util;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +25,7 @@ public class JsonPointerTextSelector implements TextSelector {
                 jsonPointers.add(JsonPointer.compile(jsonPointer));
             } catch (Exception ex) {
                 // Not including the original exception as the message itself should suffice.
-                throw new ConnectorException(String.format(
+                throw new MarkLogicLangchainException(String.format(
                     "Unable to use JSON pointer expression: %s; cause: %s", jsonPointer, ex.getMessage()));
             }
         }
@@ -37,9 +36,9 @@ public class JsonPointerTextSelector implements TextSelector {
     public String selectTextToSplit(DocumentWriteOperation sourceDocument) {
         JsonNode doc;
         try {
-            doc = JsonUtil.getJsonFromHandle(sourceDocument.getContent());
+            doc = Util.getJsonFromHandle(sourceDocument.getContent());
         } catch (Exception ex) {
-            Util.MAIN_LOGGER.warn("Unable to select text to split in document: {}; cause: {}", sourceDocument.getUri(), ex.getMessage());
+            Util.LANGCHAIN4J_LOGGER.warn("Unable to select text to split in document: {}; cause: {}", sourceDocument.getUri(), ex.getMessage());
             return null;
         }
 

--- a/src/main/java/com/marklogic/spark/Util.java
+++ b/src/main/java/com/marklogic/spark/Util.java
@@ -18,12 +18,6 @@ public interface Util {
      */
     Logger MAIN_LOGGER = LoggerFactory.getLogger("com.marklogic.spark");
 
-    /**
-     * Intended for log messages pertaining to the embedder feature. Uses a separate logger so that it can be enabled
-     * at the info/debug level without enabling any other log messages.
-     */
-    Logger EMBEDDER_LOGGER = LoggerFactory.getLogger("com.marklogic.spark.embedder");
-
     static boolean hasOption(Map<String, String> properties, String... options) {
         return Stream.of(options)
             .anyMatch(option -> properties.get(option) != null && properties.get(option).trim().length() > 0);

--- a/src/main/java/com/marklogic/spark/langchain4j/DocumentTextSplitterFactory.java
+++ b/src/main/java/com/marklogic/spark/langchain4j/DocumentTextSplitterFactory.java
@@ -4,7 +4,6 @@
 package com.marklogic.spark.langchain4j;
 
 import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.langchain4j.dom.XPathNamespaceContext;
 import com.marklogic.langchain4j.splitter.*;
 import com.marklogic.spark.ContextSupport;
 import com.marklogic.spark.Options;
@@ -41,7 +40,7 @@ public abstract class DocumentTextSplitterFactory {
 
     private static TextSelector makeXmlTextSelector(ContextSupport context) {
         String xpath = context.getStringOption(Options.WRITE_SPLITTER_XPATH);
-        return new DOMTextSelector(xpath, new XPathNamespaceContext(context.getProperties()));
+        return new DOMTextSelector(xpath, NamespaceContextFactory.makeNamespaceContext(context.getProperties()));
     }
 
     private static DocumentTextSplitter makeJsonSplitter(ContextSupport context) {

--- a/src/main/java/com/marklogic/spark/langchain4j/EmbeddingAdderFactory.java
+++ b/src/main/java/com/marklogic/spark/langchain4j/EmbeddingAdderFactory.java
@@ -3,7 +3,6 @@
  */
 package com.marklogic.spark.langchain4j;
 
-import com.marklogic.langchain4j.dom.XPathNamespaceContext;
 import com.marklogic.langchain4j.embedding.*;
 import com.marklogic.langchain4j.splitter.DocumentTextSplitter;
 import com.marklogic.spark.ConnectorException;
@@ -77,7 +76,7 @@ public abstract class EmbeddingAdderFactory {
             context.getStringOption(Options.WRITE_EMBEDDER_TEXT_XPATH),
             context.getStringOption(Options.WRITE_EMBEDDER_EMBEDDING_NAME),
             context.getStringOption(Options.WRITE_EMBEDDER_EMBEDDING_NAMESPACE),
-            new XPathNamespaceContext(context.getProperties())
+            NamespaceContextFactory.makeNamespaceContext(context.getProperties())
         );
         return new DOMChunkSelector(
             context.getStringOption(Options.WRITE_EMBEDDER_CHUNKS_XPATH),

--- a/src/main/java/com/marklogic/spark/langchain4j/NamespaceContextFactory.java
+++ b/src/main/java/com/marklogic/spark/langchain4j/NamespaceContextFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.langchain4j;
+
+import com.marklogic.langchain4j.dom.XPathNamespaceContext;
+import com.marklogic.spark.Options;
+
+import javax.xml.namespace.NamespaceContext;
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class NamespaceContextFactory {
+
+    public static NamespaceContext makeNamespaceContext(Map<String, String> properties) {
+        Map<String, String> prefixesToNamespaces = new HashMap<>();
+        properties.keySet().stream()
+            .filter(key -> key.startsWith(Options.XPATH_NAMESPACE_PREFIX))
+            .forEach(key -> {
+                String prefix = key.substring(Options.XPATH_NAMESPACE_PREFIX.length());
+                String namespace = properties.get(key);
+                prefixesToNamespaces.put(prefix, namespace);
+            });
+        return new XPathNamespaceContext(prefixesToNamespaces);
+    }
+
+    private NamespaceContextFactory() {
+    }
+}

--- a/src/test/java/com/marklogic/langchain4j/embedding/DOMChunkSelectorTest.java
+++ b/src/test/java/com/marklogic/langchain4j/embedding/DOMChunkSelectorTest.java
@@ -8,8 +8,8 @@ import com.marklogic.client.impl.DocumentWriteOperationImpl;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
-import com.marklogic.langchain4j.dom.XPathNamespaceContext;
 import com.marklogic.spark.Options;
+import com.marklogic.spark.langchain4j.NamespaceContextFactory;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -61,7 +61,7 @@ class DOMChunkSelectorTest {
         Map<String, String> properties = new HashMap<>();
         properties.put(Options.XPATH_NAMESPACE_PREFIX + "ex", "org:example");
 
-        XmlChunkConfig xmlChunkConfig = new XmlChunkConfig(textExpression, null, null, new XPathNamespaceContext(properties));
+        XmlChunkConfig xmlChunkConfig = new XmlChunkConfig(textExpression, null, null, NamespaceContextFactory.makeNamespaceContext(properties));
         List<Chunk> chunks = new DOMChunkSelector("/ex:root/ex:chunk", xmlChunkConfig).selectChunks(makeDocument(NAMESPACED_XML)).getChunks();
         assertNotNull(chunks);
         assertEquals(1, chunks.size());

--- a/src/test/java/com/marklogic/langchain4j/embedding/EmbedderTest.java
+++ b/src/test/java/com/marklogic/langchain4j/embedding/EmbedderTest.java
@@ -13,7 +13,7 @@ import com.marklogic.client.impl.DocumentWriteOperationImpl;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.junit5.XmlNode;
-import com.marklogic.langchain4j.JsonUtil;
+import com.marklogic.langchain4j.Util;
 import com.marklogic.langchain4j.splitter.*;
 import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.writer.XmlUtil;
@@ -44,7 +44,7 @@ class EmbedderTest extends AbstractIntegrationTest {
         docs.next();
 
         docs.forEachRemaining(doc -> {
-            JsonNode node = JsonUtil.getJsonFromHandle(doc.getContent());
+            JsonNode node = Util.getJsonFromHandle(doc.getContent());
             ArrayNode chunks = (ArrayNode) node.get("chunks");
             assertEquals(2, chunks.size());
             for (JsonNode chunk : chunks) {
@@ -71,7 +71,7 @@ class EmbedderTest extends AbstractIntegrationTest {
         );
 
         DocumentWriteOperation output = embedder.apply(new DocumentWriteOperationImpl("a.json", null, new JacksonHandle(doc))).next();
-        JsonNode outputDoc = JsonUtil.getJsonFromHandle(output.getContent());
+        JsonNode outputDoc = Util.getJsonFromHandle(output.getContent());
 
         assertEquals("Hello world", outputDoc.at("/custom/custom-chunks/0/wrapper/custom-text").asText());
         JsonNode chunk = outputDoc.get("custom").get("custom-chunks").get(0);

--- a/src/test/java/com/marklogic/spark/writer/splitter/SplitJsonDocumentTest.java
+++ b/src/test/java/com/marklogic/spark/writer/splitter/SplitJsonDocumentTest.java
@@ -7,9 +7,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.marklogic.junit5.PermissionsTester;
 import com.marklogic.junit5.XmlNode;
+import com.marklogic.langchain4j.MarkLogicLangchainException;
 import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
+import org.apache.spark.SparkException;
 import org.apache.spark.sql.DataFrameWriter;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -134,7 +136,8 @@ class SplitJsonDocumentTest extends AbstractIntegrationTest {
             .option(Options.WRITE_SPLITTER_JSON_POINTERS, "not-valid")
             .mode(SaveMode.Append);
 
-        ConnectorException ex = assertThrowsConnectorException(() -> writer.save());
+        SparkException sparkException = assertThrows(SparkException.class, () -> writer.save());
+        MarkLogicLangchainException ex = (MarkLogicLangchainException) sparkException.getCause();
         assertEquals("Unable to use JSON pointer expression: not-valid; cause: Invalid input: " +
                 "JSON Pointer expression must start with '/': \"not-valid\"",
             ex.getMessage());


### PR DESCRIPTION
This is to prepare for a move to multiple subprojects. The com.marklogic.langchain4j package now no longer has any references to com.marklogic.spark.

Still no functional changes, just moving furniture around.
