### PR TITLE
MLE-23330 Trimming off scheme when writing URIs to files

### DIFF
--- a/tests/src/test/java/com/marklogic/spark/writer/file/FileUtilTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/file/FileUtilTest.java
@@ -14,6 +14,16 @@ class FileUtilTest {
         assertEquals("/base/path/to/doc.xml", makePath("/path/to/doc.xml"));
     }
 
+    @Test
+    void noForwardSlash() {
+        assertEquals("/base/path/to/doc.xml", makePath("path/to/doc.xml"));
+    }
+
+    @Test
+    void justFilename() {
+        assertEquals("/base/doc.xml", makePath("doc.xml"));
+    }
+
     /**
      * This was altered in the 2.7.0 to fix a bug where a URI with two or more colons and
      * no leading slash causing a URISyntaxException when the Hadoop Path constructor was called. This
@@ -38,7 +48,20 @@ class FileUtilTest {
     void allKindsOfStuff() {
         assertEquals("/base/has+lots of&/stuff_in-it.json", makePath("has+lots of&/stuff_in-it.json"));
     }
-    
+
+    @Test
+    void fileBasedUri() {
+        assertEquals("/base/hey.json", makePath("file://tmp/hey.json"), "Per the fixes for 1.4.0, " +
+            "we're retaining the behavior where the scheme is removed for a non-opaque URI. This ensures we don't " +
+            "try to files with e.g. 'http://' or 'file://' in the URI. This won't prevent issues like writing files " +
+            "to Azure Storage, which doesn't allow colons - a colon can appear anywhere in the URI and still be valid.");
+    }
+
+    @Test
+    void httpBasedUri() {
+        assertEquals("/base/path/to/file.xml", makePath("https://www.exampple.org/path/to/file.xml"));
+    }
+
     private String makePath(String uri) {
         return FileUtil.makePathFromDocumentURI("/base", uri).toString();
     }

--- a/tests/src/test/java/com/marklogic/spark/writer/file/WriteDocumentZipFilesTest.java
+++ b/tests/src/test/java/com/marklogic/spark/writer/file/WriteDocumentZipFilesTest.java
@@ -85,9 +85,36 @@ class WriteDocumentZipFilesTest extends AbstractIntegrationTest {
         assertEquals(1, tempDir.toFile().listFiles().length);
         File file = tempDir.toFile().listFiles()[0];
         ZipFile zipFile = new ZipFile(file);
-        assertNotNull(zipFile.getEntry("some:org:example/123.xml"), "some:org:example/123.xml is considered an 'opaque' URI per " +
-            "the definition of java.net.URI:isOpaque. Per MLCP behavior, the URI is expected to be set to the " +
-            "'schema-specific part', which is just example/123.xml.");
+        assertNotNull(zipFile.getEntry(uri), "some:org:example/123.xml is considered an 'opaque' URI per " +
+            "the definition of java.net.URI:isOpaque. As of 1.4.0 now, we no longer modify those when the document " +
+            "is written to a zip, as zip entry names can be opaque URIs.");
+    }
+
+    @Test
+    void uriWithScheme(@TempDir Path tempDir) throws IOException {
+        final String uri = "http://example.org/some/file.xml";
+
+        getDatabaseClient().newXMLDocumentManager().write(uri,
+            TestUtil.withDefaultPermissions(new DocumentMetadataHandle()).withCollections("http-test"),
+            new StringHandle("<hello>world</hello>"));
+
+        newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.CLIENT_URI, makeClientUri())
+            .option(Options.READ_DOCUMENTS_COLLECTIONS, "http-test")
+            .load()
+            .repartition(1)
+            .write()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.WRITE_FILES_COMPRESSION, "zip")
+            .mode(SaveMode.Append)
+            .save(tempDir.toFile().getAbsolutePath());
+
+        assertEquals(1, tempDir.toFile().listFiles().length);
+        File file = tempDir.toFile().listFiles()[0];
+        ZipFile zipFile = new ZipFile(file);
+        assertNotNull(zipFile.getEntry(uri), "When writing URIs to a zip, we don't need to modify them at all, " +
+            "unless we later find out there's some set of characters that are not allowed in zip entry names.");
     }
 
     @Test
@@ -113,7 +140,7 @@ class WriteDocumentZipFilesTest extends AbstractIntegrationTest {
         assertEquals(1, tempDir.toFile().listFiles().length);
         File file = tempDir.toFile().listFiles()[0];
         ZipFile zipFile = new ZipFile(file);
-        assertNotNull(zipFile.getEntry("has multiple spaces.xml"));
+        assertNotNull(zipFile.getEntry(uri));
     }
 
     /**


### PR DESCRIPTION
Turns out we still need this behavior for the ordinary case of writing a URI to a file where the URI has a scheme in it. This doesn't impact zip files though.
