### PR TITLE
Can now execute non-fromView queries

### DIFF
--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/ContextSupport.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/ContextSupport.java
@@ -7,8 +7,6 @@ import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.document.DocumentManager;
 import com.marklogic.client.extra.okhttpclient.OkHttpClientConfigurator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -19,7 +17,6 @@ import java.util.concurrent.TimeUnit;
 
 public class ContextSupport extends Context implements Serializable {
 
-    protected static final Logger logger = LoggerFactory.getLogger(ContextSupport.class);
     private final boolean configuratorWasAdded;
 
     // Java Client 6.5.0 has a bug in it (to be fixed in 6.5.1 or 6.6.0) where multiple threads that use a configurator

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/WriteContext.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/WriteContext.java
@@ -260,8 +260,8 @@ public class WriteContext extends ContextSupport {
 
     public void logBatchOnSuccess(int documentCount, long optionalJobBatchNumber) {
         WriteProgressLogger.logProgressIfNecessary(documentCount);
-        if (logger.isTraceEnabled() && optionalJobBatchNumber > 0) {
-            logger.trace("Wrote batch; length: {}; job batch number: {}", documentCount, optionalJobBatchNumber);
+        if (Util.MAIN_LOGGER.isTraceEnabled() && optionalJobBatchNumber > 0) {
+            Util.MAIN_LOGGER.trace("Wrote batch; length: {}; job batch number: {}", documentCount, optionalJobBatchNumber);
         }
     }
 

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/optic/AnalyzePlanTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/optic/AnalyzePlanTest.java
@@ -6,8 +6,6 @@ package com.marklogic.spark.reader.optic;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.client.impl.DatabaseClientImpl;
 import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.row.RawQueryDSLPlan;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.spark.AbstractIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,9 +51,9 @@ class AnalyzePlanTest extends AbstractIntegrationTest {
     }
 
     private PlanAnalysis analyzePlan(long partitionCount, long batchSize) {
-        RawQueryDSLPlan userPlan = rowManager.newRawQueryDSLPlan(new StringHandle("op.fromView('Medical', 'Authors').select(['LastName', 'rowID'])"));
         PlanAnalyzer partitioner = new PlanAnalyzer((DatabaseClientImpl) getDatabaseClient());
-        PlanAnalysis planAnalysis = partitioner.analyzePlan(userPlan.getHandle(), partitionCount, batchSize);
+        String dslQuery = "op.fromView('Medical', 'Authors').select(['LastName', 'rowID'])";
+        PlanAnalysis planAnalysis = partitioner.analyzePlan(dslQuery, partitionCount, batchSize);
         assertEquals(partitionCount, planAnalysis.getPartitions().size());
         return planAnalysis;
     }
@@ -135,7 +133,7 @@ class AnalyzePlanTest extends AbstractIntegrationTest {
 
     private JsonNode runPlan(PlanAnalysis plan, PlanAnalysis.Bucket bucket, JacksonHandle resultHandle) {
         return rowManager.resultDoc(
-            rowManager.newRawPlanDefinition(new JacksonHandle(plan.getBoundedPlan()))
+            rowManager.newRawPlanDefinition(new JacksonHandle(plan.getSerializedPlan()))
                 .bindParam("ML_LOWER_BOUND", bucket.lowerBound)
                 .bindParam("ML_UPPER_BOUND", bucket.upperBound),
             resultHandle

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/optic/ReadWithAccessorOtherThanFromViewTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/optic/ReadWithAccessorOtherThanFromViewTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.reader.optic;
+
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Options;
+import org.apache.spark.sql.DataFrameReader;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that DSL queries with accessors other than "fromView" will succeed, as of the 2.5.0 release.
+ */
+class ReadWithAccessorOtherThanFromViewTest extends AbstractIntegrationTest {
+
+    @Test
+    void fromSearchDocs() {
+        List<Row> rows = readWithQuery("op.fromSearchDocs(cts.collectionQuery('author'))")
+            .load()
+            .collectAsList();
+
+        assertEquals(15, rows.size());
+
+        StructType schema = readWithQuery("op.fromSearchDocs(cts.collectionQuery('author'))")
+            .load()
+            .schema();
+        StructField uriField = schema.fields()[schema.fieldIndex("uri")];
+        assertEquals(DataTypes.StringType, uriField.dataType(), "Just verifying that the connector will infer a " +
+            "schema for a non-fromView query without issue, as the schema inference is based on columnInfo which is " +
+            "not tied to the data access function.");
+    }
+
+    @Test
+    void fromSearchDocsWithCount() {
+        long count = readWithQuery("op.fromSearchDocs(cts.collectionQuery('author'))")
+            .load()
+            .limit(10)
+            .count();
+
+        assertEquals(10, count, "This test verifies both that a 'limit' filter can be pushed down and also that " +
+            "the 'count' call is pushed down correctly with a 'groupBy' being added as the last operator to the " +
+            "Optic plan. For non-fromView queries, new operators should always be appended to the end of the " +
+            "Optic plan since there's no op:prepare call that was added by the internal/viewinfo endpoint.");
+    }
+
+    @Test
+    void fromLexicons() {
+        List<Row> rows = readWithQuery("op.fromLexicons({" +
+            "  'CitationID': cts.elementReference('CitationID')" +
+            "})" +
+            ".groupBy('CitationID', op.count('counts'))")
+            .load()
+            .orderBy("CitationID")
+            .collectAsList();
+
+        assertEquals(5, rows.size());
+
+        assertEquals(1, rows.get(0).getInt(0));
+        assertEquals(4, rows.get(0).getLong(1), "Should be 4 rows with CitationID=1.");
+    }
+
+    private DataFrameReader readWithQuery(String query) {
+        return newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.READ_OPTIC_QUERY, query)
+            .option(Options.CLIENT_URI, makeClientUri());
+    }
+}

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/optic/SerializeOpticReaderObjectsTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/optic/SerializeOpticReaderObjectsTest.java
@@ -26,10 +26,10 @@ class SerializeOpticReaderObjectsTest extends AbstractIntegrationTest {
         PlanAnalysis.Partition partition = new PlanAnalysis.Partition("id", bucket);
         ObjectNode plan = objectMapper.createObjectNode();
         plan.put("hello", "world");
-        PlanAnalysis planAnalysis = new PlanAnalysis(plan, Arrays.asList(partition));
+        PlanAnalysis planAnalysis = new PlanAnalysis(plan, Arrays.asList(partition), 0);
 
         planAnalysis = (PlanAnalysis) SerializeUtil.serialize(planAnalysis);
-        assertEquals("world", planAnalysis.getBoundedPlan().get("hello").asText());
+        assertEquals("world", planAnalysis.getSerializedPlan().get("hello").asText());
         bucket = planAnalysis.getPartitions().get(0).getBuckets().get(0);
         assertEquals("1", bucket.lowerBound);
         assertEquals("2", bucket.upperBound);

--- a/test-app/src/main/ml-config/security/roles/spark-user-role.json
+++ b/test-app/src/main/ml-config/security/roles/spark-user-role.json
@@ -33,6 +33,11 @@
       "privilege-name": "unprotected-collections",
       "action": "http://marklogic.com/xdmp/privileges/unprotected-collections",
       "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp-invoke",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke",
+      "kind": "execute"
     }
   ]
 }


### PR DESCRIPTION
I moved a little code around to make the support for fromView and non-fromView a bit easier to digest:

1. Most changes are in `OpticReadContext` and `PlanAnalyzer`, which both needed support for making a single call for non-fromView queries.
2. I also moved the filter pushdown code into `PlanAnalysis` where it's closer to the data. And needed to account for whether the serialized plan has an `op:prepare` in it or not.
