### PR TITLE
Made it easier to config classifier paths

### DIFF
--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/Options.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/Options.java
@@ -410,42 +410,42 @@ public abstract class Options {
     /**
      * Defines the host for classification requests
      *
-     * @since 2.5-SNAPSHOT
+     * @since 2.6.0
      */
     public static final String WRITE_CLASSIFIER_HOST = "spark.marklogic.write.classifier.host";
 
     /**
-     * Specifies if the protocol should be https for classification requests
+     * Specifies if the protocol should be http for classification requests.
      *
-     * @since 2.5-SNAPSHOT
+     * @since 2.6.0
      */
-    public static final String WRITE_CLASSIFIER_HTTPS = "spark.marklogic.write.classifier.https";
+    public static final String WRITE_CLASSIFIER_HTTP = "spark.marklogic.write.classifier.http";
 
     /**
      * Defines the port for classification requests
      *
-     * @since 2.5-SNAPSHOT
+     * @since 2.6.0
      */
     public static final String WRITE_CLASSIFIER_PORT = "spark.marklogic.write.classifier.port";
 
     /**
      * Defines the endpoint for classification requests
      *
-     * @since 2.5-SNAPSHOT
+     * @since 2.6.0
      */
-    public static final String WRITE_CLASSIFIER_ENDPOINT = "spark.marklogic.write.classifier.endpoint";
+    public static final String WRITE_CLASSIFIER_PATH = "spark.marklogic.write.classifier.path";
 
     /**
-     * Defines the endpoint for generating tokens for classification requests
+     * Defines the URL path for generating tokens for classification requests
      *
-     * @since 2.5-SNAPSHOT
+     * @since 2.6.0
      */
-    public static final String WRITE_CLASSIFIER_TOKEN_ENDPOINT = "spark.marklogic.write.classifier.token.endpoint";
+    public static final String WRITE_CLASSIFIER_TOKEN_PATH = "spark.marklogic.write.classifier.tokenPath";
 
     /**
      * Defines the apikey for classification API token requests
      *
-     * @since 2.5-SNAPSHOT
+     * @since 2.6.0
      */
     public static final String WRITE_CLASSIFIER_APIKEY = "spark.marklogic.write.classifier.apikey";
 

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/TextClassifier.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/TextClassifier.java
@@ -4,6 +4,7 @@
 package com.marklogic.spark.core.classifier;
 
 import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Util;
 import com.smartlogic.classificationserver.client.*;
 
 import java.util.HashMap;
@@ -16,6 +17,7 @@ public class TextClassifier {
     private static final String THRESHOLD = "20";
 
     private final ClassificationClient classificationClient;
+    private long totalDurationOfCalls;
 
     public TextClassifier(ClassificationConfiguration classificationConfiguration) {
         this.classificationClient = new ClassificationClient();
@@ -28,7 +30,14 @@ public class TextClassifier {
 
     public byte[] classifyTextToBytes(String sourceUri, String text) {
         try {
-            return classificationClient.getClassificationServerResponse(new Body(text), new Title(sourceUri));
+            long start = System.currentTimeMillis();
+            byte[] response = classificationClient.getClassificationServerResponse(new Body(text), new Title(sourceUri));
+            if (Util.MAIN_LOGGER.isDebugEnabled()) {
+                long time = (System.currentTimeMillis() - start);
+                totalDurationOfCalls += time;
+                Util.MAIN_LOGGER.debug("Source URI: {}; time: {}; total duration: {}", sourceUri, time, totalDurationOfCalls);
+            }
+            return response;
         } catch (ClassificationException e) {
             throw new ConnectorException(String.format("Unable to classify data from document with URI: %s; cause: %s", sourceUri, e.getMessage()), e);
         }

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/TextClassifierFactory.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/TextClassifierFactory.java
@@ -9,7 +9,11 @@ import com.marklogic.spark.Context;
 import com.marklogic.spark.Options;
 import com.marklogic.spark.Util;
 import com.smartlogic.classificationserver.client.ClassificationConfiguration;
+import com.smartlogic.cloud.CloudException;
 import com.smartlogic.cloud.TokenFetcher;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 
 
 public interface TextClassifierFactory {
@@ -17,35 +21,79 @@ public interface TextClassifierFactory {
     static TextClassifier newTextClassifier(Context context) {
         final String host = context.getStringOption(Options.WRITE_CLASSIFIER_HOST);
         if (host != null && host.trim().length() > 0) {
-            if (Util.MAIN_LOGGER.isDebugEnabled()) {
-                Util.MAIN_LOGGER.debug("Will classify text using host: {}",
-                    context.getStringOption(Options.WRITE_CLASSIFIER_HOST));
-            }
             try {
-                final String protocol = context.getBooleanOption(Options.WRITE_CLASSIFIER_HTTPS, true) ? "https" : "http";
-                final int port = context.getIntOption(Options.WRITE_CLASSIFIER_PORT, 443, 0);
-                final String tokenEndpoint = context.getStringOption(Options.WRITE_CLASSIFIER_TOKEN_ENDPOINT, "token/");
-                final String tokenUrl = String.format("%s://%s:%d/%s", protocol, host, port, tokenEndpoint);
-                final String apiKey = context.getStringOption(Options.WRITE_CLASSIFIER_APIKEY);
-
-                ClassificationConfiguration config = new ClassificationConfiguration();
-                TokenFetcher tokenFetcher = new TokenFetcher(tokenUrl, apiKey);
-                config.setApiToken(tokenFetcher.getAccessToken().getAccess_token());
-                config.setHostName(host);
-                config.setHostPort(port);
-                config.setProtocol(protocol);
-                config.setHostPath(context.getStringOption(Options.WRITE_CLASSIFIER_ENDPOINT));
-
-                config.setSingleArticle(false);
-                config.setMultiArticle(true);
-                config.setSocketTimeoutMS(100000);
-                config.setConnectionTimeoutMS(100000);
+                ClassificationConfiguration config = buildClassificationConfiguration(context);
                 return new TextClassifier(config);
             } catch (Exception e) {
                 throw new ConnectorException(String.format("Unable to create a TextClassifier; cause: %s", e.getMessage()));
             }
         } else {
             return null;
+        }
+    }
+
+    private static ClassificationConfiguration buildClassificationConfiguration(Context context) throws MalformedURLException, CloudException {
+        final ConfigHelper configHelper = new ConfigHelper(context);
+        final String apiKey = context.getStringOption(Options.WRITE_CLASSIFIER_APIKEY);
+        if (Util.MAIN_LOGGER.isInfoEnabled()) {
+            Util.MAIN_LOGGER.info("Will classify text via host {}; token URL: {}",
+                configHelper.getHost(), configHelper.getTokenUrl());
+        }
+
+        TokenFetcher tokenFetcher = new TokenFetcher(configHelper.getTokenUrl().toString(), apiKey);
+
+        ClassificationConfiguration config = new ClassificationConfiguration();
+        config.setApiToken(tokenFetcher.getAccessToken().getAccess_token());
+
+        config.setHostName(configHelper.getHost());
+        config.setHostPort(configHelper.getPort());
+        config.setProtocol(configHelper.getProtocol());
+        config.setHostPath(configHelper.getClassifierPath());
+
+        return config;
+    }
+
+    class ConfigHelper {
+        private final String host;
+        private final int port;
+        private final String protocol;
+        private final String classifierPath;
+        private final URL tokenUrl;
+
+        public ConfigHelper(Context context) throws MalformedURLException {
+            this.host = context.getStringOption(Options.WRITE_CLASSIFIER_HOST);
+            this.port = context.getIntOption(Options.WRITE_CLASSIFIER_PORT, 443, 0);
+            this.protocol = "true".equalsIgnoreCase(context.getStringOption(Options.WRITE_CLASSIFIER_HTTP)) ? "http" : "https";
+            this.classifierPath = fixPath(context.getStringOption(Options.WRITE_CLASSIFIER_PATH));
+            String tokenEndpoint = fixPath(context.getStringOption(Options.WRITE_CLASSIFIER_TOKEN_PATH, "/token"));
+            this.tokenUrl = new URL(protocol, host, port, tokenEndpoint);
+        }
+
+        public URL getTokenUrl() {
+            return this.tokenUrl;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public String getProtocol() {
+            return protocol;
+        }
+
+        public String getClassifierPath() {
+            return classifierPath;
+        }
+
+        private String fixPath(String path) {
+            if (path == null) {
+                return null;
+            }
+            return path.startsWith("/") ? path : "/" + path;
         }
     }
 }

--- a/tests/src/test/java/com/marklogic/spark/writer/classifier/AddClassificationToJsonTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/classifier/AddClassificationToJsonTest.java
@@ -122,6 +122,6 @@ class AddClassificationToJsonTest extends AbstractIntegrationTest {
             // Use minimal options for this test to verify that default protocol/port/tokenEndpoint are used.
             .option(Options.WRITE_CLASSIFIER_APIKEY, API_KEY)
             .option(Options.WRITE_CLASSIFIER_HOST, "demo.data.progress.cloud")
-            .option(Options.WRITE_CLASSIFIER_ENDPOINT, "/cls/dev/cs1/");
+            .option(Options.WRITE_CLASSIFIER_PATH, "/cls/dev/cs1/");
     }
 }

--- a/tests/src/test/java/com/marklogic/spark/writer/classifier/AddClassificationToXmlTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/classifier/AddClassificationToXmlTest.java
@@ -73,7 +73,7 @@ class AddClassificationToXmlTest extends AbstractIntegrationTest {
     @EnabledIfEnvironmentVariable(named = "SEMAPHORE_API_KEY", matches = ".*")
     void noHttpsSpecifiedShouldDefaultToHttpAndFail() {
         DataFrameWriter writer = readAndStartWrite()
-            .option(Options.WRITE_CLASSIFIER_HTTPS, false)
+            .option(Options.WRITE_CLASSIFIER_HTTP, true)
             .mode(SaveMode.Append);
 
         ConnectorException exception = assertThrowsConnectorException(writer::save);
@@ -106,10 +106,15 @@ class AddClassificationToXmlTest extends AbstractIntegrationTest {
             .option(Options.WRITE_URI_TEMPLATE, "/split-test.xml")
             .option(Options.WRITE_CLASSIFIER_APIKEY, API_KEY)
             .option(Options.WRITE_CLASSIFIER_HOST, "demo.data.progress.cloud")
-            .option(Options.WRITE_CLASSIFIER_ENDPOINT, "/cls/dev/cs1/")
-            .option(Options.WRITE_CLASSIFIER_TOKEN_ENDPOINT, "token/")
+
+            // Use paths that don't begin with a "/", to further ensure that a "/" is added automatically.
+            .option(Options.WRITE_CLASSIFIER_PATH, "cls/dev/cs1")
+            .option(Options.WRITE_CLASSIFIER_TOKEN_PATH, "token")
+
+            // Defining these properties, even though they use the default values, just to get a little more
+            // coverage with them.
             .option(Options.WRITE_CLASSIFIER_PORT, 443)
-            .option(Options.WRITE_CLASSIFIER_HTTPS, true);
+            .option(Options.WRITE_CLASSIFIER_HTTP, false);
     }
 
     private Dataset<Row> readDocument(String uri) {

--- a/tests/src/test/java/com/marklogic/spark/writer/classifier/ConfigHelperTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/classifier/ConfigHelperTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.classifier;
+
+import com.marklogic.spark.Context;
+import com.marklogic.spark.Options;
+import com.marklogic.spark.core.classifier.TextClassifierFactory;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ConfigHelperTest {
+
+    @Test
+    void fixPaths() throws Exception {
+        Map<String, String> properties = new HashMap<>() {{
+            put(Options.WRITE_CLASSIFIER_HOST, "somehost");
+            put(Options.WRITE_CLASSIFIER_PATH, "classifier");
+            put(Options.WRITE_CLASSIFIER_TOKEN_PATH, "tokenPath");
+        }};
+
+        TextClassifierFactory.ConfigHelper helper = new TextClassifierFactory.ConfigHelper(new Context(properties));
+        assertEquals("/classifier", helper.getClassifierPath(), "To ensure a valid URL, the helper should " +
+            "prepend a forward slash when one does not exist.");
+        assertEquals(443, helper.getPort(), "Should default to 443");
+        assertEquals("https", helper.getProtocol(), "Should default to https");
+
+        URL tokenUrl = helper.getTokenUrl();
+        assertEquals("https://somehost:443/tokenPath", tokenUrl.toString(), "The token path should have a " +
+            "forward slash prepended when one does not exist.");
+    }
+}


### PR DESCRIPTION
Also renamed from "endpoint" to "path" for alignment with the S4 config class and the Java URL class.

Added some debug logging as well.
