### PR TITLE
Added all splitter config options

### DIFF
--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/Context.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/Context.java
@@ -7,11 +7,11 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.stream.Stream;
 
-public abstract class Context implements Serializable {
+public class Context implements Serializable {
 
     private final Map<String, String> properties;
 
-    protected Context(Map<String, String> properties) {
+    public Context(Map<String, String> properties) {
         this.properties = properties;
     }
 

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/udf/TextSplitter.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/udf/TextSplitter.java
@@ -5,59 +5,59 @@ package com.marklogic.spark.udf;
 
 import com.marklogic.client.io.BytesHandle;
 import com.marklogic.langchain4j.splitter.TextSelector;
-import com.marklogic.spark.langchain4j.DocumentTextSplitterFactory;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentSplitter;
-import dev.langchain4j.data.document.splitter.DocumentSplitters;
 import dev.langchain4j.data.segment.TextSegment;
 import org.apache.spark.sql.api.java.UDF1;
-import org.apache.spark.sql.expressions.UserDefinedFunction;
-import org.apache.spark.sql.functions;
-import org.apache.spark.sql.types.DataTypes;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class TextSplitter implements UDF1<Object, List<String>> {
+public class TextSplitter implements UDF1<Object, List<String>>, Serializable {
 
-    private int maxChunkSize;
-    private int maxOverlapSize;
-    private String jsonPointer;
+    private final TextSplitterConfig textSplitterConfig;
 
-    public static UserDefinedFunction build() {
-        return build(1000, 0, null);
-    }
+    // A UDF must be serializable, and these are not. So they're lazily created based on the config.
+    private transient TextSelector textSelector;
+    private transient DocumentSplitter documentSplitter;
 
-    // Initial attempt at configuration. Will shifter to a real Builder class soon.
-    public static UserDefinedFunction build(int maxChunkSize, int maxOverlapSize, String jsonPointer) {
-        TextSplitter splitter = new TextSplitter();
-        splitter.maxChunkSize = maxChunkSize;
-        splitter.maxOverlapSize = maxOverlapSize;
-        splitter.jsonPointer = jsonPointer;
-        return functions.udf(splitter, DataTypes.createArrayType(DataTypes.StringType));
+    public TextSplitter(TextSplitterConfig textSplitterConfig) {
+        this.textSplitterConfig = textSplitterConfig;
     }
 
     @Override
-    public List<String> call(Object columnValue) throws Exception {
+    public List<String> call(Object columnValue) {
         if (columnValue == null) {
             return new ArrayList<>();
         }
-
-        DocumentSplitter splitter = DocumentSplitters.recursive(maxChunkSize, maxOverlapSize);
+        if (documentSplitter == null) {
+            this.documentSplitter = textSplitterConfig.buildDocumentSplitter();
+        }
 
         if (columnValue instanceof String) {
-            return splitter.split(new Document((String) columnValue))
-                .stream().map(TextSegment::text)
-                .collect(Collectors.toList());
+            return splitExtractedText((String) columnValue);
         } else if (columnValue instanceof byte[]) {
-            TextSelector textSelector = DocumentTextSplitterFactory.makeJsonTextSelector(this.jsonPointer);
-            String text = textSelector.selectTextToSplit(new BytesHandle((byte[]) columnValue));
-            return splitter.split(new Document(text))
-                .stream().map(TextSegment::text)
-                .collect(Collectors.toList());
+            return splitDocumentContent((byte[]) columnValue);
         } else {
             throw new IllegalArgumentException("Unable to split text from column value: " + columnValue);
         }
+    }
+
+    private List<String> splitExtractedText(String columnValue) {
+        return documentSplitter.split(new Document(columnValue))
+            .stream().map(TextSegment::text)
+            .collect(Collectors.toList());
+    }
+
+    private List<String> splitDocumentContent(byte[] columnValue) {
+        if (textSelector == null) {
+            this.textSelector = textSplitterConfig.buildTextSelector();
+        }
+        String text = textSelector.selectTextToSplit(new BytesHandle(columnValue));
+        return documentSplitter.split(new Document(text))
+            .stream().map(TextSegment::text)
+            .collect(Collectors.toList());
     }
 }

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/udf/TextSplitterConfig.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/udf/TextSplitterConfig.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.udf;
+
+import com.marklogic.langchain4j.splitter.AllTextSelector;
+import com.marklogic.langchain4j.splitter.TextSelector;
+import com.marklogic.spark.Context;
+import com.marklogic.spark.Options;
+import com.marklogic.spark.langchain4j.DocumentSplitterFactory;
+import com.marklogic.spark.langchain4j.DocumentTextSplitterFactory;
+import dev.langchain4j.data.document.DocumentSplitter;
+import org.apache.spark.sql.expressions.UserDefinedFunction;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.DataTypes;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TextSplitterConfig implements Serializable {
+
+    private int maxChunkSize = 1000;
+    private int maxOverlapSize;
+    private String xpathExpression;
+    private String jsonPointers;
+    private String regex;
+    private String joinDelimiter;
+    private String customClass;
+    private Map<String, String> customClassOptions;
+    private Map<String, String> namespaces;
+
+    // Sonar is reporting functions.udf as deprecated, but it doesn't appear to be. So ignoring Sonar warning.
+    @SuppressWarnings("java:S1874")
+    public UserDefinedFunction buildUDF() {
+        return functions.udf(
+            new TextSplitter(this),
+            DataTypes.createArrayType(DataTypes.StringType)
+        );
+    }
+
+    TextSelector buildTextSelector() {
+        if (this.jsonPointers != null) {
+            return DocumentTextSplitterFactory.makeJsonTextSelector(this.jsonPointers);
+        } else if (this.xpathExpression != null) {
+            Map<String, String> properties = new HashMap<>();
+            if (namespaces != null) {
+                namespaces.entrySet().forEach(entry ->
+                    properties.put(Options.XPATH_NAMESPACE_PREFIX + entry.getKey(), entry.getValue()));
+            }
+            return DocumentTextSplitterFactory.makeXmlTextSelector(new Context(properties));
+        } else {
+            return new AllTextSelector();
+        }
+    }
+
+    DocumentSplitter buildDocumentSplitter() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, Integer.toString(maxChunkSize));
+        properties.put(Options.WRITE_SPLITTER_MAX_OVERLAP_SIZE, Integer.toString(maxOverlapSize));
+        properties.put(Options.WRITE_SPLITTER_REGEX, regex);
+        properties.put(Options.WRITE_SPLITTER_JOIN_DELIMITER, joinDelimiter);
+        properties.put(Options.WRITE_SPLITTER_CUSTOM_CLASS, customClass);
+        if (customClassOptions != null) {
+            customClassOptions.entrySet().forEach(entry ->
+                properties.put(Options.WRITE_SPLITTER_CUSTOM_CLASS_OPTION_PREFIX + entry.getKey(), entry.getValue()));
+        }
+        return DocumentSplitterFactory.makeDocumentSplitter(new Context(properties));
+    }
+
+    public void setMaxChunkSize(int maxChunkSize) {
+        this.maxChunkSize = maxChunkSize;
+    }
+
+    public void setMaxOverlapSize(int maxOverlapSize) {
+        this.maxOverlapSize = maxOverlapSize;
+    }
+
+    public void setJsonPointers(String newlineDelimitedJsonPointers) {
+        this.jsonPointers = newlineDelimitedJsonPointers;
+    }
+
+    public void setXpathExpression(String xpathExpression) {
+        this.xpathExpression = xpathExpression;
+    }
+
+    public void setRegex(String regex) {
+        this.regex = regex;
+    }
+
+    public void setJoinDelimiter(String joinDelimiter) {
+        this.joinDelimiter = joinDelimiter;
+    }
+
+    public void setCustomClass(String customClass) {
+        this.customClass = customClass;
+    }
+
+    public void setCustomClassOptions(Map<String, String> customClassOptions) {
+        this.customClassOptions = customClassOptions;
+    }
+
+    public void setNamespaces(Map<String, String> namespaces) {
+        this.namespaces = namespaces;
+    }
+}

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/IOExceptionTestExecutionListener.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/IOExceptionTestExecutionListener.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.NotSerializableException;
 
 public class IOExceptionTestExecutionListener implements TestExecutionExceptionHandler {
 
@@ -29,7 +30,7 @@ public class IOExceptionTestExecutionListener implements TestExecutionExceptionH
     // Telling Sonar not to complain about the intentional sleep.
     @SuppressWarnings("java:S2925")
     private boolean logIfIOException(Throwable throwable) {
-        if (throwable instanceof IOException) {
+        if (throwable instanceof IOException && !(throwable instanceof NotSerializableException)) {
             logger.error("Cause is IOException: {}; assuming this is due to a temporary and intermittent connection " +
                 "issue due to MarkLogic running on Docker, so will not fail test.", throwable.getMessage());
 

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/document/WriteExtractedTextTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/document/WriteExtractedTextTest.java
@@ -8,7 +8,7 @@ import com.marklogic.junit5.XmlNode;
 import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.Options;
 import com.marklogic.spark.udf.TextExtractor;
-import com.marklogic.spark.udf.TextSplitter;
+import com.marklogic.spark.udf.TextSplitterConfig;
 import org.apache.spark.SparkException;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
@@ -83,7 +83,7 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
             .read().format(CONNECTOR_IDENTIFIER)
             .load("src/test/resources/extraction-files/hello-world.docx")
             .withColumn("extractedText", TEXT_EXTRACTOR.apply(new Column("content")))
-            .withColumn("chunks", TextSplitter.build().apply(new Column("extractedText")))
+            .withColumn("chunks", new TextSplitterConfig().buildUDF().apply(new Column("extractedText")))
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
@@ -117,7 +117,7 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
             .read().format(CONNECTOR_IDENTIFIER)
             .load("src/test/resources/extraction-files/hello-world.docx")
             .withColumn("extractedText", TEXT_EXTRACTOR.apply(new Column("content")))
-            .withColumn("chunks", TextSplitter.build().apply(new Column("extractedText")))
+            .withColumn("chunks", new TextSplitterConfig().buildUDF().apply(new Column("extractedText")))
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)

--- a/marklogic-spark-langchain4j/src/main/java/com/marklogic/spark/langchain4j/DocumentTextSplitterFactory.java
+++ b/marklogic-spark-langchain4j/src/main/java/com/marklogic/spark/langchain4j/DocumentTextSplitterFactory.java
@@ -38,7 +38,7 @@ public interface DocumentTextSplitterFactory {
         return new DocumentTextSplitter(textSelector, splitter, chunkAssembler);
     }
 
-    private static TextSelector makeXmlTextSelector(Context context) {
+    static TextSelector makeXmlTextSelector(Context context) {
         String xpath = context.getStringOption(Options.WRITE_SPLITTER_XPATH);
         return new DOMTextSelector(xpath, NamespaceContextFactory.makeNamespaceContext(context.getProperties()));
     }


### PR DESCRIPTION
This doesn't test all of the options yet. Will get tests in place later. Want to get all 4 processors built out first to make sure it all works nicely.

This sets what seems like a reasonable pattern for constructing UDFs that have non-serializable dependencies as well.
