### PR TITLE
Allowing for zero vectors

### DIFF
--- a/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/embedding/EmbeddingGenerator.java
+++ b/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/embedding/EmbeddingGenerator.java
@@ -97,32 +97,9 @@ public class EmbeddingGenerator {
         } else {
             List<Embedding> embeddings = response.content();
             for (int i = 0; i < embeddings.size(); i++) {
-                addEmbeddingToChunk(chunks.get(i), embeddings.get(i));
+                chunks.get(i).addEmbedding(embeddings.get(i));
             }
         }
-    }
-
-    private void addEmbeddingToChunk(Chunk chunk, Embedding embedding) {
-        if (vectorIsAllZeroes(embedding)) {
-            if (Util.LANGCHAIN4J_LOGGER.isDebugEnabled()) {
-                Util.LANGCHAIN4J_LOGGER.debug("Not adding embedding to chunk as it only contains zeroes; source document URI: {}; text: {}",
-                    chunk.getDocumentUri(), chunk.getEmbeddingText());
-            } else {
-                Util.LANGCHAIN4J_LOGGER.warn("Not adding embedding to chunk as it only contains zeroes; source document URI: {}",
-                    chunk.getDocumentUri());
-            }
-        } else {
-            chunk.addEmbedding(embedding);
-        }
-    }
-
-    private boolean vectorIsAllZeroes(Embedding embedding) {
-        for (float f : embedding.vector()) {
-            if (f != 0.0f) {
-                return false;
-            }
-        }
-        return true;
     }
 
     private List<TextSegment> makeTextSegments(List<Chunk> chunks) {

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/embedding/TestEmbeddingModel.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/embedding/TestEmbeddingModel.java
@@ -10,7 +10,6 @@ import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
 import dev.langchain4j.model.output.Response;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -30,11 +29,8 @@ public class TestEmbeddingModel implements EmbeddingModel, Function<Map<String, 
 
     private static AllMiniLmL6V2EmbeddingModel realEmbeddingModel = new AllMiniLmL6V2EmbeddingModel();
 
-    private boolean returnZeroesOnFirstCall;
-
     @Override
     public EmbeddingModel apply(Map<String, String> options) {
-        returnZeroesOnFirstCall = "true".equals(options.get("returnZeroesOnFirstCall"));
         return this;
     }
 
@@ -47,10 +43,6 @@ public class TestEmbeddingModel implements EmbeddingModel, Function<Map<String, 
     public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
         batchCounter++;
         chunkCounter += textSegments.size();
-        if (returnZeroesOnFirstCall) {
-            returnZeroesOnFirstCall = false;
-            return Response.from(Arrays.asList(new Embedding(new float[384])));
-        }
         return realEmbeddingModel.embedAll(textSegments);
     }
 

--- a/test-app/src/main/ml-schemas-12/tde/json-vector-chunks.json
+++ b/test-app/src/main/ml-schemas-12/tde/json-vector-chunks.json
@@ -19,8 +19,8 @@
             "scalarType": "vector",
             "val": "vec:vector(embedding)",
             "dimension": "384",
-            "invalidValues": "ignore",
-            "nullable": false
+            "invalidValues": "reject",
+            "nullable": true
           }
         ]
       }


### PR DESCRIPTION
Not a full revert of the commit that ignored zero vectors, as that had some useful cleanup in it too.
