### PR TITLE
Hopefully fixing sonarqube code coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,5 @@
 @Library('shared-libraries') _
 
-// Using testCodeCoverageReport from the jacoco-report-aggregation plugin to produce an aggregated code coverage
-// report, even though Sonar doesn't seem to be able to make sense of it yet.
 def runtests(String javaVersion){
   sh label:'test', script: '''#!/bin/bash
     export JAVA_HOME=$'''+javaVersion+'''
@@ -13,7 +11,7 @@ def runtests(String javaVersion){
    ./gradlew -i mlDeploy
    echo "Loading data a second time to try to avoid Optic bug with duplicate rows being returned."
    ./gradlew -i mlLoadData
-   ./gradlew testCodeCoverageReport || true
+   ./gradlew clean testCodeCoverageReport || true
   '''
   junit '**/build/**/*.xml'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,14 +7,13 @@ sonar {
   properties {
     property "sonar.projectKey", "marklogic-spark"
     property "sonar.host.url", "http://localhost:9000"
-    property "sonar.coverage.jacoco.xmlReportPaths", "marklogic-spark-connector/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml"
+    property "sonar.coverage.jacoco.xmlReportPaths", "code-coverage-report/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml"
   }
 }
 
 subprojects {
   apply plugin: "java-library"
   apply plugin: "jacoco"
-  apply plugin: "org.sonarqube"
 
   group = "com.marklogic"
   version "2.5-SNAPSHOT"
@@ -39,7 +38,7 @@ subprojects {
       force "org.slf4j:slf4j-api:2.0.13"
     }
   }
-  
+
   test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport

--- a/code-coverage-report/build.gradle
+++ b/code-coverage-report/build.gradle
@@ -1,0 +1,21 @@
+// See https://docs.gradle.org/current/samples/sample_jvm_multi_project_with_code_coverage_standalone.html
+// for more information on how this file was created.
+
+plugins {
+  id 'jacoco-report-aggregation'
+}
+
+dependencies {
+  jacocoAggregation project(':marklogic-langchain4j')
+  jacocoAggregation project(':marklogic-spark-api')
+  jacocoAggregation project(':marklogic-spark-langchain4j')
+  jacocoAggregation project(':marklogic-spark-connector')
+}
+
+reporting {
+  reports {
+    testCodeCoverageReport(JacocoCoverageReport) {
+      testType = TestSuiteType.UNIT_TEST
+    }
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ The connector has the following system requirements:
 [a Spark distribution](https://spark.apache.org/downloads.html), you must select a distribution that uses Scala 2.12 and not Scala 2.13.
 * For writing data, MarkLogic 9.0-9 or higher.
 * For reading data, MarkLogic 10.0-9 or higher.
+* If using Java to run Spark, Java 11 or higher is required.
 
 In addition, if your MarkLogic cluster has multiple hosts in it, it is highly recommended to put a load balancer in front
 of your cluster and have the MarkLogic Spark connector connect through the load balancer. 

--- a/marklogic-langchain4j/build.gradle
+++ b/marklogic-langchain4j/build.gradle
@@ -1,11 +1,3 @@
-//configurations.all {
-//  // Ensures that slf4j-api 1.x does not appear on the Flux classpath in particular, which can lead to this
-//  // issue - https://www.slf4j.org/codes.html#StaticLoggerBinder .
-//  resolutionStrategy {
-//    force "org.slf4j:slf4j-api:2.0.13"
-//  }
-//}
-
 dependencies {
   compileOnly "com.fasterxml.jackson.core:jackson-databind:2.17.2"
   api "com.marklogic:marklogic-client-api:7.0.0"

--- a/marklogic-spark-connector/build.gradle
+++ b/marklogic-spark-connector/build.gradle
@@ -2,12 +2,6 @@ plugins {
   id 'net.saliman.properties' version '1.5.2'
   id 'com.gradleup.shadow' version '8.3.3'
   id 'maven-publish'
-
-  // This is working in terms of nicely aggregating jacoco code coverage data from each subproject. It produces a very
-  // nice HTML report under build/reports/jacoco/testCodeCoverageReport. Unfortunately, Sonar doesn't seem able to get
-  // all the coverage data from this directory; it only reports coverage from this project. Something to be figured out
-  // later.
-  id "jacoco-report-aggregation"
 }
 
 configurations {
@@ -23,11 +17,6 @@ configurations {
 }
 
 dependencies {
-  // Adding these forces code coverage data to be calculated for these subprojects.
-  jacocoAggregation project(':marklogic-langchain4j')
-  jacocoAggregation project(':marklogic-spark-api')
-  jacocoAggregation project(':marklogic-spark-langchain4j')
-
   // This is compileOnly as any environment this is used in will provide the Spark dependencies itself.
   compileOnly('org.apache.spark:spark-sql_2.12:' + sparkVersion) {
     // Excluded from our ETL tool for size reasons, so excluded here as well to ensure we don't need it.

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
@@ -15,7 +15,6 @@ import org.apache.spark.sql.DataFrameWriter;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
-import org.jdom2.Namespace;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include "marklogic-langchain4j", "marklogic-spark-api", "marklogic-spark-langchain4j", "marklogic-spark-connector", "test-app"
+include "marklogic-langchain4j", "marklogic-spark-api", "marklogic-spark-langchain4j", "marklogic-spark-connector", "test-app", "code-coverage-report"


### PR DESCRIPTION
jacoco is producing the correct report in the `code-coverage-report` subproject, but sonarqube doesn't report the same numbers - i.e. 90% vs 77%.
