### PR TITLE
Default the classifier path to "/"

### DIFF
--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/TextClassifierFactory.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/TextClassifierFactory.java
@@ -81,7 +81,7 @@ public abstract class TextClassifierFactory {
             this.host = context.getStringOption(Options.WRITE_CLASSIFIER_HOST);
             this.port = context.getIntOption(Options.WRITE_CLASSIFIER_PORT, 443, 0);
             this.protocol = "true".equalsIgnoreCase(context.getStringOption(Options.WRITE_CLASSIFIER_HTTP)) ? "http" : "https";
-            this.classifierPath = fixPath(context.getStringOption(Options.WRITE_CLASSIFIER_PATH));
+            this.classifierPath = fixPath(context.getStringOption(Options.WRITE_CLASSIFIER_PATH, "/"));
             this.tokenEndpoint = fixPath(context.getStringOption(Options.WRITE_CLASSIFIER_TOKEN_PATH, "/token"));
 
             context.getProperties().forEach((key, value) -> {

--- a/tests/src/test/java/com/marklogic/spark/core/classifier/ConfigHelperTest.java
+++ b/tests/src/test/java/com/marklogic/spark/core/classifier/ConfigHelperTest.java
@@ -42,12 +42,11 @@ class ConfigHelperTest {
     void defaultValues() throws MalformedURLException {
         Map<String, String> properties = new HashMap<>() {{
             put(Options.WRITE_CLASSIFIER_HOST, "somehost");
-            put(Options.WRITE_CLASSIFIER_PATH, "/classifier");
         }};
 
         TextClassifierFactory.ConfigHelper helper = new TextClassifierFactory.ConfigHelper(new Context(properties));
         ClassificationConfiguration config = helper.buildClassificationConfiguration("fake-api-token");
-        assertEquals("https://somehost:443/classifier", config.getUrl());
+        assertEquals("https://somehost:443/", config.getUrl());
         assertEquals("https://somehost:443/token", helper.getTokenUrl().toString());
     }
 


### PR DESCRIPTION
Useful for local environments. Also avoids an ugly null-pointer error when not specified.
