### PR TITLE
Added test for invalid extracted text permissions

### DIFF
--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/Util.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/Util.java
@@ -122,7 +122,7 @@ public interface Util {
             final String confusingMessageForUser = "No enum constant com.marklogic.client.io.DocumentMetadataHandle.Capability.";
             if (message != null && message.contains(confusingMessageForUser)) {
                 message = message.replace(confusingMessageForUser, "Not a valid capability: ");
-                throw new IllegalArgumentException(message, ex);
+                throw new ConnectorException(message);
             }
             throw ex;
         }

--- a/tests/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
@@ -220,14 +220,12 @@ class WriteRowsTest extends AbstractWriteTest {
 
     @Test
     void invalidPermissionsCapability() {
-        SparkException ex = assertThrows(SparkException.class, () -> newWriter()
-            .option(Options.WRITE_PERMISSIONS, "rest-reader,read,rest-writer,notvalid")
-            .save());
+        DataFrameWriter writer = newWriter()
+            .option(Options.WRITE_PERMISSIONS, "rest-reader,read,rest-writer,notvalid");
 
-        Throwable cause = getCauseFromWriterException(ex);
-        assertTrue(cause instanceof IllegalArgumentException);
+        ConnectorException ex = assertThrowsConnectorException(writer::save);
         assertEquals("Unable to parse permissions string: rest-reader,read,rest-writer,notvalid; cause: Not a valid capability: NOTVALID",
-            cause.getMessage(), "When a capability is invalid, the Java Client throws an error message that refers " +
+            ex.getMessage(), "When a capability is invalid, the Java Client throws an error message that refers " +
                 "to the enum class. This likely won't make sense to a connector or Flux user. So the connector is " +
                 "expected to massage the error a bit by identifying the invalid capability without referencing " +
                 "Java classes.");


### PR DESCRIPTION
And improved the error by not including the original error, which isn't needed. Just need the "clean" error message that won't be confusing to a Flux user.
