### PR TITLE
Storing embedding values as floats

### DIFF
--- a/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/embedding/JsonChunk.java
+++ b/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/embedding/JsonChunk.java
@@ -40,7 +40,7 @@ public class JsonChunk implements Chunk {
     public void addEmbedding(Embedding embedding) {
         ArrayNode array = chunk.putArray(this.embeddingArrayName);
         for (float val : embedding.vector()) {
-            array.add(Float.toString(val));
+            array.add(val);
         }
     }
 }


### PR DESCRIPTION
This does not appear to have any functional impact. But given that float values are accepted, this seems preferable vs storing them as strings.
