### PR TITLE
Using well-known namespaces for Tika XML metadata

### DIFF
--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/extraction/ExtractionUtil.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/extraction/ExtractionUtil.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.spark.core.extraction;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class ExtractionUtil {
+
+    /**
+     * Defines XML namespaces associated with metadata extracted by Apache Tika.
+     */
+    private static final Map<String, String> PREFIX_TO_NAMESPACE_MAPPING = new HashMap<>();
+
+    static {
+        PREFIX_TO_NAMESPACE_MAPPING.put("dc", "http://purl.org/dc/elements/1.1/");
+        PREFIX_TO_NAMESPACE_MAPPING.put("dcterms", "http://purl.org/dc/terms/");
+        PREFIX_TO_NAMESPACE_MAPPING.put("exif", "http://ns.adobe.com/exif/1.0/");
+        PREFIX_TO_NAMESPACE_MAPPING.put("pdf", "http://ns.adobe.com/pdf/1.3/");
+        PREFIX_TO_NAMESPACE_MAPPING.put("tiff", "http://ns.adobe.com/tiff/1.0/");
+        PREFIX_TO_NAMESPACE_MAPPING.put("xhtml", "http://www.w3.org/1999/xhtml");
+        PREFIX_TO_NAMESPACE_MAPPING.put("xmp", "http://ns.adobe.com/xap/1.0/");
+    }
+
+    public static String getNamespace(String prefix) {
+        return PREFIX_TO_NAMESPACE_MAPPING.get(prefix);
+    }
+    
+    private ExtractionUtil() {
+    }
+}

--- a/tests/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
+++ b/tests/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
@@ -181,11 +181,15 @@ public abstract class AbstractIntegrationTest extends AbstractSpringMarkLogicTes
 
     @Override
     protected XmlNode readXmlDocument(String uri) {
-        // Registers two frequently used namespaces in tests.
+        // Registers frequently used namespaces in tests.
         return readXmlDocument(uri,
             Namespace.getNamespace("model", "http://marklogic.com/appservices/model"),
             Namespace.getNamespace("ex", "org:example"),
-            Namespace.getNamespace("acme", "org:acme")
+            Namespace.getNamespace("acme", "org:acme"),
+
+            // These are specific to text extraction tests, but no harm in including them here.
+            Namespace.getNamespace("pdf", "http://ns.adobe.com/pdf/1.3/"),
+            Namespace.getNamespace("dc", "http://purl.org/dc/elements/1.1/")
         );
     }
 

--- a/tests/src/test/java/com/marklogic/spark/writer/document/WriteExtractedTextTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/document/WriteExtractedTextTest.java
@@ -94,6 +94,9 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
         doc.assertElementValue("/model:root/model:source-uri", "/extract-test/marklogic-getting-started.pdf");
         String content = doc.getElementValue("/model:root/model:content");
         assertTrue(content.contains("MarkLogic Server Table of Contents"), "Unexpected text: " + content);
+
+        doc.assertElementValue("/model:root/model:metadata/pdf:PDFVersion", "1.5");
+        doc.assertElementValue("/model:root/model:metadata/dc:description", "MarkLogic Server");
     }
 
     @Test


### PR DESCRIPTION
Not possible in JSON, but this spruces up the XML into something more useful.
