### PR TITLE
MLE-12345 Added note explaining java17 configuration

### DIFF
--- a/marklogic-spark-connector/build.gradle
+++ b/marklogic-spark-connector/build.gradle
@@ -10,6 +10,11 @@ configurations {
   // with Spark.
   shadowDependencies
 
+  // Allows for Java 17-specific dependencies to be declared so that they can be added to the shadowJar, but also
+  // not included on the compile classpath for the connector. These dependencies are also declared in the "tests"
+  // project as test dependencies so that they can be tested. These are separate from shadowDependencies, as those
+  // are on the compile classpath. But we don't want the connector to require any Java 17 dependencies to be on the
+  // compile classpath so that we can still compile it using Java 11.
   java17Dependencies
 
   // This approach allows for all of the dependencies to be available for compilation and for running tests.


### PR DESCRIPTION
I'm not totally certain it can't be removed, but it's not doing any harm. And it'll go away once we shift to Spark 4 where Java 17 is required.
