### PR TITLE
MLE-22784 Using just a UUID as a temporary URI

### DIFF
--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/ArbitraryRowConverter.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/ArbitraryRowConverter.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
  */
 class ArbitraryRowConverter implements RowConverter {
 
-    private static final String MARKLOGIC_SPARK_FILE_PATH_COLUMN_NAME = "marklogic_spark_file_path" ;
+    private static final String MARKLOGIC_SPARK_FILE_PATH_COLUMN_NAME = "marklogic_spark_file_path";
 
     private final ObjectMapper objectMapper;
     private final XmlMapper xmlMapper;
@@ -108,9 +108,10 @@ class ArbitraryRowConverter implements RowConverter {
             row.setNullAt(this.filePathIndex);
         } else {
             // Temporary URI to avoid issues during the document pipeline, where the lack of a URI can cause an error
-            // when constructing a DocumentWriteOperationImpl. This temporary URI will be replaced in all cases based
-            // on other inputs provided by the user.
-            initialUri = String.format("/temporary/%s.json", UUID.randomUUID());
+            // when constructing a DocumentWriteOperationImpl. This does duplicate a little bit of logic -
+            // StandardUriMaker assumes the same default value for a URI. That is acceptable, though, as a UUID is a very
+            // common way to generate a unique identifier.
+            initialUri = UUID.randomUUID().toString();
         }
         return initialUri;
     }

--- a/tests/src/test/java/com/marklogic/spark/writer/embedding/AddEmbeddingsToJsonTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/embedding/AddEmbeddingsToJsonTest.java
@@ -344,6 +344,29 @@ class AddEmbeddingsToJsonTest extends AbstractIntegrationTest {
     }
 
     @Test
+    void arbitraryRowWithNoInitialUriAndNoUriModifier() {
+        newSparkSession().read()
+            .option("header", true)
+            .csv("src/test/resources/inputForStream/Hogwarts.csv")
+            .write().format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.WRITE_PERMISSIONS, DEFAULT_PERMISSIONS)
+            .option(Options.WRITE_COLLECTIONS, "hogwarts")
+            .option(Options.WRITE_EMBEDDER_CHUNKS_JSON_POINTER, "")
+            .option(Options.WRITE_EMBEDDER_TEXT_JSON_POINTER, "/House")
+            .option(Options.WRITE_EMBEDDER_MODEL_FUNCTION_CLASS_NAME, TEST_EMBEDDING_FUNCTION_CLASS)
+            .mode(SaveMode.Append)
+            .save();
+
+        assertCollectionSize("hogwarts", 9);
+        getUrisInCollection("hogwarts", 9).forEach(uri -> {
+            String message = "The default URI should be a UUID followed by .json; actual URI: " + uri;
+            assertTrue(uri.endsWith(".json"), message);
+            assertFalse(uri.contains("/"), message);
+        });
+    }
+
+    @Test
     void base64EncodeVectors() {
         TestEmbeddingModel.reset();
         TestEmbeddingModel.useFixedTestVector = true;


### PR DESCRIPTION
Using "/temporary/(UUID)" resulted in the "/temporary" being retained if no URI modification option was provided.
