### PR TITLE
Classifier tests now use a mock

### DIFF
--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/DocumentProcessor.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/DocumentProcessor.java
@@ -92,11 +92,11 @@ public class DocumentProcessor {
         // whether this happens or not.
         final String uri = inputs.getInitialUri();
         if (inputs.getExtractedText() != null) {
-            byte[] classification = textClassifier.classifyTextToBytes(uri, inputs.getExtractedText());
+            byte[] classification = textClassifier.classifyText(uri, inputs.getExtractedText());
             inputs.setClassificationResponse(classification);
         } else {
             String content = HandleAccessor.contentAsString(inputs.getContent());
-            byte[] classification = textClassifier.classifyTextToBytes(uri, content);
+            byte[] classification = textClassifier.classifyText(uri, content);
             inputs.setClassificationResponse(classification);
         }
     }
@@ -120,7 +120,7 @@ public class DocumentProcessor {
     private void classifyChunks(DocumentInputs inputs) {
         List<byte[]> classifications = new ArrayList<>();
         for (String chunk : inputs.getChunks()) {
-            byte[] result = textClassifier.classifyTextToBytes(inputs.getInitialUri(), chunk);
+            byte[] result = textClassifier.classifyText(inputs.getInitialUri(), chunk);
             classifications.add(result);
         }
         inputs.setClassifications(classifications);

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/SemaphoreTextClassifier.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/SemaphoreTextClassifier.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.core.classifier;
+
+import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Util;
+import com.smartlogic.classificationserver.client.*;
+
+class SemaphoreTextClassifier implements TextClassifier {
+
+    private final ClassificationClient classificationClient;
+    private long totalDurationOfCalls;
+
+    SemaphoreTextClassifier(ClassificationConfiguration classificationConfiguration) {
+        this.classificationClient = new ClassificationClient();
+        classificationClient.setClassificationConfiguration(classificationConfiguration);
+    }
+
+    @Override
+    public byte[] classifyText(String sourceUri, String text) {
+        try {
+            long start = System.currentTimeMillis();
+            byte[] response = classificationClient.getClassificationServerResponse(new Body(text), new Title(sourceUri));
+            if (Util.MAIN_LOGGER.isDebugEnabled()) {
+                long time = (System.currentTimeMillis() - start);
+                totalDurationOfCalls += time;
+                Util.MAIN_LOGGER.debug("Source URI: {}; time: {}; total duration: {}", sourceUri, time, totalDurationOfCalls);
+            }
+            return response;
+        } catch (ClassificationException e) {
+            throw new ConnectorException(String.format("Unable to classify data from document with URI: %s; cause: %s", sourceUri, e.getMessage()), e);
+        }
+    }
+}

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/SemaphoreUtil.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/SemaphoreUtil.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.core.classifier;
+
+public abstract class SemaphoreUtil {
+
+    public static final String CLASSIFICATION_MAIN_ELEMENT = "STRUCTUREDDOCUMENT";
+
+    private SemaphoreUtil() {
+    }
+}

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/TextClassifier.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/TextClassifier.java
@@ -3,43 +3,8 @@
  */
 package com.marklogic.spark.core.classifier;
 
-import com.marklogic.spark.ConnectorException;
-import com.marklogic.spark.Util;
-import com.smartlogic.classificationserver.client.*;
+public interface TextClassifier {
 
-import java.util.HashMap;
-import java.util.Map;
+    byte[] classifyText(String sourceUri, String text);
 
-public class TextClassifier {
-
-    public static final String CLASSIFICATION_MAIN_ELEMENT = "STRUCTUREDDOCUMENT";
-
-    private static final String THRESHOLD = "20";
-
-    private final ClassificationClient classificationClient;
-    private long totalDurationOfCalls;
-
-    public TextClassifier(ClassificationConfiguration classificationConfiguration) {
-        this.classificationClient = new ClassificationClient();
-        Map<String, String> additionalParameters = new HashMap<>();
-        additionalParameters.put("threshold", THRESHOLD);
-        additionalParameters.put("language", "en1");
-        classificationConfiguration.setAdditionalParameters(additionalParameters);
-        classificationClient.setClassificationConfiguration(classificationConfiguration);
-    }
-
-    public byte[] classifyTextToBytes(String sourceUri, String text) {
-        try {
-            long start = System.currentTimeMillis();
-            byte[] response = classificationClient.getClassificationServerResponse(new Body(text), new Title(sourceUri));
-            if (Util.MAIN_LOGGER.isDebugEnabled()) {
-                long time = (System.currentTimeMillis() - start);
-                totalDurationOfCalls += time;
-                Util.MAIN_LOGGER.debug("Source URI: {}; time: {}; total duration: {}", sourceUri, time, totalDurationOfCalls);
-            }
-            return response;
-        } catch (ClassificationException e) {
-            throw new ConnectorException(String.format("Unable to classify data from document with URI: %s; cause: %s", sourceUri, e.getMessage()), e);
-        }
-    }
 }

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/splitter/JsonChunkDocumentProducer.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/splitter/JsonChunkDocumentProducer.java
@@ -13,11 +13,11 @@ import com.marklogic.client.impl.DocumentWriteOperationImpl;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
-import com.marklogic.spark.core.classifier.TextClassifier;
+import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.core.classifier.SemaphoreUtil;
 import com.marklogic.spark.core.embedding.Chunk;
 import com.marklogic.spark.core.embedding.DocumentAndChunks;
 import com.marklogic.spark.core.embedding.JsonChunk;
-import com.marklogic.spark.ConnectorException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -51,7 +51,8 @@ class JsonChunkDocumentProducer extends AbstractChunkDocumentProducer {
             chunk.put("text", text);
             if (classifications != null && !classifications.isEmpty()) {
                 try {
-                    JsonNode classificationNode = xmlMapper.readTree(classifications.get(ct.getAndIncrement())).get(TextClassifier.CLASSIFICATION_MAIN_ELEMENT);
+                    JsonNode classificationNode = xmlMapper.readTree(classifications.get(ct.getAndIncrement()))
+                        .get(SemaphoreUtil.CLASSIFICATION_MAIN_ELEMENT);
                     chunk.set("classification", classificationNode);
                 } catch (IOException e) {
                     throw new ConnectorException(String.format("Unable to classify data from document with URI: %s; cause: %s", sourceDocument.getUri(), e.getMessage()), e);
@@ -85,7 +86,8 @@ class JsonChunkDocumentProducer extends AbstractChunkDocumentProducer {
             chunk.put("text", text);
             if (classifications != null) {
                 try {
-                    JsonNode classificationNode = xmlMapper.readTree(classifications.get(ct.getAndIncrement())).get(TextClassifier.CLASSIFICATION_MAIN_ELEMENT);
+                    JsonNode classificationNode = xmlMapper.readTree(classifications.get(ct.getAndIncrement()))
+                        .get(SemaphoreUtil.CLASSIFICATION_MAIN_ELEMENT);
                     chunk.set("classification", classificationNode);
                 } catch (IOException e) {
                     throw new ConnectorException(String.format("Unable to classify data from document with URI: %s; cause: %s", uri, e.getMessage()), e);

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/splitter/XmlChunkDocumentProducer.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/splitter/XmlChunkDocumentProducer.java
@@ -7,13 +7,13 @@ import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.impl.DocumentWriteOperationImpl;
 import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.io.Format;
-import com.marklogic.spark.core.classifier.TextClassifier;
+import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Util;
+import com.marklogic.spark.core.classifier.SemaphoreUtil;
 import com.marklogic.spark.core.embedding.Chunk;
 import com.marklogic.spark.core.embedding.DOMChunk;
 import com.marklogic.spark.core.embedding.DocumentAndChunks;
 import com.marklogic.spark.core.embedding.XmlChunkConfig;
-import com.marklogic.spark.ConnectorException;
-import com.marklogic.spark.Util;
 import com.marklogic.spark.dom.DOMHelper;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -119,7 +119,7 @@ class XmlChunkDocumentProducer extends AbstractChunkDocumentProducer {
         chunk.appendChild(text);
         if (classificationReponseNode != null) {
             Node classificationNode = doc.createElement("classification");
-            NodeList structuredDocumentNodeChildNodes = classificationReponseNode.getElementsByTagName(TextClassifier.CLASSIFICATION_MAIN_ELEMENT).item(0).getChildNodes();
+            NodeList structuredDocumentNodeChildNodes = classificationReponseNode.getElementsByTagName(SemaphoreUtil.CLASSIFICATION_MAIN_ELEMENT).item(0).getChildNodes();
             for (int i = 0; i < structuredDocumentNodeChildNodes.getLength(); i++) {
                 Node importedChildNode = doc.importNode(structuredDocumentNodeChildNodes.item(i), true);
                 classificationNode.appendChild(importedChildNode);

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilder.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilder.java
@@ -17,6 +17,7 @@ import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Util;
 import com.marklogic.spark.core.DocumentInputs;
+import com.marklogic.spark.core.classifier.SemaphoreUtil;
 import com.marklogic.spark.core.embedding.Chunk;
 import com.marklogic.spark.core.embedding.DocumentAndChunks;
 import com.marklogic.spark.core.splitter.ChunkAssembler;
@@ -39,8 +40,6 @@ import java.util.*;
  * of the schema of the Spark row.
  */
 public class DocBuilder {
-
-    private static final String CLASSIFICATION_MAIN_ELEMENT = "STRUCTUREDDOCUMENT";
 
     public interface UriMaker {
         String makeURI(String initialUri, JsonNode uriTemplateValues);
@@ -143,7 +142,7 @@ public class DocBuilder {
         JsonNode originalJsonContent, String uri, byte[] classificationResponse
     ) {
         try {
-            JsonNode structuredDocumentNode = xmlMapper.readTree(classificationResponse).get(CLASSIFICATION_MAIN_ELEMENT);
+            JsonNode structuredDocumentNode = xmlMapper.readTree(classificationResponse).get(SemaphoreUtil.CLASSIFICATION_MAIN_ELEMENT);
             ((ObjectNode) originalJsonContent).set("classification", structuredDocumentNode);
             return new JacksonHandle(originalJsonContent);
         } catch (IOException e) {
@@ -159,7 +158,7 @@ public class DocBuilder {
             DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
             Document responseDoc = builder.parse(new ByteArrayInputStream(classificationResponse));
 
-            NodeList structuredDocumentNodeChildNodes = responseDoc.getElementsByTagName(CLASSIFICATION_MAIN_ELEMENT).item(0).getChildNodes();
+            NodeList structuredDocumentNodeChildNodes = responseDoc.getElementsByTagName(SemaphoreUtil.CLASSIFICATION_MAIN_ELEMENT).item(0).getChildNodes();
             Node classificationNode = originalDoc.createElementNS(com.marklogic.spark.Util.DEFAULT_XML_NAMESPACE, "classification");
             for (int i = 0; i < structuredDocumentNodeChildNodes.getLength(); i++) {
                 Node importedChildNode = originalDoc.importNode(structuredDocumentNodeChildNodes.item(i), true);

--- a/tests/src/test/java/com/marklogic/spark/writer/classifier/AddClassificationToJsonTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/classifier/AddClassificationToJsonTest.java
@@ -10,20 +10,23 @@ import org.apache.spark.sql.DataFrameWriter;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class AddClassificationToJsonTest extends AbstractIntegrationTest {
 
-    private static final String API_KEY = System.getenv("SEMAPHORE_API_KEY");
-
     @Test
-    @EnabledIfEnvironmentVariable(named = "SEMAPHORE_API_KEY", matches = ".*")
     void chunkAndAddClassificationToJsonInOriginalJsonDoc() {
         readAndStartWrite()
+            .option(ClassifierTestUtil.MOCK_RESPONSE_OPTION, ClassifierTestUtil.MOCK_RESPONSE)
+
+            // These will be ignored because the mock response option is used. But to test S4 for real, you can comment
+            // out the line above that enables use of the mock classifier and populate the below environment variable.
+            .option(Options.WRITE_CLASSIFIER_APIKEY, System.getenv("SEMAPHORE_API_KEY"))
+            .option(Options.WRITE_CLASSIFIER_HOST, "demo.data.progress.cloud")
+            .option(Options.WRITE_CLASSIFIER_PATH, "/cls/dev/cs1/")
+
             .option(Options.WRITE_SPLITTER_JSON_POINTERS, "/text\n/more-text")
             .mode(SaveMode.Append)
             .save();
@@ -38,9 +41,9 @@ class AddClassificationToJsonTest extends AbstractIntegrationTest {
      * as part of one write process.
      */
     @Test
-    @EnabledIfEnvironmentVariable(named = "SEMAPHORE_API_KEY", matches = ".*")
     void sidecarChunksAddClassificationToJson() {
         readAndStartWrite()
+            .option(ClassifierTestUtil.MOCK_RESPONSE_OPTION, ClassifierTestUtil.MOCK_RESPONSE)
             .option(Options.WRITE_SPLITTER_JSON_POINTERS, "/text\n/more-text")
             .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 3)
             .option(Options.WRITE_SPLITTER_SIDECAR_COLLECTIONS, "chunks")
@@ -61,7 +64,6 @@ class AddClassificationToJsonTest extends AbstractIntegrationTest {
     @Test
     void noClassificationAddedToJsonWhenNoSemaphoreServerSpecified() {
         readAndStartWrite()
-            .option(Options.WRITE_CLASSIFIER_HOST, "")
             .option(Options.WRITE_SPLITTER_JSON_POINTERS, "/text")
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
             .option(Options.WRITE_SPLITTER_SIDECAR_MAX_CHUNKS, 2)
@@ -75,9 +77,9 @@ class AddClassificationToJsonTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledIfEnvironmentVariable(named = "SEMAPHORE_API_KEY", matches = ".*")
     void classifyJsonContentsWithoutChunking() {
         readAndStartWrite()
+            .option(ClassifierTestUtil.MOCK_RESPONSE_OPTION, ClassifierTestUtil.MOCK_RESPONSE)
             .mode(SaveMode.Append)
             .save();
 
@@ -87,9 +89,9 @@ class AddClassificationToJsonTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledIfEnvironmentVariable(named = "SEMAPHORE_API_KEY", matches = ".*")
     void chunkAndAddClassificationOnlyToChunksInOriginalDoc() {
         readAndStartWrite()
+            .option(ClassifierTestUtil.MOCK_RESPONSE_OPTION, ClassifierTestUtil.MOCK_RESPONSE)
             .option(Options.WRITE_SPLITTER_JSON_POINTERS, "/text\n/more-text")
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 500)
             .mode(SaveMode.Append)
@@ -97,12 +99,6 @@ class AddClassificationToJsonTest extends AbstractIntegrationTest {
 
         JsonNode doc = readJsonDocument("/split-test.json");
         assertEquals(4, doc.get("chunks").size(), "Expecting 4 chunks based on max chunk size of 500.");
-    }
-
-    @Test
-    @Disabled("Placeholder for a future test for data that is not UTF-8")
-    void classifyNonUtf8JsonData() {
-        assertTrue(true);
     }
 
     private Dataset<Row> readDocument(String uri) {
@@ -117,11 +113,6 @@ class AddClassificationToJsonTest extends AbstractIntegrationTest {
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
-            .option(Options.WRITE_URI_TEMPLATE, "/split-test.json")
-
-            // Use minimal options for this test to verify that default protocol/port/tokenEndpoint are used.
-            .option(Options.WRITE_CLASSIFIER_APIKEY, API_KEY)
-            .option(Options.WRITE_CLASSIFIER_HOST, "demo.data.progress.cloud")
-            .option(Options.WRITE_CLASSIFIER_PATH, "/cls/dev/cs1/");
+            .option(Options.WRITE_URI_TEMPLATE, "/split-test.json");
     }
 }

--- a/tests/src/test/java/com/marklogic/spark/writer/classifier/ClassifierTestUtil.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/classifier/ClassifierTestUtil.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.writer.classifier;
+
+public interface ClassifierTestUtil {
+
+    String MOCK_RESPONSE_OPTION = "spark.marklogic.testing.mockClassifierResponse";
+
+    String MOCK_RESPONSE = """
+        <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+        <response>
+          <STRUCTUREDDOCUMENT>
+          <URL>../tmp/ca002056-e3f6-4c81-8c9f-00ca218330c4/1739460469_43eb</URL>
+          <SYSTEM name=\"HASH\" value=\"2c3bcaf41fbabf8ff2e236c7580893ec\"/>
+          <META name=\"Type\" value=\"TEXT (4003)\"/>
+          <META name=\"title/document_title\" value=\"/some-uri.xml\"/>
+          <SYSTEM name=\"Template\" value=\"default\"/>
+          <ARTICLE>
+           <SYSTEM name=\"DeterminedLanguage\" value=\"english\"/>
+           <SYSTEM name=\"LanguageGuessed\" value=\"no\"/>
+          </ARTICLE>
+         </STRUCTUREDDOCUMENT>
+        </response>""";
+}

--- a/tests/src/test/java/com/marklogic/spark/writer/classifier/ConfigHelperTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/classifier/ConfigHelperTest.java
@@ -6,6 +6,7 @@ package com.marklogic.spark.writer.classifier;
 import com.marklogic.spark.Context;
 import com.marklogic.spark.Options;
 import com.marklogic.spark.core.classifier.TextClassifierFactory;
+import com.smartlogic.classificationserver.client.ClassificationConfiguration;
 import org.junit.jupiter.api.Test;
 
 import java.net.URL;
@@ -25,13 +26,44 @@ class ConfigHelperTest {
         }};
 
         TextClassifierFactory.ConfigHelper helper = new TextClassifierFactory.ConfigHelper(new Context(properties));
-        assertEquals("/classifier", helper.getClassifierPath(), "To ensure a valid URL, the helper should " +
+        ClassificationConfiguration config = helper.buildClassificationConfiguration("fake-api-token");
+        assertEquals("somehost", config.getHostName());
+        assertEquals("/classifier", config.getHostPath(), "To ensure a valid URL, the helper should " +
             "prepend a forward slash when one does not exist.");
-        assertEquals(443, helper.getPort(), "Should default to 443");
-        assertEquals("https", helper.getProtocol(), "Should default to https");
+        assertEquals(443, config.getHostPort(), "Should default to 443");
+        assertEquals("https", config.getProtocol(), "Should default to https");
 
         URL tokenUrl = helper.getTokenUrl();
         assertEquals("https://somehost:443/tokenPath", tokenUrl.toString(), "The token path should have a " +
             "forward slash prepended when one does not exist.");
+    }
+
+    @Test
+    void defaultValues() throws Exception {
+        Map<String, String> properties = new HashMap<>() {{
+            put(Options.WRITE_CLASSIFIER_HOST, "somehost");
+            put(Options.WRITE_CLASSIFIER_PATH, "/classifier");
+        }};
+
+        TextClassifierFactory.ConfigHelper helper = new TextClassifierFactory.ConfigHelper(new Context(properties));
+        ClassificationConfiguration config = helper.buildClassificationConfiguration("fake-api-token");
+        assertEquals("https://somehost:443/classifier", config.getUrl());
+        assertEquals("https://somehost:443/token", helper.getTokenUrl().toString());
+    }
+
+    @Test
+    void overrideAllValues() throws Exception {
+        Map<String, String> properties = new HashMap<>() {{
+            put(Options.WRITE_CLASSIFIER_HOST, "somehost");
+            put(Options.WRITE_CLASSIFIER_PATH, "/classifier");
+            put(Options.WRITE_CLASSIFIER_PORT, "8080");
+            put(Options.WRITE_CLASSIFIER_TOKEN_PATH, "my-token");
+            put(Options.WRITE_CLASSIFIER_HTTP, "true");
+        }};
+
+        TextClassifierFactory.ConfigHelper helper = new TextClassifierFactory.ConfigHelper(new Context(properties));
+        ClassificationConfiguration config = helper.buildClassificationConfiguration("fake-api-token");
+        assertEquals("http://somehost:8080/classifier", config.getUrl());
+        assertEquals("http://somehost:8080/my-token", helper.getTokenUrl().toString());
     }
 }


### PR DESCRIPTION
Turned TextClassifier into an interface to support this, with SemaphoreTextClassifier having the goods in it now. Added a few more S4 config tests to ensure we build a connection correctly, as none of the tests now depend on an active S4 connection. A couple tests still have the "live" options for easy manual testing though.

Removed the two disabled UTF-8 tests as we no longer have any code that constructs a String from bytes.
