### PR TITLE
Fixed bug with extracted text permissions

### DIFF
--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/WriteContext.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/WriteContext.java
@@ -128,12 +128,13 @@ public class WriteContext extends ContextSupport {
     }
 
     DocBuilder newDocBuilder() {
+        final String permissions = getStringOption(Options.WRITE_PERMISSIONS);
         DocBuilderFactory factory = new DocBuilderFactory()
             .withCollections(getStringOption(Options.WRITE_COLLECTIONS))
-            .withPermissions(getStringOption(Options.WRITE_PERMISSIONS))
+            .withPermissions(permissions)
             .withExtractedTextDocumentType(getStringOption(Options.WRITE_EXTRACTED_TEXT_DOCUMENT_TYPE, "json"))
             .withExtractedTextCollections(getStringOption(Options.WRITE_EXTRACTED_TEXT_COLLECTIONS))
-            .withExtractedTextPermissions(getStringOption(Options.WRITE_EXTRACTED_TEXT_PERMISSIONS))
+            .withExtractedTextPermissions(getStringOption(Options.WRITE_EXTRACTED_TEXT_PERMISSIONS, permissions))
             .withExtractedTextDropSource(getBooleanOption(Options.WRITE_EXTRACTED_TEXT_DROP_SOURCE, false))
             .withChunkAssembler(ChunkAssemblerFactory.makeChunkAssembler(this));
 

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -43,8 +43,7 @@ dependencies {
   testImplementation "org.skyscreamer:jsonassert:1.5.1"
 
   // Adding these to test the Tika UDF. Flux will include these as well in its distribution.
-  testImplementation "org.apache.tika:tika-parser-microsoft-module:3.0.0"
-  testImplementation "org.apache.tika:tika-parser-pdf-module:3.0.0"
+  testImplementation "org.apache.tika:tika-parsers:3.0.0"
 }
 
 test {


### PR DESCRIPTION
The regular permissions are now inherited when user specifies collections but not permissions for extracted text doc.
