### PR TITLE
Renaming extracted metadata to... "extracted-metadata"

### DIFF
--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilder.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilder.java
@@ -236,7 +236,7 @@ public class DocBuilder {
         }
         doc.put("content", inputs.getExtractedText());
         if (inputs.getExtractedMetadata() != null) {
-            ObjectNode node = doc.putObject("metadata");
+            ObjectNode node = doc.putObject("extracted-metadata");
             inputs.getExtractedMetadata().entrySet().forEach(entry -> {
                 // Replacing the colon, which is not allowable in an index declaration.
                 String key = entry.getKey().replace(":", "-");
@@ -266,7 +266,7 @@ public class DocBuilder {
         root.appendChild(content);
 
         if (inputs.getExtractedMetadata() != null && !inputs.getExtractedMetadata().isEmpty()) {
-            Element metadata = doc.createElementNS(Util.DEFAULT_XML_NAMESPACE, "metadata");
+            Element metadata = doc.createElementNS(Util.DEFAULT_XML_NAMESPACE, "extracted-metadata");
             root.appendChild(metadata);
             inputs.getExtractedMetadata().entrySet().forEach(entry -> {
                 Element metadataElement = createXmlMetadataElement(doc, entry);

--- a/tests/src/test/java/com/marklogic/spark/writer/classifier/ClassifyExtractedTextTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/classifier/ClassifyExtractedTextTest.java
@@ -147,8 +147,8 @@ class ClassifyExtractedTextTest extends AbstractIntegrationTest {
 
     private JsonNode verifyExtractedJsonDocumentHasMetadataAndClassification() {
         JsonNode doc = readJsonDocument("/aaa/arch.pdf/extracted-text.json");
-        assertTrue(doc.has("metadata"));
-        assertEquals("application/pdf", doc.get("metadata").get("Content-Type").asText());
+        assertTrue(doc.has("extracted-metadata"));
+        assertEquals("application/pdf", doc.get("extracted-metadata").get("Content-Type").asText());
         verifyJsonHasClassification(doc);
         return doc;
     }
@@ -160,7 +160,7 @@ class ClassifyExtractedTextTest extends AbstractIntegrationTest {
 
     private XmlNode verifyExtractedXmlDocumentHasMetadataAndClassification() {
         XmlNode doc = readXmlDocument("/aaa/arch.pdf/extracted-text.xml");
-        doc.assertElementValue("/model:root/model:metadata/model:Content-Type", "application/pdf");
+        doc.assertElementValue("/model:root/model:extracted-metadata/model:Content-Type", "application/pdf");
         doc.assertElementExists("/model:root/model:classification/model:SYSTEM[@name = 'DeterminedLanguage']");
         doc.assertElementExists("/model:root/model:classification/model:SYSTEM[@name = 'LanguageGuessed']");
         return doc;

--- a/tests/src/test/java/com/marklogic/spark/writer/document/WriteExtractedTextTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/document/WriteExtractedTextTest.java
@@ -40,7 +40,7 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
         String content = doc.get("content").asText();
         assertTrue(content.contains("MarkLogic Server Table of Contents"), "Unexpected text: " + content);
 
-        JsonNode metadata = doc.get("metadata");
+        JsonNode metadata = doc.get("extracted-metadata");
         // Verify a couple fields as a sanity check.
         assertEquals("Getting Started With MarkLogic Server", metadata.get("pdf-docinfo-title").asText());
         assertEquals("application/pdf", metadata.get("Content-Type").asText());
@@ -70,7 +70,7 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
         assertEquals("/extract-test/hello-world.docx", doc.get("source-uri").asText());
         assertEquals("Hello world.\n\nThis file is used for testing text extraction.\n", doc.get("content").asText());
         assertEquals("application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            doc.get("metadata").get("Content-Type").asText());
+            doc.get("extracted-metadata").get("Content-Type").asText());
     }
 
     @Test
@@ -108,8 +108,8 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
         String content = doc.getElementValue("/model:root/model:content");
         assertTrue(content.contains("MarkLogic Server Table of Contents"), "Unexpected text: " + content);
 
-        doc.assertElementValue("/model:root/model:metadata/pdf:PDFVersion", "1.5");
-        doc.assertElementValue("/model:root/model:metadata/dc:description", "MarkLogic Server");
+        doc.assertElementValue("/model:root/model:extracted-metadata/pdf:PDFVersion", "1.5");
+        doc.assertElementValue("/model:root/model:extracted-metadata/dc:description", "MarkLogic Server");
     }
 
     @Test
@@ -185,7 +185,7 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
 
         JsonNode doc = readJsonDocument("/extract-test/marklogic-getting-started.pdf/extracted-text.json");
         assertTrue(doc.has("content"));
-        assertTrue(doc.has("metadata"));
+        assertTrue(doc.has("extracted-metadata"));
         assertFalse(doc.has("source-uri"), "source-uri should be omitted since the source was dropped");
         assertEquals(2, doc.size());
     }
@@ -213,7 +213,7 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
 
         XmlNode doc = readXmlDocument("/extract-test/marklogic-getting-started.pdf/extracted-text.xml");
         doc.assertElementExists("/model:root/model:content");
-        doc.assertElementExists("/model:root/model:metadata");
+        doc.assertElementExists("/model:root/model:extracted-metadata");
         doc.assertElementMissing("source-uri should be omitted since the source was dropped", "/model:root/model:source-uri");
         doc.assertElementCount("/model:root/node()", 2);
     }


### PR DESCRIPTION
This avoids claiming the oft-used term of "metadata", which is often used for logical domain metadata from a developer's perspective. Whereas the extracted metadata is specific to the extraction process.
