### PR TITLE
Can now use a classifier UDF to classifier top-level documents with XML content.

### DIFF
--- a/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/classifier/TextClassifier.java
+++ b/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/classifier/TextClassifier.java
@@ -28,6 +28,17 @@ public class TextClassifier {
     private final ClassificationClient classificationClient;
     private final DocumentBuilderFactory documentBuilderFactory;
 
+    public TextClassifier(ClassificationConfiguration classificationConfiguration) {
+        documentBuilderFactory = DocumentBuilderFactory.newInstance();
+
+        this.classificationClient = new ClassificationClient();
+        Map<String, String> additionalParameters = new HashMap<>();
+        additionalParameters.put("threshold", THRESHOLD);
+        additionalParameters.put("language", "en1");
+        classificationConfiguration.setAdditionalParameters(additionalParameters);
+        classificationClient.setClassificationConfiguration(classificationConfiguration);
+    }
+
     public TextClassifier(String host, String https, String port, String endpoint, String apikey, String tokenEndpoint) throws CloudException {
         String protocol = "true".equalsIgnoreCase(https) ? "https" : "http";
         String tokenUrl = protocol + "://" + host + ":" + port + "/" + tokenEndpoint;

--- a/marklogic-spark-connector/build.gradle
+++ b/marklogic-spark-connector/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     exclude group: "com.fasterxml.jackson.core"
     exclude group: "com.fasterxml.jackson.dataformat"
   }
+  implementation 'com.smartlogic.cloud:Semaphore-Cloud-Client:5.6.1'
+  implementation 'com.smartlogic.csclient:Semaphore-CS-Client:5.6.1'
 
   // Required for converting JSON to XML. Using 2.15.2 to align with Spark 3.5.3.
   shadowDependencies("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2") {

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/udf/TextClassifierUdf.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/udf/TextClassifierUdf.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.udf;
+
+import com.marklogic.langchain4j.classifier.TextClassifier;
+import com.marklogic.spark.ConnectorException;
+import com.smartlogic.classificationserver.client.ClassificationConfiguration;
+import com.smartlogic.cloud.CloudException;
+import com.smartlogic.cloud.Token;
+import com.smartlogic.cloud.TokenFetcher;
+import org.apache.spark.sql.expressions.UserDefinedFunction;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.DataTypes;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class TextClassifierUdf {
+    private static final String THRESHOLD = "20";
+
+    private static ClassificationConfiguration classificationConfiguration;
+
+    public static UserDefinedFunction build(
+            String host,boolean https, String port, String endpoint, String apiKey, String tokenEndpoint
+    ) {
+        String protocol = https ? "https" : "http";
+        String tokenUrl = protocol + "://" + host + ":" + port + "/" + tokenEndpoint;
+        TokenFetcher tokenFetcher = new TokenFetcher(tokenUrl, apiKey);
+        Token token;
+        try {
+            token = tokenFetcher.getAccessToken();
+        } catch (CloudException e) {
+            throw new ConnectorException(String.format("Unable to initialize Classifier UDF; cause: %s", e.getMessage()), e);
+        }
+
+        classificationConfiguration = new ClassificationConfiguration();
+        classificationConfiguration.setSingleArticle(false);
+        classificationConfiguration.setMultiArticle(true);
+        classificationConfiguration.setSocketTimeoutMS(100000);
+        classificationConfiguration.setConnectionTimeoutMS(100000);
+        classificationConfiguration.setApiToken(token.getAccess_token());
+        classificationConfiguration.setProtocol(protocol);
+        classificationConfiguration.setHostName(host);
+        classificationConfiguration.setHostPort(Integer.parseInt(port));
+        classificationConfiguration.setHostPath(endpoint);
+
+        Map<String, String> additionalParameters = new HashMap<>();
+        additionalParameters.put("threshold", THRESHOLD);
+        additionalParameters.put("language", "en1");
+        classificationConfiguration.setAdditionalParameters(additionalParameters);
+        return functions.udf(TextClassifierUdf::classifyText, DataTypes.BinaryType);
+    }
+
+    private static byte[] classifyText(Object binaryContent) {
+        if (!(binaryContent instanceof byte[])) {
+            throw new IllegalArgumentException(
+                    "Text classification UDF must be run against a column containing non-null byte arrays."
+            );
+        }
+        // Need to add handler for when a token expires midstream.
+        String content = new String((byte[]) binaryContent, StandardCharsets.UTF_8);
+        TextClassifier textClassifier = new TextClassifier(classificationConfiguration);
+        return textClassifier.classifyTextToBytes("sourceUri", content);
+    }
+
+    private TextClassifierUdf() {
+    }
+}

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/document/DocumentRow.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/document/DocumentRow.java
@@ -22,6 +22,7 @@ import java.util.List;
  */
 class DocumentRow {
 
+    public static final String CLASSIFED_TEXT_COLUMN_NAME = "classificationResponse";
     private final InternalRow row;
     private final StructType schema;
 
@@ -45,6 +46,11 @@ class DocumentRow {
     String getExtractedText() {
         int index = getOptionalFieldIndex(schema, "extractedText");
         return index > -1 ? row.getString(index) : null;
+    }
+
+    byte[] getClassificationResponse() {
+        int index = getOptionalFieldIndex(schema, CLASSIFED_TEXT_COLUMN_NAME);
+        return index > -1 ? row.getBinary(index) : null;
     }
 
     List<String> getChunks() {

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/document/DocumentRowConverter.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/document/DocumentRowConverter.java
@@ -6,10 +6,7 @@ package com.marklogic.spark.writer.document;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.marklogic.client.io.BytesHandle;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.InputStreamHandle;
+import com.marklogic.client.io.*;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
 import com.marklogic.spark.reader.document.DocumentRowSchema;
@@ -81,6 +78,8 @@ public class DocumentRowConverter implements RowConverter {
 
         DocBuilder.DocumentInputs documentInputs = new DocBuilder.DocumentInputs(uri, bytesHandle, uriTemplateValues, documentRow.getMetadata());
         documentInputs.setExtractedText(documentRow.getExtractedText());
+        documentInputs.setClassificationResponse(documentRow.getClassificationResponse());
+
         documentInputs.setChunks(documentRow.getChunks());
         return Stream.of(documentInputs).iterator();
     }

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/classifier/AddClassificationToXmlTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/classifier/AddClassificationToXmlTest.java
@@ -7,16 +7,29 @@ import com.marklogic.junit5.XmlNode;
 import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
-import org.apache.spark.sql.DataFrameWriter;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SaveMode;
+import com.marklogic.spark.udf.TextClassifierUdf;
+import org.apache.spark.sql.*;
+import org.apache.spark.sql.expressions.UserDefinedFunction;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class AddClassificationToXmlTest extends AbstractIntegrationTest {
+
+    private static final String API_KEY = System.getenv("SEMAPHORE_API_KEY");
+    private static final UserDefinedFunction TEXT_CLASSIFIER;
+    private static final String CLASSIFED_TEXT_COLUMN_NAME = "classificationResponse";
+
+    static {
+        try {
+            TEXT_CLASSIFIER = TextClassifierUdf.build(
+                "demo.data.progress.cloud", true, "443", "/cls/dev/cs1/", API_KEY, "token/");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     @Test
     @EnabledIfEnvironmentVariable(named = "SEMAPHORE_API_KEY", matches = ".*")
@@ -68,9 +81,6 @@ class AddClassificationToXmlTest extends AbstractIntegrationTest {
     @Test
     @EnabledIfEnvironmentVariable(named = "SEMAPHORE_API_KEY", matches = ".*")
     void noHttpsSpecifiedShouldDefaultToHttpAndFail() {
-        final String apiKey = System.getenv("SEMAPHORE_API_KEY");
-        assertNotNull(apiKey);
-
         final DataFrameWriter<Row> dfw = readDocument("/marklogic-docs/java-client-intro.xml")
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
@@ -78,12 +88,40 @@ class AddClassificationToXmlTest extends AbstractIntegrationTest {
             .option(Options.WRITE_CLASSIFIER_HOST, "demo.data.progress.cloud")
             .option(Options.WRITE_CLASSIFIER_PORT, "443")
             .option(Options.WRITE_CLASSIFIER_ENDPOINT, "/cls/dev/cs1/")
-            .option(Options.WRITE_CLASSIFIER_APIKEY, apiKey)
+            .option(Options.WRITE_CLASSIFIER_APIKEY, API_KEY)
             .option(Options.WRITE_CLASSIFIER_TOKEN_ENDPOINT, "token/")
             .mode(SaveMode.Append);
 
         ConnectorException exception = assertThrowsConnectorException(dfw::save);
         assertTrue(exception.getMessage().contains("CloudException thrown fetching token"), "Unexpected error: " + exception.getMessage());
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "SEMAPHORE_API_KEY", matches = ".*")
+    void classifyContentsWithUdf() {
+        Dataset<Row> dataset = readDocument("/marklogic-docs/java-client-intro.xml")
+            .withColumn(CLASSIFED_TEXT_COLUMN_NAME, TEXT_CLASSIFIER.apply(new Column("content")));
+
+        assertEquals(1, dataset.count(), "Expecting 1 file");
+        assertNotNull(dataset.col(CLASSIFED_TEXT_COLUMN_NAME));
+        assertEquals(9, dataset.collectAsList().get(0).size(),
+            format("Expecting the 8 standard columns for representing a column, plus the '%s' column.", CLASSIFED_TEXT_COLUMN_NAME));
+
+        dataset.write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
+            .option(Options.WRITE_URI_TEMPLATE, "/split-test.xml")
+            .mode(SaveMode.Append)
+            .save();
+
+        XmlNode doc = readXmlDocument("/split-test.xml");
+        doc.assertElementExists("Expecting the root of the document to have a 'model:classification' child element", "/root/model:classification/model:URL");
+    }
+
+    @Test
+    @Disabled("Placeholder for a future test for data that is not UTF-8")
+    void classifyNonUtf8Data() {
+        assertTrue(true);
     }
 
     private Dataset<Row> readDocument(String uri) {


### PR DESCRIPTION
New attempt. This one uses the newly implemented DocBuilder.