### PR TITLE
Added splitter test and some messages about embedding customizations

### DIFF
--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/embedding/AddEmbeddingsToJsonTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/embedding/AddEmbeddingsToJsonTest.java
@@ -156,7 +156,10 @@ class AddEmbeddingsToJsonTest extends AbstractIntegrationTest {
         ArrayNode chunks = (ArrayNode) doc.get("envelope").get("my-chunks");
         assertEquals(2, chunks.size());
         chunks.forEach(chunk -> {
-            assertTrue(chunk.has("my-embedding"));
+            assertTrue(chunk.has("my-embedding"), "In the 2.5.0 release, both chunks and embeddings were added, " +
+                "but only embeddings can have their element name changed. It's not clear why this support was " +
+                "added instead of using the chunks approach, which is to use a name of e.g. 'embedder-embedding' " +
+                "instead. This option may be deprecated and removed in the future.");
             assertEquals(JsonNodeType.ARRAY, chunk.get("my-embedding").getNodeType());
         });
     }

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/embedding/AddEmbeddingsToXmlTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/embedding/AddEmbeddingsToXmlTest.java
@@ -224,7 +224,13 @@ class AddEmbeddingsToXmlTest extends AbstractIntegrationTest {
         XmlNode doc = readXmlDocument("/split-test.xml",
             Namespace.getNamespace("ex", "org:example"), Namespace.getNamespace("ml", "org:marklogic"));
 
-        doc.assertElementCount("Each of the 2 custom chunks should have a custom embedding element.",
+        doc.assertElementCount("Each of the 2 custom chunks should have a custom embedding element. " +
+                "In the 2.5.0 release, both chunks and embeddings were added, " +
+                "but only embeddings can have their element name / namespace changed. It's not clear why this " +
+                "support was added, as a user can always use a REST transform to adjust the data structure. And if " +
+                "an embedding element already exists, that won't cause a conflict as the connector embedding element " +
+                "is not appended and thus will not overwrite the existing element. These " +
+                "options may be deprecated and removed in the future.",
             "/ex:envelope/ex:my-chunks/ex:my-chunk[ex:my-text and ml:my-embedding]", 2);
     }
 

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
@@ -253,6 +253,23 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
     }
 
     @Test
+    void maxChunksWithCustomRootNameAndDefaultNamespace() {
+        prepareToWriteChunkDocuments()
+            .option(Options.WRITE_URI_TEMPLATE, "/split-test.xml")
+            .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
+            .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 4)
+            .option(Options.WRITE_SPLITTER_SIDECAR_ROOT_NAME, "sidecar")
+            .mode(SaveMode.Append)
+            .save();
+
+        XmlNode doc = readXmlDocument("/split-test.xml-chunks-1.xml");
+        doc.assertElementExists("When a custom root name is set, but no custom namespace is set, the entire document " +
+            "should be in the default namespace.", "/model:sidecar");
+        doc.assertElementValue("/model:sidecar/model:source-uri", "/split-test.xml");
+        doc.assertElementCount("/model:sidecar/model:chunks/model:chunk", 4);
+    }
+
+    @Test
     void maxChunksWithCustomRootNameAndNamespace() {
         prepareToWriteChunkDocuments()
             .option(Options.WRITE_URI_TEMPLATE, "/split-test.xml")


### PR DESCRIPTION
For XML, it doesn't matter if the element already exists since we're doing an `appendChild`.

For JSON - it does matter if the property name already exists. The splitter then uses "splitter-chunks" as the name. I think we can take the same approach for the classifier so we avoid the need for two more options. May later change the embedder to follow the same pattern.
