### PR TITLE
Revert "Adjusting extracted text URI"

### DIFF
--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilder.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilder.java
@@ -246,7 +246,7 @@ public class DocBuilder {
         if (inputs.getDocumentClassification() != null) {
             addClassificationToJsonDocument(doc, sourceUri, inputs.getDocumentClassification());
         }
-        String uri = sourceUri + "/extracted-text.json";
+        String uri = sourceUri + "-extracted-text.json";
         return new DocumentWriteOperationImpl(uri, sourceMetadata, new JacksonHandle(doc));
     }
 
@@ -277,8 +277,7 @@ public class DocBuilder {
         if (inputs.getDocumentClassification() != null) {
             addClassificationToXmlDocument(doc, sourceUri, inputs.getDocumentClassification());
         }
-
-        String uri = sourceUri + "/extracted-text.xml";
+        String uri = sourceUri + "-extracted-text.xml";
         return new DocumentWriteOperationImpl(uri, sourceMetadata, new DOMHandle(doc));
     }
 

--- a/tests/src/test/java/com/marklogic/spark/writer/classifier/ClassifyExtractedTextTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/classifier/ClassifyExtractedTextTest.java
@@ -146,7 +146,7 @@ class ClassifyExtractedTextTest extends AbstractIntegrationTest {
     }
 
     private JsonNode verifyExtractedJsonDocumentHasMetadataAndClassification() {
-        JsonNode doc = readJsonDocument("/aaa/arch.pdf/extracted-text.json");
+        JsonNode doc = readJsonDocument("/aaa/arch.pdf-extracted-text.json");
         assertTrue(doc.has("extracted-metadata"));
         assertEquals("application/pdf", doc.get("extracted-metadata").get("Content-Type").asText());
         verifyJsonHasClassification(doc);
@@ -159,7 +159,7 @@ class ClassifyExtractedTextTest extends AbstractIntegrationTest {
     }
 
     private XmlNode verifyExtractedXmlDocumentHasMetadataAndClassification() {
-        XmlNode doc = readXmlDocument("/aaa/arch.pdf/extracted-text.xml");
+        XmlNode doc = readXmlDocument("/aaa/arch.pdf-extracted-text.xml");
         doc.assertElementValue("/model:root/model:extracted-metadata/model:Content-Type", "application/pdf");
         doc.assertElementExists("/model:root/model:classification/model:SYSTEM[@name = 'DeterminedLanguage']");
         doc.assertElementExists("/model:root/model:classification/model:SYSTEM[@name = 'LanguageGuessed']");

--- a/tests/src/test/java/com/marklogic/spark/writer/document/WriteExtractedTextTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/document/WriteExtractedTextTest.java
@@ -35,7 +35,7 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        JsonNode doc = readJsonDocument("/extract-test/marklogic-getting-started.pdf/extracted-text.json");
+        JsonNode doc = readJsonDocument("/extract-test/marklogic-getting-started.pdf-extracted-text.json");
         assertEquals("/extract-test/marklogic-getting-started.pdf", doc.get("source-uri").asText());
         String content = doc.get("content").asText();
         assertTrue(content.contains("MarkLogic Server Table of Contents"), "Unexpected text: " + content);
@@ -66,7 +66,7 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        JsonNode doc = readJsonDocument("/extract-test/hello-world.docx/extracted-text.json");
+        JsonNode doc = readJsonDocument("/extract-test/hello-world.docx-extracted-text.json");
         assertEquals("/extract-test/hello-world.docx", doc.get("source-uri").asText());
         assertEquals("Hello world.\n\nThis file is used for testing text extraction.\n", doc.get("content").asText());
         assertEquals("application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -103,7 +103,7 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        XmlNode doc = readXmlDocument("/extract-test/marklogic-getting-started.pdf/extracted-text.xml");
+        XmlNode doc = readXmlDocument("/extract-test/marklogic-getting-started.pdf-extracted-text.xml");
         doc.assertElementValue("/model:root/model:source-uri", "/extract-test/marklogic-getting-started.pdf");
         String content = doc.getElementValue("/model:root/model:content");
         assertTrue(content.contains("MarkLogic Server Table of Contents"), "Unexpected text: " + content);
@@ -132,7 +132,7 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
         assertCollectionSize("original-doc", 2);
         assertCollectionSize("extracted-doc", 2);
 
-        PermissionsTester perms = readDocumentPermissions("/extract-test/marklogic-getting-started.pdf/extracted-text.json");
+        PermissionsTester perms = readDocumentPermissions("/extract-test/marklogic-getting-started.pdf-extracted-text.json");
         assertEquals(2, perms.getDocumentPermissions().size(), "Expecting 2 roles - spark-user-role and qconsole-user");
         perms.assertReadPermissionExists("spark-user-role");
         perms.assertReadPermissionExists("qconsole-user");
@@ -157,7 +157,7 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        PermissionsTester perms = readDocumentPermissions("/extract-test/marklogic-getting-started.pdf/extracted-text.json");
+        PermissionsTester perms = readDocumentPermissions("/extract-test/marklogic-getting-started.pdf-extracted-text.json");
         final String message = "The extracted text doc should default to " + Options.WRITE_PERMISSIONS + " when " +
             "extracted text permissions are not specified.";
         perms.assertReadPermissionExists(message, "spark-user-role");
@@ -183,7 +183,7 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
         assertCollectionSize("Should only have the 2 extracted text docs as the two source docs should " +
             "have been dropped", "extraction-test", 2);
 
-        JsonNode doc = readJsonDocument("/extract-test/marklogic-getting-started.pdf/extracted-text.json");
+        JsonNode doc = readJsonDocument("/extract-test/marklogic-getting-started.pdf-extracted-text.json");
         assertTrue(doc.has("content"));
         assertTrue(doc.has("extracted-metadata"));
         assertFalse(doc.has("source-uri"), "source-uri should be omitted since the source was dropped");
@@ -211,7 +211,7 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
         assertCollectionSize("Should only have the 2 extracted text docs as the two source docs should " +
             "have been dropped", "extraction-test", 2);
 
-        XmlNode doc = readXmlDocument("/extract-test/marklogic-getting-started.pdf/extracted-text.xml");
+        XmlNode doc = readXmlDocument("/extract-test/marklogic-getting-started.pdf-extracted-text.xml");
         doc.assertElementExists("/model:root/model:content");
         doc.assertElementExists("/model:root/model:extracted-metadata");
         doc.assertElementMissing("source-uri should be omitted since the source was dropped", "/model:root/model:source-uri");
@@ -241,14 +241,14 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
             "extraction-test", 2);
         assertInCollections("/abc/marklogic-getting-started.pdf", "extraction-test");
 
-        JsonNode extractedTextDoc = readJsonDocument("/abc/marklogic-getting-started.pdf/extracted-text.json", "extraction-test");
+        JsonNode extractedTextDoc = readJsonDocument("/abc/marklogic-getting-started.pdf-extracted-text.json", "extraction-test");
         assertEquals("/abc/marklogic-getting-started.pdf", extractedTextDoc.get("source-uri").asText());
         assertTrue(extractedTextDoc.get("content").asText().contains("MarkLogic Server Table of Contents"));
 
         assertCollectionSize("Expecting 5 chunks based on a max chunk size of 10k chars", "chunks", 5);
-        JsonNode sidecarDoc = readJsonDocument("/abc/marklogic-getting-started.pdf/extracted-text.json-chunks-1.json", "chunks");
+        JsonNode sidecarDoc = readJsonDocument("/abc/marklogic-getting-started.pdf-extracted-text.json-chunks-1.json", "chunks");
 
-        assertEquals("/abc/marklogic-getting-started.pdf/extracted-text.json", sidecarDoc.get("source-uri").asText());
+        assertEquals("/abc/marklogic-getting-started.pdf-extracted-text.json", sidecarDoc.get("source-uri").asText());
         assertEquals(1, sidecarDoc.get("chunks").size());
         assertTrue(sidecarDoc.get("chunks").get(0).get("text").asText().contains("MarkLogic Server Table of Contents"));
     }
@@ -273,7 +273,7 @@ class WriteExtractedTextTest extends AbstractIntegrationTest {
                 "The chunks are in the extracted text doc since the number of max chunks per sidecar defaults to zero.",
             "extraction-test", 2);
 
-        JsonNode doc = readJsonDocument("/abc/marklogic-getting-started.pdf/extracted-text.json");
+        JsonNode doc = readJsonDocument("/abc/marklogic-getting-started.pdf-extracted-text.json");
         assertEquals(4, doc.size(), "Should have source-uri, content, metadata, and chunks.");
         assertEquals("/abc/marklogic-getting-started.pdf", doc.get("source-uri").asText());
         assertTrue(doc.get("content").asText().contains("MarkLogic Server Table of Contents"));


### PR DESCRIPTION
This reverts commit 1de4b7415c8ad558f5d8d63bd0b995ac41c46160.

This is very likely to cause issues when exporting documents, as it will produce a file and a directory with the same name.
