### PR TITLE
Refactor: Renamed to SemaphoreProxy

### DIFF
--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/SemaphoreProxy.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/SemaphoreProxy.java
@@ -9,11 +9,10 @@ import java.io.Closeable;
 
 /**
  * Provides an abstraction over the call to Semaphore that sends a document containing multiple articles and
- * then receives a document containing a classification for each article.
- *
- * This will get a new name soon now that its scope is more than just classifying a set of articles.
+ * then receives a document containing a classification for each article. Main use case is to enable easy mocking of
+ * the calls to Semaphore for testing purposes.
  */
-public interface MultiArticleClassifier extends Closeable {
+public interface SemaphoreProxy extends Closeable {
 
     byte[] classifyDocument(byte[] content, String uri);
 

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/SemaphoreProxyImpl.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/SemaphoreProxyImpl.java
@@ -15,12 +15,12 @@ import java.io.IOException;
  * Not threadsafe, as the config of the underlying client is modified. This is fine in the context of the connector,
  * where it is only used by a single Spark data writer.
  */
-class SemaphoreMultiArticleClassifier implements MultiArticleClassifier {
+class SemaphoreProxyImpl implements SemaphoreProxy {
 
     private final ClassificationClient classificationClient;
     private long totalDurationOfCalls;
 
-    public SemaphoreMultiArticleClassifier(ClassificationConfiguration config) {
+    public SemaphoreProxyImpl(ClassificationConfiguration config) {
         this.classificationClient = new ClassificationClient();
         config.setMultiArticle(true);
         classificationClient.setClassificationConfiguration(config);

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/SemaphoreTextClassifier.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/SemaphoreTextClassifier.java
@@ -34,15 +34,15 @@ class SemaphoreTextClassifier implements TextClassifier {
 
     static final Logger SEMAPHORE_LOGGER = LoggerFactory.getLogger("com.marklogic.semaphore.classifier");
 
-    private final MultiArticleClassifier multiArticleClassifier;
+    private final SemaphoreProxy semaphoreProxy;
     private final DOMHelper domHelper;
     private final Transformer transformer;
     private final String encoding;
     private final XPathExpression articleExpression;
     private final int batchSize;
 
-    SemaphoreTextClassifier(MultiArticleClassifier multiArticleClassifier, String encoding, int batchSize) {
-        this.multiArticleClassifier = multiArticleClassifier;
+    SemaphoreTextClassifier(SemaphoreProxy semaphoreProxy, String encoding, int batchSize) {
+        this.semaphoreProxy = semaphoreProxy;
         this.domHelper = new DOMHelper(null);
         this.transformer = newTransformer();
         this.encoding = encoding;
@@ -53,7 +53,7 @@ class SemaphoreTextClassifier implements TextClassifier {
     @Override
     public void classifyDocument(DocumentInputs inputs) {
         byte[] content = inputs.getContentAsBytes();
-        byte[] classification = multiArticleClassifier.classifyDocument(content, inputs.getInitialUri());
+        byte[] classification = semaphoreProxy.classifyDocument(content, inputs.getInitialUri());
         inputs.setDocumentClassification(classification);
     }
 
@@ -82,7 +82,7 @@ class SemaphoreTextClassifier implements TextClassifier {
 
         Document structuredDocument;
         try {
-            structuredDocument = multiArticleClassifier.classifyArticles(documentBytes);
+            structuredDocument = semaphoreProxy.classifyArticles(documentBytes);
         } catch (Exception e) {
             throw new ConnectorException(String.format("Unable to classify content, cause: %s", e.getMessage()), e);
         }
@@ -96,7 +96,7 @@ class SemaphoreTextClassifier implements TextClassifier {
 
     @Override
     public void close() throws IOException {
-        IOUtils.closeQuietly(multiArticleClassifier);
+        IOUtils.closeQuietly(semaphoreProxy);
     }
 
     private Document buildMultiArticleRequest(List<ClassifiableContent> classifiableContents) {

--- a/tests/src/test/java/com/marklogic/spark/writer/classifier/AddClassificationToJsonTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/classifier/AddClassificationToJsonTest.java
@@ -26,7 +26,7 @@ class AddClassificationToJsonTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        assertTrue(TextClassifierFactory.MockTextClassifier.isClosed());
+        assertTrue(TextClassifierFactory.MockSemaphoreProxy.isClosed());
 
         JsonNode doc = readJsonDocument("/split-test.json");
         assertTrue(doc.get("classification").has("STRUCTUREDDOCUMENT"));
@@ -47,7 +47,7 @@ class AddClassificationToJsonTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        assertTrue(TextClassifierFactory.MockTextClassifier.isClosed());
+        assertTrue(TextClassifierFactory.MockSemaphoreProxy.isClosed());
 
         JsonNode doc = readJsonDocument("/split-test.json");
         assertTrue(doc.get("classification").has("STRUCTUREDDOCUMENT"));
@@ -82,7 +82,7 @@ class AddClassificationToJsonTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        assertTrue(TextClassifierFactory.MockTextClassifier.isClosed());
+        assertTrue(TextClassifierFactory.MockSemaphoreProxy.isClosed());
 
         JsonNode doc = readJsonDocument("/split-test.json");
         assertTrue(doc.get("classification").has("STRUCTUREDDOCUMENT"));
@@ -98,7 +98,7 @@ class AddClassificationToJsonTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        assertTrue(TextClassifierFactory.MockTextClassifier.isClosed());
+        assertTrue(TextClassifierFactory.MockSemaphoreProxy.isClosed());
 
         JsonNode doc = readJsonDocument("/split-test.json");
         assertEquals(4, doc.get("chunks").size(), "Expecting 4 chunks based on max chunk size of 500.");

--- a/tests/src/test/java/com/marklogic/spark/writer/classifier/AddClassificationToXmlTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/classifier/AddClassificationToXmlTest.java
@@ -25,7 +25,7 @@ class AddClassificationToXmlTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        assertTrue(TextClassifierFactory.MockTextClassifier.isClosed());
+        assertTrue(TextClassifierFactory.MockSemaphoreProxy.isClosed());
 
         XmlNode doc = readXmlDocument("/split-test.xml");
         doc.assertElementExists("Expecting each chunk to have a 'model:classification' child element",
@@ -44,7 +44,7 @@ class AddClassificationToXmlTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        assertTrue(TextClassifierFactory.MockTextClassifier.isClosed());
+        assertTrue(TextClassifierFactory.MockSemaphoreProxy.isClosed());
 
         XmlNode doc = readXmlDocument("/split-test.xml");
         doc.assertElementExists("Expecting the root of the document to have a 'model:classification' child element",
@@ -75,7 +75,7 @@ class AddClassificationToXmlTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        assertTrue(TextClassifierFactory.MockTextClassifier.isClosed());
+        assertTrue(TextClassifierFactory.MockSemaphoreProxy.isClosed());
 
         XmlNode doc = readXmlDocument("/split-test.xml");
         doc.assertElementExists("Expecting the root of the document to have a 'model:classification' child element",

--- a/tests/src/test/java/com/marklogic/spark/writer/classifier/ClassifyExtractedTextTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/classifier/ClassifyExtractedTextTest.java
@@ -73,7 +73,7 @@ class ClassifyExtractedTextTest extends AbstractIntegrationTest {
             .mode(SaveMode.Append)
             .save();
 
-        assertEquals(3, TextClassifierFactory.MockTextClassifier.getTimesInvoked(), "The mock classifier should " +
+        assertEquals(3, TextClassifierFactory.MockSemaphoreProxy.getTimesInvoked(), "The mock classifier should " +
             "have been invoked 3 times - with 10, 10, and then 8 articles.");
     }
 


### PR DESCRIPTION
Avoids confusion over use of "MultiArticle". Main use case for this is to hide the actual call to Semaphore so it can be mocked easily.
