### PR TITLE
MLE-22889 Renamed base64 option

### DIFF
--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/Options.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/Options.java
@@ -468,7 +468,7 @@ public abstract class Options {
      *
      * @since 2.7.0
      */
-    public static final String WRITE_EMBEDDER_BASE64_ENCODE_VECTORS = WRITE_EMBEDDER_PREFIX + "base64EncodeVectors";
+    public static final String WRITE_EMBEDDER_BASE64_ENCODE = WRITE_EMBEDDER_PREFIX + "base64Encode";
 
     /**
      * Defines the host for classification requests

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/embedding/ChunkSelectorFactory.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/embedding/ChunkSelectorFactory.java
@@ -24,7 +24,7 @@ public interface ChunkSelectorFactory {
             .withChunksPointer(context.getProperties().get(Options.WRITE_EMBEDDER_CHUNKS_JSON_POINTER))
             .withTextPointer(context.getStringOption(Options.WRITE_EMBEDDER_TEXT_JSON_POINTER))
             .withEmbeddingArrayName(context.getStringOption(Options.WRITE_EMBEDDER_EMBEDDING_NAME))
-            .withBase64EncodeVectors(context.getBooleanOption(Options.WRITE_EMBEDDER_BASE64_ENCODE_VECTORS, false))
+            .withBase64EncodeVectors(context.getBooleanOption(Options.WRITE_EMBEDDER_BASE64_ENCODE, false))
             .build();
     }
 
@@ -34,7 +34,7 @@ public interface ChunkSelectorFactory {
             context.getStringOption(Options.WRITE_EMBEDDER_EMBEDDING_NAME),
             context.getProperties().get(Options.WRITE_EMBEDDER_EMBEDDING_NAMESPACE),
             NamespaceContextFactory.makeNamespaceContext(context.getProperties()),
-            context.getBooleanOption(Options.WRITE_EMBEDDER_BASE64_ENCODE_VECTORS, false)
+            context.getBooleanOption(Options.WRITE_EMBEDDER_BASE64_ENCODE, false)
         );
         return new DOMChunkSelector(
             context.getStringOption(Options.WRITE_EMBEDDER_CHUNKS_XPATH),

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/splitter/ChunkAssemblerFactory.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/splitter/ChunkAssemblerFactory.java
@@ -34,7 +34,7 @@ public interface ChunkAssemblerFactory {
             .withUriSuffix(context.getStringOption(Options.WRITE_SPLITTER_SIDECAR_URI_SUFFIX))
             .withXmlNamespace(context.getProperties().get(Options.WRITE_SPLITTER_SIDECAR_XML_NAMESPACE))
             .withEmbeddingXmlNamespace(context.getProperties().get(Options.WRITE_EMBEDDER_EMBEDDING_NAMESPACE))
-            .withBase64EncodeVectors(context.getBooleanOption(Options.WRITE_EMBEDDER_BASE64_ENCODE_VECTORS, false))
+            .withBase64EncodeVectors(context.getBooleanOption(Options.WRITE_EMBEDDER_BASE64_ENCODE, false))
             .build()
         );
     }

--- a/tests/src/test/java/com/marklogic/spark/writer/embedding/AddEmbeddingsToJsonTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/embedding/AddEmbeddingsToJsonTest.java
@@ -32,7 +32,7 @@ class AddEmbeddingsToJsonTest extends AbstractIntegrationTest {
     void teardown() {
         TestEmbeddingModel.reset();
     }
-    
+
     /**
      * Tests the use case where a user wants to split the text into chunks and generate embeddings for each chunk, all
      * as part of one write process.
@@ -356,7 +356,7 @@ class AddEmbeddingsToJsonTest extends AbstractIntegrationTest {
             .option(Options.WRITE_URI_TEMPLATE, "/split-test.json")
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 1000)
             .option(Options.WRITE_EMBEDDER_MODEL_FUNCTION_CLASS_NAME, "com.marklogic.spark.writer.embedding.TestEmbeddingModel")
-            .option(Options.WRITE_EMBEDDER_BASE64_ENCODE_VECTORS, "true")
+            .option(Options.WRITE_EMBEDDER_BASE64_ENCODE, "true")
             .mode(SaveMode.Append)
             .save();
 
@@ -385,7 +385,7 @@ class AddEmbeddingsToJsonTest extends AbstractIntegrationTest {
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.WRITE_EMBEDDER_MODEL_FUNCTION_CLASS_NAME, "com.marklogic.spark.writer.embedding.TestEmbeddingModel")
             .option(Options.WRITE_EMBEDDER_CHUNKS_JSON_POINTER, "/chunks")
-            .option(Options.WRITE_EMBEDDER_BASE64_ENCODE_VECTORS, "true")
+            .option(Options.WRITE_EMBEDDER_BASE64_ENCODE, "true")
             .mode(SaveMode.Append)
             .save();
 

--- a/tests/src/test/java/com/marklogic/spark/writer/embedding/AddEmbeddingsToXmlTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/embedding/AddEmbeddingsToXmlTest.java
@@ -347,7 +347,7 @@ class AddEmbeddingsToXmlTest extends AbstractIntegrationTest {
             .option(Options.WRITE_URI_TEMPLATE, "/split-test.xml")
             .option(Options.WRITE_SPLITTER_MAX_CHUNK_SIZE, 1000)
             .option(Options.WRITE_EMBEDDER_MODEL_FUNCTION_CLASS_NAME, "com.marklogic.spark.writer.embedding.TestEmbeddingModel")
-            .option(Options.WRITE_EMBEDDER_BASE64_ENCODE_VECTORS, "true")
+            .option(Options.WRITE_EMBEDDER_BASE64_ENCODE, "true")
             .mode(SaveMode.Append)
             .save();
 
@@ -377,7 +377,7 @@ class AddEmbeddingsToXmlTest extends AbstractIntegrationTest {
             .option(Options.WRITE_EMBEDDER_MODEL_FUNCTION_CLASS_NAME, "com.marklogic.spark.writer.embedding.TestEmbeddingModel")
             .option(Options.XPATH_NAMESPACE_PREFIX + "model", "http://marklogic.com/appservices/model")
             .option(Options.WRITE_EMBEDDER_CHUNKS_XPATH, "/root/model:chunks/model:chunk")
-            .option(Options.WRITE_EMBEDDER_BASE64_ENCODE_VECTORS, "true")
+            .option(Options.WRITE_EMBEDDER_BASE64_ENCODE, "true")
             .mode(SaveMode.Append)
             .save();
 


### PR DESCRIPTION
The use of "embedder" in the option name makes it clear that we're talking about base64 encoding of the vector. The underlying variables still say "base64EncodeVectors" to make it obvious what they refer to.
