### PR TITLE
Building and testing against Spark 3.5.5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,8 +150,8 @@ spark.read.option("header", True).csv("marklogic-spark-connector/src/test/resour
 When you run PySpark, it will create its own Spark cluster. If you'd like to try against a separate Spark cluster
 that still runs on your local machine, perform the following steps:
 
-1. Use [sdkman to install Spark](https://sdkman.io/sdks#spark). Run `sdk install spark 3.5.3` since we are currently
-building against Spark 3.5.3.
+1. Use [sdkman to install Spark](https://sdkman.io/sdks#spark). Run `sdk install spark 3.5.5` since we are currently
+building against Spark 3.5.5.
 2. `cd ~/.sdkman/candidates/spark/current/sbin`, which is where sdkman will install Spark.
 3. Run `./start-master.sh` to start a master Spark node.
 4. `cd ../logs` and open the master log file that was created to find the address for the master node. It will be in a

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ from any data source that Spark supports and then writing it to MarkLogic.
 
 The connector has the following system requirements:
 
-* Apache Spark 3.5.3 is recommended, but earlier versions of Spark 3.4.x and 3.3.x should work as well. When choosing 
+* Apache Spark 3.5.5 is recommended, but earlier versions of Spark 3.5.x, 3.4.x, and 3.3.x should work as well. When choosing 
 [a Spark distribution](https://spark.apache.org/downloads.html), you must select a distribution that uses Scala 2.12 and not Scala 2.13.
 * For writing data, MarkLogic 9.0-9 or higher.
 * For reading data, MarkLogic 10.0-9 or higher.

--- a/examples/entity-aggregation/build.gradle
+++ b/examples/entity-aggregation/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'org.apache.spark:spark-sql_2.12:3.5.3'
+  implementation 'org.apache.spark:spark-sql_2.12:3.5.5'
   implementation "com.marklogic:marklogic-spark-connector:2.5.1"
   implementation "org.postgresql:postgresql:42.7.4"
 }

--- a/examples/java-dependency/build.gradle
+++ b/examples/java-dependency/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'org.apache.spark:spark-sql_2.12:3.5.3'
+  implementation 'org.apache.spark:spark-sql_2.12:3.5.5'
   implementation 'com.marklogic:marklogic-spark-connector:2.5.1'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # 3.5.0 caused test failures with our pushdown support, but that is not an issue with 3.5.3 - perhaps a bug fix in
 # the Spark connector plumbing between 3.5.0 and 3.5.3. This also bumps Jackson to 2.15.2.
-# 3.5.3 release notes - https://spark.apache.org/releases/spark-release-3-5-3.html .
-sparkVersion=3.5.3
+# 3.5.5 release notes - https://spark.apache.org/releases/spark-release-3-5-5.html .
+sparkVersion=3.5.5
 
 tikaVersion=3.1.0
 


### PR DESCRIPTION
This should be a no-op for the connector, just staying up-to-date with the latest public release of Spark. Will bump Flux next.
