### PR TITLE
Refactor: Overhauling how batching works for document processing

### DIFF
--- a/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/embedding/EmbeddingGenerator.java
+++ b/marklogic-langchain4j/src/main/java/com/marklogic/langchain4j/embedding/EmbeddingGenerator.java
@@ -4,7 +4,7 @@
 package com.marklogic.langchain4j.embedding;
 
 import com.marklogic.spark.Util;
-import com.marklogic.spark.core.DocumentInputs;
+import com.marklogic.spark.core.embedding.Chunk;
 import com.marklogic.spark.core.embedding.EmbeddingProducer;
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
@@ -32,71 +32,36 @@ public class EmbeddingGenerator implements EmbeddingProducer {
     private static final AtomicLong tokenCount = new AtomicLong(0);
     private static final AtomicLong requestCount = new AtomicLong(0);
 
-    private List<DocumentInputs> pendingInputs = new ArrayList<>();
-
     public EmbeddingGenerator(EmbeddingModel embeddingModel, int batchSize) {
         this.embeddingModel = embeddingModel;
         this.batchSize = batchSize;
     }
 
     @Override
-    public List<DocumentInputs> produceEmbeddings(DocumentInputs newInputs) {
-        final List<DocumentInputs> inputsToReturn = new ArrayList<>();
-        final List<float[]> embeddingsForNewInputs = new ArrayList<>();
-
-        final List<TextSegment> textSegments = collectPendingChunks();
-        // Start adding chunks from the new inputs until we have enough to meet embedder batch size.
-        boolean generatedEmbeddingsAtLeastOnce = false;
-        for (String chunk : newInputs.getTextSegmentsToGenerateEmbeddings()) {
-            textSegments.add(new TextSegment(chunk, TEXT_SEGMENT_METADATA));
-            if (textSegments.size() >= batchSize) {
-                List<Embedding> embeddings = generateEmbeddings(textSegments);
-                assignEmbeddings(embeddings, embeddingsForNewInputs);
-                textSegments.clear();
-
-                if (!generatedEmbeddingsAtLeastOnce) {
-                    generatedEmbeddingsAtLeastOnce = true;
-                    // We know we're done with the pending inputs, so add them as inputs to return and clear out the list.
-                    inputsToReturn.addAll(pendingInputs);
-                    pendingInputs.clear();
-                }
+    public void addEmbeddings(List<Chunk> chunks) {
+        List<TextSegment> segments = new ArrayList<>();
+        int chunkCounter = 0;
+        for (Chunk chunk : chunks) {
+            segments.add(new TextSegment(chunk.getEmbeddingText(), TEXT_SEGMENT_METADATA));
+            if (segments.size() >= batchSize) {
+                chunkCounter = generateAndAddEmbeddings(segments, chunks, chunkCounter);
+                segments.clear();
             }
         }
 
-        // If we have at least one document to return, that means we sent at least 1 of the chunks in newInputs.
-        // We don't want to leave newInputs in a partial state, so we flush the rest of the text segments.
-        if (generatedEmbeddingsAtLeastOnce) {
-            if (!textSegments.isEmpty()) {
-                List<Embedding> embeddings = generateEmbeddings(textSegments);
-                assignEmbeddings(embeddings, embeddingsForNewInputs);
-            }
-            newInputs.setGeneratedEmbeddings(embeddingsForNewInputs);
-            inputsToReturn.add(newInputs);
-        } else {
-            // We didn't send anything to the embedding model, so add the new inputs to the list of pending inputs.
-            pendingInputs.add(newInputs);
+        if (!segments.isEmpty()) {
+            generateAndAddEmbeddings(segments, chunks, chunkCounter);
         }
-
-        return inputsToReturn;
     }
 
-    @Override
-    public List<DocumentInputs> flush() {
-        List<DocumentInputs> inputsToReturn = new ArrayList<>();
-        if (pendingInputs.isEmpty()) {
-            return inputsToReturn;
+    private int generateAndAddEmbeddings(List<TextSegment> segments, List<Chunk> chunks, int chunkCounter) {
+        List<Embedding> embeddings = generateEmbeddings(segments);
+        for (int i = 0; i < embeddings.size(); i++) {
+            Embedding embedding = embeddings.get(i);
+            chunks.get(chunkCounter).addEmbedding(embedding.vector());
+            chunkCounter++;
         }
-
-        List<TextSegment> textSegments = collectPendingChunks();
-        if (!textSegments.isEmpty()) {
-            List<Embedding> embeddings = generateEmbeddings(textSegments);
-            assignEmbeddings(embeddings, null);
-        }
-
-        inputsToReturn.addAll(pendingInputs);
-        pendingInputs.clear();
-
-        return inputsToReturn;
+        return chunkCounter;
     }
 
     private List<Embedding> generateEmbeddings(List<TextSegment> textSegments) {
@@ -106,35 +71,6 @@ public class EmbeddingGenerator implements EmbeddingProducer {
         Response<List<Embedding>> response = embeddingModel.embedAll(textSegments);
         logResponse(response, textSegments);
         return response.content();
-    }
-
-    private void assignEmbeddings(List<Embedding> embeddings, List<float[]> embeddingsForNewInputs) {
-        int embeddingCounter = 0;
-        // Assign embeddings to the pending inputs first.
-        for (DocumentInputs pendingInput : pendingInputs) {
-            int chunkCount = pendingInput.getTextSegmentsToGenerateEmbeddings().size();
-            List<float[]> embeddingsForPendingInput = new ArrayList<>(chunkCount);
-            for (; embeddingCounter < embeddings.size(); embeddingCounter++) {
-                embeddingsForPendingInput.add(embeddings.get(embeddingCounter).vector());
-            }
-            pendingInput.setGeneratedEmbeddings(embeddingsForPendingInput);
-        }
-
-        // Any remaining embeddings should go into the ones for the newInputs.
-        for (; embeddingCounter < embeddings.size(); embeddingCounter++) {
-            embeddingsForNewInputs.add(embeddings.get(embeddingCounter).vector());
-        }
-    }
-
-    // Probably want to cache this as well.
-    private List<TextSegment> collectPendingChunks() {
-        List<TextSegment> textSegments = new ArrayList<>();
-        for (DocumentInputs pendingInput : pendingInputs) {
-            for (String chunk : pendingInput.getTextSegmentsToGenerateEmbeddings()) {
-                textSegments.add(new TextSegment(chunk, TEXT_SEGMENT_METADATA));
-            }
-        }
-        return textSegments;
     }
 
     private void logResponse(Response<List<Embedding>> response, List<TextSegment> textSegments) {

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/Options.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/Options.java
@@ -407,6 +407,9 @@ public abstract class Options {
      */
     public static final String WRITE_EMBEDDER_BATCH_SIZE = WRITE_EMBEDDER_PREFIX + "batchSize";
 
+    // Temporary, likely to change in next PR.
+    public static final String WRITE_PROCESSOR_BATCH_SIZE = "spark.marklogic.write.processor.batchSize";
+
     /**
      * Defines the host for classification requests
      *

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/DocumentProcessor.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/DocumentProcessor.java
@@ -7,6 +7,7 @@ import com.marklogic.client.impl.HandleAccessor;
 import com.marklogic.client.io.BytesHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.spark.core.classifier.TextClassifier;
+import com.marklogic.spark.core.embedding.Chunk;
 import com.marklogic.spark.core.embedding.ChunkSelector;
 import com.marklogic.spark.core.embedding.DocumentAndChunks;
 import com.marklogic.spark.core.embedding.EmbeddingProducer;
@@ -17,9 +18,7 @@ import com.marklogic.spark.core.splitter.TextSplitter;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Handles "processing" a document, which involves receiving a {@code DocumentInputs} instance, enriching it,
@@ -49,40 +48,135 @@ public class DocumentProcessor implements Closeable {
         }
     }
 
-    public Optional<List<DocumentInputs>> flush() {
-        if (embeddingProducer != null) {
-            return Optional.of(embeddingProducer.flush());
+    public List<DocumentInputs> batchProcessDocuments(List<DocumentInputs> inputs) {
+        if (textExtractor != null) {
+            inputs.stream().filter(input -> input.getContent() instanceof BytesHandle).forEach(this::extractText);
         }
-        return Optional.empty();
-    }
 
-    public List<DocumentInputs> processDocument(DocumentInputs inputs) {
-        // There's no getInputStream() on an AbstractWriteHandle. As our main use case so far involves reading
-        // files, which are read into a BytesHandle, we check for a BytesHandle and only perform text extraction on that
-        // for now.
-        if (textExtractor != null && inputs.getContent() instanceof BytesHandle) {
-            extractText(inputs);
-        }
         if (textSplitter != null) {
-            applySplitter(inputs);
+            inputs.forEach(this::applySplitter);
         }
+
         if (textClassifier != null) {
             classifyText(inputs);
         }
 
         if (embeddingProducer != null) {
-            if (inputs.getChunks() != null && !inputs.getChunks().isEmpty()) {
-                return embeddingProducer.produceEmbeddings(inputs);
-            } else if (chunkSelector != null) {
-                DocumentAndChunks documentAndChunks = chunkSelector.selectChunks(inputs.getInitialUri(), inputs.getContent());
-                if (documentAndChunks != null && documentAndChunks.hasChunks()) {
-                    inputs.setContentAndExistingChunks(documentAndChunks);
-                    return embeddingProducer.produceEmbeddings(inputs);
+            addEmbeddings(inputs);
+        }
+
+        return inputs;
+    }
+
+    private void classifyText(List<DocumentInputs> inputs) {
+        List<TextClassifier.ClassifiableContent> contents = new ArrayList<>();
+        for (DocumentInputs input : inputs) {
+            // Not sure if we'll keep this behavior, where we always classify the document, even if it has chunks.
+            contents.add(new ClassifiableDocument(input));
+            if (input.getChunks() != null && !input.getChunks().isEmpty()) {
+                for (int i = 0; i < input.getChunks().size(); i++) {
+                    contents.add(new ClassifiableChunk(input, i));
                 }
             }
         }
+        textClassifier.classifyText(contents);
+    }
 
-        return Arrays.asList(inputs);
+    private void addEmbeddings(List<DocumentInputs> inputs) {
+        List<Chunk> chunks = new ArrayList<>();
+        for (DocumentInputs input : inputs) {
+            if (input.getChunks() != null && !input.getChunks().isEmpty()) {
+                for (int i = 0; i < input.getChunks().size(); i++) {
+                    chunks.add(new EmbeddableChunk(input, i));
+                }
+            } else if (chunkSelector != null) {
+                DocumentAndChunks documentAndChunks = chunkSelector.selectChunks(input.getInitialUri(), input.getContent());
+                if (documentAndChunks != null && documentAndChunks.hasChunks()) {
+                    input.overrideContent(documentAndChunks.getContent());
+                    documentAndChunks.getChunks().forEach(chunks::add);
+                }
+            }
+        }
+        if (!chunks.isEmpty()) {
+            embeddingProducer.addEmbeddings(chunks);
+        }
+    }
+
+    private static class EmbeddableChunk implements Chunk {
+        private final DocumentInputs inputs;
+        private final int chunkIndex;
+
+        public EmbeddableChunk(DocumentInputs inputs, int chunkIndex) {
+            this.inputs = inputs;
+            this.chunkIndex = chunkIndex;
+        }
+
+        @Override
+        public String getDocumentUri() {
+            return inputs.getInitialUri();
+        }
+
+        @Override
+        public String getEmbeddingText() {
+            return inputs.getChunks().get(chunkIndex);
+        }
+
+        @Override
+        public void addEmbedding(float[] embedding) {
+            inputs.addEmbedding(embedding);
+        }
+    }
+
+    private static class ClassifiableDocument implements TextClassifier.ClassifiableContent {
+        private final DocumentInputs documentInputs;
+
+        private ClassifiableDocument(DocumentInputs documentInputs) {
+            this.documentInputs = documentInputs;
+        }
+
+        @Override
+        public String getSourceUri() {
+            return documentInputs.getInitialUri();
+        }
+
+        @Override
+        public String getTextToClassify() {
+            return documentInputs.getExtractedText() != null ?
+                documentInputs.getExtractedText() :
+                HandleAccessor.contentAsString(documentInputs.getContent());
+        }
+
+        @Override
+        public void addClassification(byte[] classification) {
+            documentInputs.setClassificationResponse(classification);
+        }
+    }
+
+    private static class ClassifiableChunk implements TextClassifier.ClassifiableContent {
+        private final int chunkListIndex;
+        private final DocumentInputs documentInputs;
+
+        private ClassifiableChunk(DocumentInputs documentInputs, int chunkListIndex) {
+            this.documentInputs = documentInputs;
+            this.chunkListIndex = chunkListIndex;
+        }
+
+        @Override
+        public String getSourceUri() {
+            return documentInputs.getInitialUri();
+        }
+
+        @Override
+        public String getTextToClassify() {
+            return documentInputs.getChunks().get(chunkListIndex);
+        }
+
+        @Override
+        public void addClassification(byte[] classification) {
+            // We shouldn't need an index here, as we expect to add classifications in the correct order, based on
+            // classifying chunks in the order defined by the chunks list.
+            documentInputs.addChunkClassification(classification);
+        }
     }
 
     private void extractText(DocumentInputs inputs) {
@@ -90,20 +184,6 @@ public class DocumentProcessor implements Closeable {
         if (result != null) {
             inputs.setExtractedText(result.getText());
             inputs.setExtractedMetadata(result.getMetadata());
-        }
-    }
-
-    private void classifyText(DocumentInputs inputs) {
-        // Not sure if we should run the classifier if the user specifies a splitter. We may need options to control
-        // whether this happens or not.
-        final String uri = inputs.getInitialUri();
-        if (inputs.getExtractedText() != null) {
-            byte[] classification = textClassifier.classifyText(uri, inputs.getExtractedText());
-            inputs.setClassificationResponse(classification);
-        } else {
-            String content = HandleAccessor.contentAsString(inputs.getContent());
-            byte[] classification = textClassifier.classifyText(uri, content);
-            inputs.setClassificationResponse(classification);
         }
     }
 
@@ -116,19 +196,5 @@ public class DocumentProcessor implements Closeable {
             chunks = textSplitter.split(inputs.getInitialUri(), inputs.getContent());
         }
         inputs.setChunks(chunks);
-
-        if (textClassifier != null && chunks != null && !chunks.isEmpty()) {
-            classifyChunks(inputs);
-        }
-    }
-
-    // Should this impact existing chunks???
-    private void classifyChunks(DocumentInputs inputs) {
-        List<byte[]> classifications = new ArrayList<>();
-        for (String chunk : inputs.getChunks()) {
-            byte[] result = textClassifier.classifyText(inputs.getInitialUri(), chunk);
-            classifications.add(result);
-        }
-        inputs.setClassifications(classifications);
     }
 }

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/SemaphoreTextClassifier.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/SemaphoreTextClassifier.java
@@ -8,6 +8,8 @@ import com.smartlogic.classificationserver.client.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 class SemaphoreTextClassifier implements TextClassifier {
 
     protected static final Logger CLASSIFIER_LOGGER = LoggerFactory.getLogger("com.marklogic.semaphore.classifier");
@@ -36,6 +38,14 @@ class SemaphoreTextClassifier implements TextClassifier {
         } catch (ClassificationException e) {
             throw new ConnectorException(String.format("Unable to classify data from document with URI: %s; cause: %s", sourceUri, e.getMessage()), e);
         }
+    }
+
+    @Override
+    public void classifyText(List<ClassifiableContent> classifiableContents) {
+        classifiableContents.forEach(content -> {
+            byte[] response = classifyText(content.getSourceUri(), content.getTextToClassify());
+            content.addClassification(response);
+        });
     }
 
     @Override

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/TextClassifier.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/TextClassifier.java
@@ -4,9 +4,25 @@
 package com.marklogic.spark.core.classifier;
 
 import java.io.Closeable;
+import java.util.List;
 
 public interface TextClassifier extends Closeable {
 
+    // This will be removed soon in favor of the below method.
     byte[] classifyText(String sourceUri, String text);
 
+    void classifyText(List<ClassifiableContent> classifiableContents);
+
+    /**
+     * Abstraction to hide whether a document is being classified or an individual chunk is being classified. For the
+     * classifier, it doesn't matter in terms of batching up requests.
+     */
+    interface ClassifiableContent {
+
+        String getSourceUri();
+
+        String getTextToClassify();
+
+        void addClassification(byte[] classification);
+    }
 }

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/TextClassifierFactory.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/TextClassifierFactory.java
@@ -14,6 +14,7 @@ import com.smartlogic.cloud.TokenFetcher;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
@@ -115,6 +116,14 @@ public abstract class TextClassifierFactory {
 
         public static boolean isClosed() {
             return wasClosed;
+        }
+
+        @Override
+        public void classifyText(List<ClassifiableContent> classifiableContents) {
+            classifiableContents.forEach(contents -> {
+                byte[] classification = classifyText(contents.getSourceUri(), contents.getTextToClassify());
+                contents.addClassification(classification);
+            });
         }
 
         @Override

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/embedding/EmbeddingProducer.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/embedding/EmbeddingProducer.java
@@ -3,23 +3,10 @@
  */
 package com.marklogic.spark.core.embedding;
 
-import com.marklogic.spark.core.DocumentInputs;
-
 import java.util.List;
 
 public interface EmbeddingProducer {
 
-    /**
-     * @param inputs
-     * @return zero or more input objects with embeddings added to the chunks. The count depends on whether batching
-     * is enabled in the implementation.
-     */
-    List<DocumentInputs> produceEmbeddings(DocumentInputs inputs);
-
-    /**
-     * @return zero or more input objects with embeddings added to the chunks. Intended to catch any leftover input
-     * objects such that the batch size wasn't met.
-     */
-    List<DocumentInputs> flush();
+    void addEmbeddings(List<Chunk> chunks);
 
 }

--- a/tests/src/test/java/com/marklogic/spark/writer/embedding/AddEmbeddingsToJsonTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/embedding/AddEmbeddingsToJsonTest.java
@@ -226,7 +226,12 @@ class AddEmbeddingsToJsonTest extends AbstractIntegrationTest {
             .save();
 
         JsonNode doc = readJsonDocument("/split-test.json");
-        assertEquals(8, doc.get("chunks").size());
+        ArrayNode chunks = (ArrayNode) doc.get("chunks");
+        assertEquals(8, chunks.size());
+        for (int i = 0; i < chunks.size(); i++) {
+            JsonNode chunk = chunks.get(i);
+            assertTrue(chunk.has("embedding"), "No embedding found in chunk " + i);
+        }
 
         assertEquals(3, TestEmbeddingModel.batchCounter, "Expecting 3 batches to be sent to the test " +
             "embedding model, with 3 in the first call, 3 in the second call, and 2 when the processor is flushed " +


### PR DESCRIPTION
Summary:

- The WriteBatcherDataWriter (DW) now batches documents up until it has N.
- It then passes N documents to the DocumentProcessor (DP).
- The DP then fully processes everything in the batch.

This doesn't do batching yet for S4 though. I started down that road, and it's a lot more changes, so tossed that on a separate branch so this can be a straight refactor (notice that none of the tests changed, except I enhanced one to make more assertions).
