### PR TITLE
Bug MLE-20704 - incorrect embeddings stored for chunk documents.

### DIFF
--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/splitter/AbstractChunkDocumentProducer.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/splitter/AbstractChunkDocumentProducer.java
@@ -19,16 +19,18 @@ abstract class AbstractChunkDocumentProducer implements Iterator<DocumentWriteOp
     protected final List<String> textSegments;
     protected final ChunkConfig chunkConfig;
     protected final List<byte[]> classifications;
+    protected final List<float[]> embeddings;
     protected final int maxChunksPerDocument;
 
     protected int listIndex = -1;
     private int chunkDocumentCounter = 1;
 
-    AbstractChunkDocumentProducer(DocumentWriteOperation sourceDocument, Format sourceDocumentFormat, List<String> textSegments, ChunkConfig chunkConfig, List<byte[]> classifications) {
+    AbstractChunkDocumentProducer(DocumentWriteOperation sourceDocument, Format sourceDocumentFormat, List<String> textSegments, ChunkConfig chunkConfig, List<byte[]> classifications, List<float[]> embeddings) {
         this.sourceDocument = sourceDocument;
         this.textSegments = textSegments;
         this.chunkConfig = chunkConfig;
         this.classifications = classifications;
+        this.embeddings = embeddings;
 
         // Chunks cannot be written to the source document unless its format is JSON or XML. So if maxChunks is zero and
         // we don't have a JSON or XML document, all chunks will be written to a separate document.
@@ -81,4 +83,15 @@ abstract class AbstractChunkDocumentProducer implements Iterator<DocumentWriteOp
         }
         return uri;
     }
+
+    /**
+     * Return the embedding at position n if it exists.
+     * @param embeddings the embeddings list
+     * @param n the position for the embedding requests
+     * @return the embedding float array
+     */
+    protected float[] getEmbeddingIfExists(List<float[]> embeddings, int n) {
+        return (embeddings != null && n < embeddings.size() ? embeddings.get(n) : null);
+    }
+
 }

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/splitter/ChunkAssembler.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/splitter/ChunkAssembler.java
@@ -17,7 +17,9 @@ public interface ChunkAssembler {
      * @param sourceDocument
      * @param chunks
      * @param classifications
+     * @param embeddings
      * @return an iterator, which allows for an implementation to lazily construct documents if necessary.
      */
-    Iterator<DocumentWriteOperation> assembleChunks(DocumentWriteOperation sourceDocument, List<String> chunks, List<byte[]> classifications);
+    Iterator<DocumentWriteOperation> assembleChunks(DocumentWriteOperation sourceDocument, List<String> chunks,
+                                                    List<byte[]> classifications, List<float[]> embeddings);
 }

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/splitter/DefaultChunkAssembler.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/splitter/DefaultChunkAssembler.java
@@ -20,7 +20,7 @@ public class DefaultChunkAssembler implements ChunkAssembler {
     }
 
     @Override
-    public Iterator<DocumentWriteOperation> assembleChunks(DocumentWriteOperation sourceDocument, List<String> textSegments, List<byte[]> classifications) {
+    public Iterator<DocumentWriteOperation> assembleChunks(DocumentWriteOperation sourceDocument, List<String> textSegments, List<byte[]> classifications, List<float[]> embeddings) {
         final Format sourceDocumentFormat = Util.determineSourceDocumentFormat(sourceDocument.getContent(), sourceDocument.getUri());
         if (sourceDocumentFormat == null) {
             Util.MAIN_LOGGER.warn("Cannot split document with URI {}; cannot determine the document format.", sourceDocument.getUri());
@@ -30,8 +30,8 @@ public class DefaultChunkAssembler implements ChunkAssembler {
         final Format chunkDocumentFormat = determineChunkDocumentFormat(sourceDocumentFormat);
 
         return Format.XML.equals(chunkDocumentFormat) ?
-            new XmlChunkDocumentProducer(sourceDocument, sourceDocumentFormat, textSegments, chunkConfig, classifications) :
-            new JsonChunkDocumentProducer(sourceDocument, sourceDocumentFormat, textSegments, chunkConfig, classifications);
+            new XmlChunkDocumentProducer(sourceDocument, sourceDocumentFormat, textSegments, chunkConfig, classifications, embeddings) :
+            new JsonChunkDocumentProducer(sourceDocument, sourceDocumentFormat, textSegments, chunkConfig, classifications, embeddings);
     }
 
     private Format determineChunkDocumentFormat(Format sourceDocumentFormat) {

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilder.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilder.java
@@ -17,8 +17,6 @@ import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Util;
 import com.marklogic.spark.core.DocumentInputs;
-import com.marklogic.spark.core.embedding.Chunk;
-import com.marklogic.spark.core.embedding.DocumentAndChunks;
 import com.marklogic.spark.core.extraction.ExtractionUtil;
 import com.marklogic.spark.core.splitter.ChunkAssembler;
 import com.marklogic.spark.dom.DOMHelper;
@@ -310,17 +308,14 @@ public class DocBuilder {
             // If there's an extracted doc, we want to use that as the source document so that the user has the option
             // of adding chunks to it.
             DocumentWriteOperation sourceDocument = extractedTextDocument != null ? extractedTextDocument : mainDocument;
-            Iterator<DocumentWriteOperation> iterator = chunkAssembler.assembleChunks(sourceDocument, inputs.getChunks(), inputs.getClassifications());
+            Iterator<DocumentWriteOperation> iterator = chunkAssembler.assembleChunks(
+                sourceDocument,
+                inputs.getChunks(),
+                inputs.getClassifications(),
+                inputs.getEmbeddings());
             while (iterator.hasNext()) {
                 DocumentWriteOperation doc = iterator.next();
                 chunkDocuments.add(doc);
-                if (doc instanceof DocumentAndChunks && inputs.getEmbeddings() != null && !inputs.getEmbeddings().isEmpty()) {
-                    DocumentAndChunks docAndChunks = (DocumentAndChunks) doc;
-                    for (int i = 0; i < docAndChunks.getChunks().size(); i++) {
-                        Chunk chunk = docAndChunks.getChunks().get(i);
-                        chunk.addEmbedding(inputs.getEmbeddings().get(i));
-                    }
-                }
             }
         }
         return chunkDocuments;


### PR DESCRIPTION
Refactor ChunkAssembler to have embeddings list passed for chunk construction.

Refactor XML and JSON producers to add the embeddings to the chunks as they are built. Add two test to ensure different text chunks do not have the same embedding vector for JSON and XML document formats.