### PR TITLE
MLE-23024 Bumping more dependencies for Spark 4

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -10,7 +10,7 @@ product and version for which you are requesting source code.
 
 Third Party Notices
 
-jackson-dataformat-xml 2.15.2 (Apache-2.0)
+jackson-dataformat-xml 2.17.2 (Apache-2.0)
 jdom2 2.0.6.1 (Apache-2.0)
 jena-arq 4.10.0 (Apache-2.0)
 langchain4j 1.0.0-rc1 (Apache-2.0)
@@ -28,7 +28,7 @@ Third-Party Components
 
 The following is a list of the third-party components used by the MarkLogic® Spark connector 2.6.0 (last updated May 1, 2025):
 
-jackson-dataformat-xml 2.15.2 (Apache-2.0)
+jackson-dataformat-xml 2.17.2 (Apache-2.0)
 https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-xml/
 For the full text of the Apache-2.0 license, see Apache License 2.0 (Apache-2.0)
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,13 +44,12 @@ subprojects {
 
   configurations.all {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-      // Added after upgrading langchain4j to 1.0.0-beta2, which brought Jackson 2.18.2 in.
       if (details.requested.group.startsWith('com.fasterxml.jackson')) {
-        details.useVersion '2.15.2'
+        details.useVersion '2.17.2'
         details.because 'Need to match the version used by Spark.'
       }
       if (details.requested.group.equals("org.slf4j")) {
-        details.useVersion "2.0.16"
+        details.useVersion "2.0.17"
         details.because "Ensures that slf4j-api 1.x does not appear on the Flux classpath in particular, which can " +
           "lead to this issue - https://www.slf4j.org/codes.html#StaticLoggerBinder."
       }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 sparkVersion=4.0.0
-
 tikaVersion=3.2.1
+semaphoreVersion=5.10.0
 
 # Define these on the command line to publish to OSSRH
 # See https://central.sonatype.org/publish/publish-gradle/#credentials for more information

--- a/marklogic-langchain4j/build.gradle
+++ b/marklogic-langchain4j/build.gradle
@@ -1,14 +1,11 @@
 /**
  * This project defines processing that depends on langchain4j and thus will require Java 17.
+ *
+ * Now that we're building on Spark 4, this separation can be removed and this functionality can be moved into either
+ * marklogic-spark-api or marklogic-spark-connector.
  */
-
-java {
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
-  }
-}
 
 dependencies {
   api project(":marklogic-spark-api")
-  api "dev.langchain4j:langchain4j:1.0.0"
+  api "dev.langchain4j:langchain4j:1.1.0"
 }

--- a/marklogic-spark-api/build.gradle
+++ b/marklogic-spark-api/build.gradle
@@ -10,27 +10,19 @@ dependencies {
   }
 
   // This is compileOnly as Spark will provide its own copy at runtime.
-  compileOnly "com.fasterxml.jackson.core:jackson-databind:2.15.2"
-
-  // Used for null-checks; Spark should provide its own copy at runtime as well, but this is included just in case
-  // a particular Spark runtime doesn't include this.
-  implementation "jakarta.validation:jakarta.validation-api:2.0.2"
+  compileOnly "com.fasterxml.jackson.core:jackson-databind:2.17.2"
 
   // For logging.
-  implementation "org.slf4j:jcl-over-slf4j:2.0.13"
+  implementation "org.slf4j:jcl-over-slf4j:2.0.17"
 
   // Needed for splitting XML documents via XPath.
   implementation "jaxen:jaxen:2.0.0"
 
   // Needed for classifying documents via Semaphore.
-  api("com.smartlogic.csclient:Semaphore-CS-Client:5.6.1") {
+  api("com.smartlogic.csclient:Semaphore-CS-Client:${semaphoreVersion}") {
     exclude group: "com.fasterxml.jackson.core"
-    exclude module: "icu4j"
   }
-  // The S4 CS client depends on a very old version of icu4j - 4.0.1 - which has a critical security vulnerability.
-  // Bumping up to the latest version, which has worked correctly via manual testing.
-  implementation "com.ibm.icu:icu4j:77.1"
-  api("com.smartlogic.cloud:Semaphore-Cloud-Client:5.6.1") {
+  api("com.smartlogic.cloud:Semaphore-Cloud-Client:${semaphoreVersion}") {
     exclude group: "com.fasterxml.jackson.core"
   }
 
@@ -39,13 +31,14 @@ dependencies {
   api "org.apache.tika:tika-core:${tikaVersion}"
 
   // Needed for using XmlMapper.
-  api("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2") {
+  api("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.17.2") {
     // Not needed, as the modules in this group that this dependency depends on are all provided by Spark.
     exclude group: "com.fasterxml.jackson.core"
   }
 
   // Supports reading and writing RDF data. Including this here so it's available to the tests as well.
-  api("org.apache.jena:jena-arq:4.10.0") {
+  // Bumped to 5.x, which requires Java 17, while upgrading Spark to 4.x.
+  api("org.apache.jena:jena-arq:5.5.0") {
     exclude group: "com.fasterxml.jackson.core"
     exclude group: "com.fasterxml.jackson.dataformat"
   }

--- a/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/TextClassifierFactory.java
+++ b/marklogic-spark-api/src/main/java/com/marklogic/spark/core/classifier/TextClassifierFactory.java
@@ -18,7 +18,6 @@ import com.smartlogic.cloud.Token;
 import com.smartlogic.cloud.TokenFetcher;
 import org.w3c.dom.Document;
 
-import javax.validation.constraints.NotNull;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
@@ -149,7 +148,7 @@ public abstract class TextClassifierFactory {
 
         // Sonar doesn't like this static assignment, but it's fine in a class that's only used as a mock.
         @SuppressWarnings("java:S3010")
-        private MockSemaphoreProxy(@NotNull String mockResponse) {
+        private MockSemaphoreProxy(String mockResponse) {
             this.mockResponse = new DOMHelper(null).parseXmlString(mockResponse, null);
             timesInvoked = 0;
         }

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,24 +1,15 @@
-java {
-  // Must use Java 17 as langchain4j depends on 17+.
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
-  }
-}
-
 dependencies {
   testImplementation "org.apache.spark:spark-sql_2.13:${sparkVersion}"
   testImplementation project(":marklogic-spark-api")
   testImplementation project(":marklogic-spark-connector")
 
-  // This forces this subproject onto Java 17.
   testImplementation (project(":marklogic-langchain4j")) {
     exclude group: "com.fasterxml.jackson.core"
     exclude group: "com.fasterxml.jackson.dataformat"
   }
 
   // Supports testing the embedder feature.
-  // This oddly still doesn't have a 1.0.0 release, even though langchain4j has a 1.0.0 release from May 2025.
-  testImplementation "dev.langchain4j:langchain4j-embeddings-all-minilm-l6-v2:1.0.0-beta5"
+  testImplementation "dev.langchain4j:langchain4j-embeddings-all-minilm-l6-v2:1.1.0-beta7"
 
   testImplementation('com.marklogic:ml-app-deployer:5.0.0') {
     exclude group: "com.fasterxml.jackson.core"


### PR DESCRIPTION
The main bump here is jena-arq to 5.5.0, which requires Java 17. Which is fine to do now that Spark 4 is being used.
