### PR TITLE
Fixing memory leak with eval call

### DIFF
--- a/marklogic-langchain4j/build.gradle
+++ b/marklogic-langchain4j/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
   compileOnly "com.fasterxml.jackson.core:jackson-databind:2.17.2"
-  api "com.marklogic:marklogic-client-api:7.0.0"
+  api "com.marklogic:marklogic-client-api:7.1-SNAPSHOT"
 
   // Supports splitting documents.
   api "dev.langchain4j:langchain4j:0.35.0"

--- a/marklogic-spark-connector/build.gradle
+++ b/marklogic-spark-connector/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
   shadowDependencies project(":marklogic-spark-api")
 
-  shadowDependencies("com.marklogic:marklogic-client-api:7.0.0") {
+  shadowDependencies("com.marklogic:marklogic-client-api:7.1-SNAPSHOT") {
     // The Java Client uses Jackson 2.15.2; Scala 3.4.x does not yet support that and will throw the following error:
     // Scala module 2.14.2 requires Jackson Databind version >= 2.14.0 and < 2.15.0 - Found jackson-databind version 2.15.2
     // So the 4 Jackson modules are excluded to allow for Spark's to be used.


### PR DESCRIPTION
Ran into this while testing the Java Client change in Flux. No tests, the only indication this happens is a log message from OkHttp (which oddly does not appear in the tests here, but does appear in Flux).
