### PR TITLE
Better error message for invalid permission capabilities

### DIFF
--- a/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/Util.java
+++ b/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/Util.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.impl.HandleAccessor;
+import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 import org.slf4j.Logger;
@@ -35,4 +36,23 @@ public interface Util {
             }
         }
     }
+
+    static void addPermissionsFromDelimitedString(DocumentMetadataHandle.DocumentPermissions permissions,
+                                                  String rolesAndCapabilities) {
+        // This isn't likely the best home for this class, but it's needed by this module and by the connector to
+        // massage an error message that is meaningful for a Java Client user but not meaningful for a connector
+        // or Flux user.
+        try {
+            permissions.addFromDelimitedString(rolesAndCapabilities);
+        } catch (IllegalArgumentException ex) {
+            String message = ex.getMessage();
+            final String confusingMessageForUser = "No enum constant com.marklogic.client.io.DocumentMetadataHandle.Capability.";
+            if (message != null && message.contains(confusingMessageForUser)) {
+                message = message.replace(confusingMessageForUser, "Not a valid capability: ");
+                throw new IllegalArgumentException(message, ex);
+            }
+            throw ex;
+        }
+    }
+
 }

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilderFactory.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilderFactory.java
@@ -4,6 +4,7 @@
 package com.marklogic.spark.writer;
 
 import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.langchain4j.Util;
 
 /**
  * This is intended to migrate to java-client-api and likely just be a Builder class on DocumentWriteOperation.
@@ -29,7 +30,7 @@ class DocBuilderFactory {
     }
 
     DocBuilderFactory withPermissions(String permissionsString) {
-        metadata.getPermissions().addFromDelimitedString(permissionsString);
+        Util.addPermissionsFromDelimitedString(metadata.getPermissions(), permissionsString);
         return this;
     }
 

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/rdf/GraphWriter.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/rdf/GraphWriter.java
@@ -6,6 +6,7 @@ package com.marklogic.spark.writer.rdf;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.eval.ServerEvaluationCall;
 import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.langchain4j.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,10 +23,10 @@ public class GraphWriter {
     private final DatabaseClient databaseClient;
     private final String permissions;
 
-    public GraphWriter(DatabaseClient databaseClient, String permissionsString) {
+    public GraphWriter(DatabaseClient databaseClient, String rolesAndCapabilities) {
         this.databaseClient = databaseClient;
-        this.permissions = permissionsString != null && permissionsString.trim().length() > 0 ?
-            parsePermissions(permissionsString) :
+        this.permissions = rolesAndCapabilities != null && rolesAndCapabilities.trim().length() > 0 ?
+            parsePermissions(rolesAndCapabilities) :
             "xdmp:default-permissions()";
     }
 
@@ -50,12 +51,12 @@ public class GraphWriter {
      * We know the permissions string is valid at this point, as if it weren't, the writing process would have failed
      * before the connector gets to here.
      *
-     * @param permissions
+     * @param rolesAndCapabilities
      * @return
      */
-    private String parsePermissions(final String permissions) {
+    private String parsePermissions(final String rolesAndCapabilities) {
         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
-        metadata.getPermissions().addFromDelimitedString(permissions);
+        Util.addPermissionsFromDelimitedString(metadata.getPermissions(), rolesAndCapabilities);
         StringBuilder permissionsString = new StringBuilder("(");
         boolean firstOne = true;
         for (String role : metadata.getPermissions().keySet()) {

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
@@ -205,6 +205,21 @@ class WriteRowsTest extends AbstractWriteTest {
     }
 
     @Test
+    void invalidPermissionsCapability() {
+        SparkException ex = assertThrows(SparkException.class, () -> newWriter()
+            .option(Options.WRITE_PERMISSIONS, "rest-reader,read,rest-writer,notvalid")
+            .save());
+
+        Throwable cause = getCauseFromWriterException(ex);
+        assertTrue(cause instanceof IllegalArgumentException);
+        assertEquals("Unable to parse permissions string: rest-reader,read,rest-writer,notvalid; cause: Not a valid capability: NOTVALID",
+            cause.getMessage(), "When a capability is invalid, the Java Client throws an error message that refers " +
+                "to the enum class. This likely won't make sense to a connector or Flux user. So the connector is " +
+                "expected to massage the error a bit by identifying the invalid capability without referencing " +
+                "Java classes.");
+    }
+
+    @Test
     void dontAbortOnFailure() {
         AtomicInteger successCount = new AtomicInteger();
         AtomicInteger failureCount = new AtomicInteger();

--- a/marklogic-spark-langchain4j/build.gradle
+++ b/marklogic-spark-langchain4j/build.gradle
@@ -1,7 +1,9 @@
 dependencies {
   implementation project(":marklogic-spark-api")
 
-  implementation (project(":marklogic-langchain4j")) {
+  // API dependency so that public class in marklogic-langchain4j - specifically Util - can be accessed
+  // in the connector.
+  api (project(":marklogic-langchain4j")) {
     // These need to be excluded here so they don't sneak in when this module is depended on by the
     // marklogic-spark-connector module.
     exclude group: "com.fasterxml.jackson.core"

--- a/marklogic-spark-langchain4j/src/main/java/com/marklogic/spark/langchain4j/DocumentTextSplitterFactory.java
+++ b/marklogic-spark-langchain4j/src/main/java/com/marklogic/spark/langchain4j/DocumentTextSplitterFactory.java
@@ -70,15 +70,17 @@ public abstract class DocumentTextSplitterFactory {
 
     private static ChunkAssembler makeChunkAssembler(Context context) {
         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+
         if (context.hasOption(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS)) {
             metadata.getCollections().addAll(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS).split(","));
         }
+
         if (context.hasOption(Options.WRITE_SPLITTER_SIDECAR_PERMISSIONS)) {
             String value = context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_PERMISSIONS);
-            metadata.getPermissions().addFromDelimitedString(value);
+            com.marklogic.langchain4j.Util.addPermissionsFromDelimitedString(metadata.getPermissions(), value);
         } else if (context.hasOption(Options.WRITE_PERMISSIONS)) {
             String value = context.getStringOption(Options.WRITE_PERMISSIONS);
-            metadata.getPermissions().addFromDelimitedString(value);
+            com.marklogic.langchain4j.Util.addPermissionsFromDelimitedString(metadata.getPermissions(), value);
         }
 
         return new DefaultChunkAssembler(new ChunkConfig.Builder()


### PR DESCRIPTION
Ran into this while testing sidecar permissions in Flux.
