### PR TITLE
Fixing progress logging issue for reading rows

### DIFF
--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/optic/OpticReadContext.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/optic/OpticReadContext.java
@@ -39,7 +39,7 @@ public class OpticReadContext extends ContextSupport {
     // choose to perform multiple operations on the dataset, each of which may benefit from a fairly different batch
     // size. 100k has been chosen as the default batch size to strike a reasonable balance for operations that do need
     // to collect all the rows, such as writing the dataset to another data source.
-    private static final long DEFAULT_BATCH_SIZE = 100000;
+    public static final long DEFAULT_BATCH_SIZE = 100000;
 
     private PlanAnalysis planAnalysis;
     private StructType schema;

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/optic/ReadRowsTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/optic/ReadRowsTest.java
@@ -21,8 +21,12 @@ class ReadRowsTest extends AbstractIntegrationTest {
     @Test
     void validPartitionCountAndBatchSize() {
         List<Row> rows = newDefaultReader()
-            .option(Options.READ_NUM_PARTITIONS, "3")
-            .option(Options.READ_BATCH_SIZE, "10000")
+            .option(Options.READ_NUM_PARTITIONS, 3)
+            .option(Options.READ_BATCH_SIZE, 5)
+
+            // Including this only to ensure it doesn't cause errors.
+            .option(Options.READ_LOG_PROGRESS, 5)
+
             .load()
             .collectAsList();
 
@@ -112,20 +116,15 @@ class ReadRowsTest extends AbstractIntegrationTest {
 
     @Test
     void nonNumericBatchSize() {
-        Dataset<Row> reader = newDefaultReader()
-            .option(Options.READ_BATCH_SIZE, "abc")
-            .load();
-
-        ConnectorException ex = assertThrows(ConnectorException.class, () -> reader.count());
+        DataFrameReader reader = newDefaultReader().option(Options.READ_BATCH_SIZE, "abc");
+        ConnectorException ex = assertThrows(ConnectorException.class, () -> reader.load());
         assertEquals("The value of 'spark.marklogic.read.batchSize' must be numeric.", ex.getMessage());
     }
 
     @Test
     void batchSizeLessThanZero() {
-        Dataset<Row> reader = newDefaultReader()
-            .option(Options.READ_BATCH_SIZE, "-1")
-            .load();
-        ConnectorException ex = assertThrows(ConnectorException.class, () -> reader.count());
+        DataFrameReader reader = newDefaultReader().option(Options.READ_BATCH_SIZE, "-1");
+        ConnectorException ex = assertThrows(ConnectorException.class, () -> reader.load());
         assertEquals("The value of 'spark.marklogic.read.batchSize' must be 0 or greater.", ex.getMessage());
     }
 }


### PR DESCRIPTION
Ran into this while testing, as I was using an interval smaller than the batch size, which led to erroneous progress logging.
