### PR TITLE
Refactor: Moved doc construction to DocBuilder

### DIFF
--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilderFactory.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilderFactory.java
@@ -4,6 +4,7 @@
 package com.marklogic.spark.writer;
 
 import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.Format;
 import com.marklogic.langchain4j.Util;
 
 /**
@@ -11,31 +12,39 @@ import com.marklogic.langchain4j.Util;
  */
 class DocBuilderFactory {
 
-    private DocumentMetadataHandle metadata;
+    private DocumentMetadataHandle metadataFromOptions;
     private DocBuilder.UriMaker uriMaker;
+    private Format extractedTextFormat;
 
     DocBuilderFactory() {
-        this.metadata = new DocumentMetadataHandle();
+        this.metadataFromOptions = new DocumentMetadataHandle();
     }
 
     DocBuilder newDocBuilder() {
-        return new DocBuilder(uriMaker, metadata);
+        return new DocBuilder(uriMaker, metadataFromOptions, extractedTextFormat);
     }
 
     DocBuilderFactory withCollections(String collections) {
         if (collections != null && collections.trim().length() > 0) {
-            metadata.withCollections(collections.split(","));
+            metadataFromOptions.withCollections(collections.split(","));
         }
         return this;
     }
 
     DocBuilderFactory withPermissions(String permissionsString) {
-        Util.addPermissionsFromDelimitedString(metadata.getPermissions(), permissionsString);
+        Util.addPermissionsFromDelimitedString(metadataFromOptions.getPermissions(), permissionsString);
         return this;
     }
 
     DocBuilderFactory withUriMaker(DocBuilder.UriMaker uriMaker) {
         this.uriMaker = uriMaker;
+        return this;
+    }
+
+    DocBuilderFactory withExtractedTextFormat(String extractedTextFormat) {
+        if (extractedTextFormat != null && extractedTextFormat.trim().length() > 0) {
+            this.extractedTextFormat = "xml".equalsIgnoreCase(extractedTextFormat) ? Format.XML : Format.JSON;
+        }
         return this;
     }
 }

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/WriteBatcherDataWriter.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -149,11 +150,12 @@ class WriteBatcherDataWriter implements DataWriter<InternalRow> {
     private void buildAndWriteDocuments(Iterator<DocBuilder.DocumentInputs> iterator) {
         try {
             iterator.forEachRemaining(documentInputs -> {
-                DocumentWriteOperation sourceDocument = this.docBuilder.build(documentInputs);
+                List<DocumentWriteOperation> documents = this.docBuilder.buildDocuments(documentInputs);
                 if (this.documentProcessor != null) {
-                    this.documentProcessor.apply(sourceDocument).forEachRemaining(this::writeDocument);
+                    // This will go away soon.
+                    documents.forEach(document -> this.documentProcessor.apply(document).forEachRemaining(this::writeDocument));
                 } else {
-                    writeDocument(sourceDocument);
+                    documents.forEach(this::writeDocument);
                 }
             });
         } finally {

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/WriteContext.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/WriteContext.java
@@ -128,8 +128,9 @@ public class WriteContext extends ContextSupport {
 
     DocBuilder newDocBuilder() {
         DocBuilderFactory factory = new DocBuilderFactory()
-            .withCollections(getProperties().get(Options.WRITE_COLLECTIONS))
-            .withPermissions(getProperties().get(Options.WRITE_PERMISSIONS));
+            .withCollections(getStringOption(Options.WRITE_COLLECTIONS))
+            .withPermissions(getStringOption(Options.WRITE_PERMISSIONS))
+            .withExtractedTextFormat(getStringOption(Options.WRITE_EXTRACTED_TEXT_FORMAT, "json"));
 
         if (hasOption(Options.WRITE_URI_TEMPLATE)) {
             configureTemplateUriMaker(factory);

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/document/DocumentRow.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/document/DocumentRow.java
@@ -14,7 +14,8 @@ import org.apache.spark.sql.types.StructType;
 import java.util.Optional;
 
 /**
- * Encapsulates a row that confirms to {@code DocumentRowSchema} and may have additional columns as well.
+ * Encapsulates a row that confirms to {@code DocumentRowSchema} and may have additional columns as well. Intended to
+ * handle converting from row-specific types into data structures preferred by {@code DocBuilder.DocumentInputs}.
  */
 class DocumentRow {
 
@@ -38,9 +39,9 @@ class DocumentRow {
         return row.isNullAt(2) ? null : row.getString(2);
     }
 
-    Optional<String> getExtractedText() {
+    String getExtractedText() {
         int index = getOptionalFieldIndex(schema, "extractedText");
-        return index > -1 ? Optional.of(row.getString(index)) : Optional.empty();
+        return index > -1 ? row.getString(index) : null;
     }
 
     DocumentMetadataHandle getMetadata() {


### PR DESCRIPTION
Intent is to capture all the inputs from a Spark row in a DocumentInputs class, and then DocBuilder has all the smarts for building 1 or more documents.
