### PR TITLE
Minimizing dependency on marklogic-langchain4j module

### DIFF
--- a/marklogic-langchain4j/build.gradle
+++ b/marklogic-langchain4j/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
+  implementation project(":marklogic-spark-api")
+
   compileOnly "com.fasterxml.jackson.core:jackson-databind:2.17.2"
   api "com.marklogic:marklogic-client-api:7.1.0"
 

--- a/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/Util.java
+++ b/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/Util.java
@@ -3,16 +3,11 @@
  */
 package com.marklogic.langchain4j;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marklogic.client.extra.jdom.JDOMHandle;
-import com.marklogic.client.impl.HandleAccessor;
-import com.marklogic.client.io.*;
-import com.marklogic.client.io.marker.AbstractWriteHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+// Telling Sonar to ignore this for now, will refactor it soon.
+@SuppressWarnings("java:S1214")
 public interface Util {
 
     /**
@@ -20,53 +15,5 @@ public interface Util {
      * at the info/debug level without enabling any other log messages.
      */
     Logger LANGCHAIN4J_LOGGER = LoggerFactory.getLogger("com.marklogic.langchain4j");
-
-    String DEFAULT_XML_NAMESPACE = "http://marklogic.com/appservices/model";
-
-    static JsonNode getJsonFromHandle(AbstractWriteHandle writeHandle) {
-        if (writeHandle instanceof JacksonHandle) {
-            return ((JacksonHandle) writeHandle).get();
-        } else {
-            String json = HandleAccessor.contentAsString(writeHandle);
-            try {
-                return new ObjectMapper().readTree(json);
-            } catch (JsonProcessingException e) {
-                throw new MarkLogicLangchainException(String.format(
-                    "Unable to read JSON from content handle; cause: %s", e.getMessage()), e);
-            }
-        }
-    }
-
-    static void addPermissionsFromDelimitedString(DocumentMetadataHandle.DocumentPermissions permissions,
-                                                  String rolesAndCapabilities) {
-        // This isn't likely the best home for this class, but it's needed by this module and by the connector to
-        // massage an error message that is meaningful for a Java Client user but not meaningful for a connector
-        // or Flux user.
-        try {
-            permissions.addFromDelimitedString(rolesAndCapabilities);
-        } catch (IllegalArgumentException ex) {
-            String message = ex.getMessage();
-            final String confusingMessageForUser = "No enum constant com.marklogic.client.io.DocumentMetadataHandle.Capability.";
-            if (message != null && message.contains(confusingMessageForUser)) {
-                message = message.replace(confusingMessageForUser, "Not a valid capability: ");
-                throw new IllegalArgumentException(message, ex);
-            }
-            throw ex;
-        }
-    }
-
-    static Format determineSourceDocumentFormat(AbstractWriteHandle content, String sourceUri) {
-        final String uri = sourceUri != null ? sourceUri : "";
-        if (content instanceof JacksonHandle || uri.endsWith(".json")) {
-            return Format.JSON;
-        }
-        if (content instanceof DOMHandle || content instanceof JDOMHandle || uri.endsWith(".xml")) {
-            return Format.XML;
-        }
-        if (content instanceof BaseHandle) {
-            return ((BaseHandle) content).getFormat();
-        }
-        return null;
-    }
 
 }

--- a/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/embedding/DOMChunkSelector.java
+++ b/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/embedding/DOMChunkSelector.java
@@ -7,7 +7,7 @@ import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.impl.DocumentWriteOperationImpl;
 import com.marklogic.client.io.DOMHandle;
 import com.marklogic.langchain4j.MarkLogicLangchainException;
-import com.marklogic.langchain4j.dom.DOMHelper;
+import com.marklogic.spark.dom.DOMHelper;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;

