### PR TITLE
Refactor: Added DocumentRow

### DIFF
--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/document/DocumentRowSchema.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/document/DocumentRowSchema.java
@@ -26,12 +26,6 @@ public abstract class DocumentRowSchema {
         .add("properties", DataTypes.StringType)
         .add("metadataValues", DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType));
 
-    // Defines optional fields that are used when processing documents. Will need a better name.
-    public static final StructType IMPORT_SCHEMA = SCHEMA
-        // We may want for this to be a map with specific keys. Makes managing the schema a lot easier.
-        // Could be a "context" map.
-        .add("extractedText", DataTypes.StringType);
-
     private DocumentRowSchema() {
     }
 

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
@@ -18,6 +18,7 @@ import com.marklogic.spark.Util;
 import com.marklogic.spark.reader.document.DocumentRowBuilder;
 import com.marklogic.spark.reader.document.DocumentRowSchema;
 import com.marklogic.spark.reader.file.TripleRowSchema;
+import com.marklogic.spark.writer.document.DocumentRowConverter;
 import com.marklogic.spark.writer.file.ZipFileWriter;
 import com.marklogic.spark.writer.rdf.RdfRowConverter;
 import org.apache.commons.io.IOUtils;

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/WriteContext.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/WriteContext.java
@@ -140,7 +140,7 @@ public class WriteContext extends ContextSupport {
         return factory.newDocBuilder();
     }
 
-    Format getDocumentFormat() {
+    public Format getDocumentFormat() {
         if (hasOption(Options.WRITE_DOCUMENT_TYPE)) {
             String value = getStringOption(Options.WRITE_DOCUMENT_TYPE);
             try {

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/document/DocumentRow.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/document/DocumentRow.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.document;
+
+import com.marklogic.client.io.BytesHandle;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.spark.Util;
+import com.marklogic.spark.reader.document.DocumentRowSchema;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.Optional;
+
+/**
+ * Encapsulates a row that confirms to {@code DocumentRowSchema} and may have additional columns as well.
+ */
+class DocumentRow {
+
+    private final InternalRow row;
+    private final StructType schema;
+
+    DocumentRow(InternalRow row, StructType schema) {
+        this.row = row;
+        this.schema = schema;
+    }
+
+    BytesHandle getContent(Format documentFormat) {
+        BytesHandle content = new BytesHandle(row.getBinary(1));
+        // Ensures a format is set if possible, before the content is used in any other operations, including writing
+        // the content to MarkLogic.
+        setHandleFormat(content, documentFormat);
+        return content;
+    }
+
+    String getFormat() {
+        return row.isNullAt(2) ? null : row.getString(2);
+    }
+
+    Optional<String> getExtractedText() {
+        int index = getOptionalFieldIndex(schema, "extractedText");
+        return index > -1 ? Optional.of(row.getString(index)) : Optional.empty();
+    }
+
+    DocumentMetadataHandle getMetadata() {
+        return DocumentRowSchema.makeDocumentMetadata(row);
+    }
+
+    private int getOptionalFieldIndex(StructType schema, String fieldName) {
+        // We know what the first set of fields should be, so check each field after the expected set of document
+        // row fields.
+        for (int i = DocumentRowSchema.SCHEMA.size(); i < schema.size(); i++) {
+            if (fieldName.equals(schema.fields()[i].name())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private void setHandleFormat(BytesHandle bytesHandle, Format documentFormat) {
+        if (documentFormat != null) {
+            bytesHandle.withFormat(documentFormat);
+        } else {
+            String format = getFormat();
+            if (format != null) {
+                try {
+                    bytesHandle.withFormat(Format.valueOf(format.toUpperCase()));
+                } catch (IllegalArgumentException e) {
+                    // We don't ever expect this to happen, but in case it does - we'll proceed with a null format
+                    // on the handle, as it's not essential that it be set.
+                    if (Util.MAIN_LOGGER.isDebugEnabled()) {
+                        Util.MAIN_LOGGER.debug("Unable to set format on row with URI: {}; format: {}; error: {}",
+                            row.getString(0), format, e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Intent is to avoid bloat in DocumentRowConverter and provide a nice OO wrapper around an InternalRow that represents a document. Will be useful for upcoming methods for getting chunks and classification data and embeddings from a row.