--- a/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/embedding/JsonChunkSelector.java
+++ b/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/embedding/JsonChunkSelector.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.impl.DocumentWriteOperationImpl;
 import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.langchain4j.Util;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,7 +59,7 @@ public class JsonChunkSelector implements ChunkSelector {
 
     @Override
     public DocumentAndChunks selectChunks(DocumentWriteOperation sourceDocument) {
-        JsonNode doc = Util.getJsonFromHandle(sourceDocument.getContent());
+        JsonNode doc = com.marklogic.spark.Util.getJsonFromHandle(sourceDocument.getContent());
 
         JsonNode chunksNode = doc.at(chunksPointer);
         if (chunksNode == null || (!(chunksNode instanceof ArrayNode) && !(chunksNode instanceof ObjectNode))) {

--- a/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/embedding/XmlChunkConfig.java
+++ b/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/embedding/XmlChunkConfig.java
@@ -3,7 +3,7 @@
  */
 package com.marklogic.langchain4j.embedding;
 
-import com.marklogic.langchain4j.Util;
+import com.marklogic.spark.Util;
 
 import javax.xml.namespace.NamespaceContext;
 

--- a/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/splitter/ChunkConfig.java
+++ b/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/splitter/ChunkConfig.java
@@ -4,8 +4,8 @@
 package com.marklogic.langchain4j.splitter;
 
 import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.langchain4j.Util;
 import com.marklogic.langchain4j.classifier.TextClassifier;
+import com.marklogic.spark.Util;
 
 /**
  * Captures configuration settings for producing chunks, either in a source document or in separate
@@ -142,5 +142,7 @@ public class ChunkConfig {
         return embeddingXmlNamespace;
     }
 
-    public TextClassifier getClassifier() { return classifier; }
+    public TextClassifier getClassifier() {
+        return classifier;
+    }
 }

--- a/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/splitter/DOMTextSelector.java
+++ b/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/splitter/DOMTextSelector.java
@@ -7,7 +7,7 @@ import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.langchain4j.MarkLogicLangchainException;
 import com.marklogic.langchain4j.Util;
-import com.marklogic.langchain4j.dom.DOMHelper;
+import com.marklogic.spark.dom.DOMHelper;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 

--- a/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/splitter/DefaultChunkAssembler.java
+++ b/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/splitter/DefaultChunkAssembler.java
@@ -14,8 +14,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.marklogic.langchain4j.Util.determineSourceDocumentFormat;
-
 public class DefaultChunkAssembler implements ChunkAssembler {
 
     private final ChunkConfig chunkConfig;
@@ -33,7 +31,7 @@ public class DefaultChunkAssembler implements ChunkAssembler {
 
     @Override
     public Iterator<DocumentWriteOperation> assembleChunks(DocumentWriteOperation sourceDocument, List<TextSegment> textSegments) {
-        final Format sourceDocumentFormat = determineSourceDocumentFormat(sourceDocument.getContent(), sourceDocument.getUri());
+        final Format sourceDocumentFormat = com.marklogic.spark.Util.determineSourceDocumentFormat(sourceDocument.getContent(), sourceDocument.getUri());
         if (sourceDocumentFormat == null) {
             Util.LANGCHAIN4J_LOGGER.warn("Cannot split document with URI {}; cannot determine the document format.", sourceDocument.getUri());
             return Stream.of(sourceDocument).iterator();

--- a/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/splitter/JsonChunkDocumentProducer.java
+++ b/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/splitter/JsonChunkDocumentProducer.java
@@ -39,7 +39,7 @@ class JsonChunkDocumentProducer extends AbstractChunkDocumentProducer {
     @Override
     protected DocumentWriteOperation addChunksToSourceDocument() {
         AbstractWriteHandle content = sourceDocument.getContent();
-        ObjectNode doc = (ObjectNode) Util.getJsonFromHandle(content);
+        ObjectNode doc = (ObjectNode) com.marklogic.spark.Util.getJsonFromHandle(content);
 
         ArrayNode chunksArray = doc.putArray(determineChunksArrayName(doc));
         List<Chunk> chunks = new ArrayList<>();

--- a/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/splitter/JsonPointerTextSelector.java
+++ b/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/splitter/JsonPointerTextSelector.java
@@ -47,7 +47,7 @@ public class JsonPointerTextSelector implements TextSelector {
     private String selectTextToSplit(AbstractWriteHandle contentHandle, String uriForLogMessage) {
         JsonNode doc;
         try {
-            doc = Util.getJsonFromHandle(contentHandle);
+            doc = com.marklogic.spark.Util.getJsonFromHandle(contentHandle);
         } catch (Exception ex) {
             Util.LANGCHAIN4J_LOGGER.warn("Unable to select text to split in document: {}; cause: {}", uriForLogMessage, ex.getMessage());
             return null;

--- a/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/splitter/XmlChunkDocumentProducer.java
+++ b/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/splitter/XmlChunkDocumentProducer.java
@@ -7,12 +7,12 @@ import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.impl.DocumentWriteOperationImpl;
 import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.io.Format;
-import com.marklogic.langchain4j.Util;
-import com.marklogic.langchain4j.dom.DOMHelper;
 import com.marklogic.langchain4j.embedding.Chunk;
 import com.marklogic.langchain4j.embedding.DOMChunk;
 import com.marklogic.langchain4j.embedding.DocumentAndChunks;
 import com.marklogic.langchain4j.embedding.XmlChunkConfig;
+import com.marklogic.spark.Util;
+import com.marklogic.spark.dom.DOMHelper;
 import dev.langchain4j.data.segment.TextSegment;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -20,7 +20,8 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import javax.xml.xpath.XPathFactory;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 class XmlChunkDocumentProducer extends AbstractChunkDocumentProducer {
 
@@ -96,7 +97,7 @@ class XmlChunkDocumentProducer extends AbstractChunkDocumentProducer {
             Document responseDoc = chunkConfig.getClassifier().classifyTextToXml(super.sourceDocument.getUri(), textSegment.text());
             NodeList structuredDocumentNodeChildNodes = responseDoc.getElementsByTagName("STRUCTUREDDOCUMENT").item(0).getChildNodes();
             for (int i = 0; i < structuredDocumentNodeChildNodes.getLength(); i++) {
-                Node importedChildNode = doc.importNode(structuredDocumentNodeChildNodes.item(i),true);
+                Node importedChildNode = doc.importNode(structuredDocumentNodeChildNodes.item(i), true);
                 classificationNode.appendChild(importedChildNode);
             }
             chunk.appendChild(classificationNode);

--- a/marklogic-spark-api/build.gradle
+++ b/marklogic-spark-api/build.gradle
@@ -3,5 +3,7 @@
  * it doesn't have a circular dependency with the connector subproject.
  */
 dependencies {
+  compileOnly "com.marklogic:marklogic-client-api:7.1.0"
+  compileOnly "com.fasterxml.jackson.core:jackson-databind:2.17.2"
   implementation "org.slf4j:jcl-over-slf4j:2.0.13"
 }

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/Util.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/Util.java
@@ -3,6 +3,13 @@
  */
 package com.marklogic.spark;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marklogic.client.extra.jdom.JDOMHandle;
+import com.marklogic.client.impl.HandleAccessor;
+import com.marklogic.client.io.*;
+import com.marklogic.client.io.marker.AbstractWriteHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,6 +23,8 @@ public interface Util {
      * messages.
      */
     Logger MAIN_LOGGER = LoggerFactory.getLogger("com.marklogic.spark");
+
+    String DEFAULT_XML_NAMESPACE = "http://marklogic.com/appservices/model";
 
     static boolean hasOption(Map<String, String> properties, String... options) {
         return Stream.of(options)
@@ -71,5 +80,51 @@ public interface Util {
         ResourceBundle bundle = ResourceBundle.getBundle("marklogic-spark-messages", Locale.getDefault());
         String optionName = bundle.getString(option);
         return optionName != null && optionName.trim().length() > 0 ? optionName.trim() : option;
+    }
+
+    static Format determineSourceDocumentFormat(AbstractWriteHandle content, String sourceUri) {
+        final String uri = sourceUri != null ? sourceUri : "";
+        if (content instanceof JacksonHandle || uri.endsWith(".json")) {
+            return Format.JSON;
+        }
+        if (content instanceof DOMHandle || content instanceof JDOMHandle || uri.endsWith(".xml")) {
+            return Format.XML;
+        }
+        if (content instanceof BaseHandle) {
+            return ((BaseHandle) content).getFormat();
+        }
+        return null;
+    }
+
+    static JsonNode getJsonFromHandle(AbstractWriteHandle writeHandle) {
+        if (writeHandle instanceof JacksonHandle) {
+            return ((JacksonHandle) writeHandle).get();
+        } else {
+            String json = HandleAccessor.contentAsString(writeHandle);
+            try {
+                return new ObjectMapper().readTree(json);
+            } catch (JsonProcessingException e) {
+                throw new ConnectorException(String.format(
+                    "Unable to read JSON from content handle; cause: %s", e.getMessage()), e);
+            }
+        }
+    }
+
+    static void addPermissionsFromDelimitedString(DocumentMetadataHandle.DocumentPermissions permissions,
+                                                  String rolesAndCapabilities) {
+        // This isn't likely the best home for this class, but it's needed by this module and by the connector to
+        // massage an error message that is meaningful for a Java Client user but not meaningful for a connector
+        // or Flux user.
+        try {
+            permissions.addFromDelimitedString(rolesAndCapabilities);
+        } catch (IllegalArgumentException ex) {
+            String message = ex.getMessage();
+            final String confusingMessageForUser = "No enum constant com.marklogic.client.io.DocumentMetadataHandle.Capability.";
+            if (message != null && message.contains(confusingMessageForUser)) {
+                message = message.replace(confusingMessageForUser, "Not a valid capability: ");
+                throw new IllegalArgumentException(message, ex);
+            }
+            throw ex;
+        }
     }
 }

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/dom/DOMHelper.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/dom/DOMHelper.java
@@ -1,13 +1,13 @@
 /*
  * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
-package com.marklogic.langchain4j.dom;
+package com.marklogic.spark.dom;
 
 import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.impl.HandleAccessor;
 import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
-import com.marklogic.langchain4j.MarkLogicLangchainException;
+import com.marklogic.spark.ConnectorException;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -56,7 +56,7 @@ public class DOMHelper {
             String message = sourceUri != null ?
                 String.format("Unable to parse XML for document with URI: %s; cause: %s", sourceUri, e.getMessage()) :
                 String.format("Unable to parse XML; cause: %s", e.getMessage());
-            throw new MarkLogicLangchainException(message, e);
+            throw new ConnectorException(message, e);
         }
     }
 
@@ -74,7 +74,7 @@ public class DOMHelper {
             return xpath.compile(xpathExpression);
         } catch (XPathExpressionException e) {
             String message = massageXPathCompilationError(e.getMessage());
-            throw new MarkLogicLangchainException(String.format(
+            throw new ConnectorException(String.format(
                 "Unable to compile XPath expression for %s: %s; cause: %s",
                 purposeForErrorMessage, xpathExpression, message), e
             );
@@ -94,7 +94,7 @@ public class DOMHelper {
             try {
                 this.documentBuilder = this.documentBuilderFactory.newDocumentBuilder();
             } catch (ParserConfigurationException e) {
-                throw new MarkLogicLangchainException(String.format("Unable to create XML document; cause: %s", e.getMessage()), e);
+                throw new ConnectorException(String.format("Unable to create XML document; cause: %s", e.getMessage()), e);
             }
         }
         return this.documentBuilder;

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/dom/XPathNamespaceContext.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/dom/XPathNamespaceContext.java
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
  */
-package com.marklogic.langchain4j.dom;
+package com.marklogic.spark.dom;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilderFactory.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilderFactory.java
@@ -5,8 +5,8 @@ package com.marklogic.spark.writer;
 
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
-import com.marklogic.langchain4j.Util;
 import com.marklogic.langchain4j.splitter.ChunkAssembler;
+import com.marklogic.spark.Util;
 
 /**
  * This is intended to migrate to java-client-api and likely just be a Builder class on DocumentWriteOperation.
@@ -38,7 +38,7 @@ class DocBuilderFactory {
     }
 
     DocBuilderFactory withPermissions(String permissionsString) {
-        Util.addPermissionsFromDelimitedString(metadata.getPermissions(), permissionsString);
+        com.marklogic.spark.Util.addPermissionsFromDelimitedString(metadata.getPermissions(), permissionsString);
         return this;
     }
 

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/rdf/GraphWriter.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/rdf/GraphWriter.java
@@ -6,7 +6,7 @@ package com.marklogic.spark.writer.rdf;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.eval.ServerEvaluationCall;
 import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.langchain4j.Util;
+import com.marklogic.spark.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/marklogic-spark-connector/src/test/java/com/marklogic/langchain4j/embedding/EmbedderTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/langchain4j/embedding/EmbedderTest.java
@@ -13,9 +13,9 @@ import com.marklogic.client.impl.DocumentWriteOperationImpl;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.junit5.XmlNode;
-import com.marklogic.langchain4j.Util;
 import com.marklogic.langchain4j.splitter.*;
 import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.Util;
 import com.marklogic.spark.writer.XmlUtil;
 import dev.langchain4j.data.document.splitter.DocumentSplitters;
 import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
@@ -43,7 +43,7 @@ class EmbedderTest extends AbstractIntegrationTest {
         docs.next();
 
         docs.forEachRemaining(doc -> {
-            JsonNode node = Util.getJsonFromHandle(doc.getContent());
+            JsonNode node = com.marklogic.spark.Util.getJsonFromHandle(doc.getContent());
             ArrayNode chunks = (ArrayNode) node.get("chunks");
             assertEquals(2, chunks.size());
             for (JsonNode chunk : chunks) {

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/splitter/SplitXmlDocumentTest.java
@@ -89,8 +89,7 @@ class SplitXmlDocumentTest extends AbstractIntegrationTest {
             .option(Options.WRITE_SPLITTER_XPATH, "/ex:root/ex:text/text()")
             .mode(SaveMode.Append);
 
-        SparkException sparkException = assertThrows(SparkException.class, () -> writer.save());
-        MarkLogicLangchainException ex = (MarkLogicLangchainException) sparkException.getCause();
+        ConnectorException ex = assertThrowsConnectorException(() -> writer.save());
         assertEquals(
             "Unable to compile XPath expression for selecting text: /ex:root/ex:text/text(); cause: Prefix must resolve to a namespace: ex",
             ex.getMessage()

--- a/marklogic-spark-langchain4j/src/main/java/com/marklogic/spark/langchain4j/DocumentTextSplitterFactory.java
+++ b/marklogic-spark-langchain4j/src/main/java/com/marklogic/spark/langchain4j/DocumentTextSplitterFactory.java
@@ -79,10 +79,10 @@ public interface DocumentTextSplitterFactory {
 
         if (context.hasOption(Options.WRITE_SPLITTER_SIDECAR_PERMISSIONS)) {
             String value = context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_PERMISSIONS);
-            com.marklogic.langchain4j.Util.addPermissionsFromDelimitedString(metadata.getPermissions(), value);
+            Util.addPermissionsFromDelimitedString(metadata.getPermissions(), value);
         } else if (context.hasOption(Options.WRITE_PERMISSIONS)) {
             String value = context.getStringOption(Options.WRITE_PERMISSIONS);
-            com.marklogic.langchain4j.Util.addPermissionsFromDelimitedString(metadata.getPermissions(), value);
+            Util.addPermissionsFromDelimitedString(metadata.getPermissions(), value);
         }
 
         return new DefaultChunkAssembler(new ChunkConfig.Builder()

--- a/marklogic-spark-langchain4j/src/main/java/com/marklogic/spark/langchain4j/NamespaceContextFactory.java
+++ b/marklogic-spark-langchain4j/src/main/java/com/marklogic/spark/langchain4j/NamespaceContextFactory.java
@@ -3,9 +3,9 @@
  */
 package com.marklogic.spark.langchain4j;
 
-import com.marklogic.langchain4j.Util;
-import com.marklogic.langchain4j.dom.XPathNamespaceContext;
+import com.marklogic.spark.dom.XPathNamespaceContext;
 import com.marklogic.spark.Options;
+import com.marklogic.spark.Util;
 
 import javax.xml.namespace.NamespaceContext;
 import java.util.HashMap;
@@ -18,7 +18,7 @@ public interface NamespaceContextFactory {
         prefixesToNamespaces.put("model", Util.DEFAULT_XML_NAMESPACE);
         return new XPathNamespaceContext(prefixesToNamespaces);
     }
-    
+
     static NamespaceContext makeNamespaceContext(Map<String, String> properties) {
         Map<String, String> prefixesToNamespaces = new HashMap<>();
         properties.keySet().stream()


### PR DESCRIPTION
That module is going to require Java 17. Still have a few things left to fix, but this takes care of some easy stuff by moving things into marklogic-spark-api.
