### PR TITLE
MLE-24402 No longer needed to shade OkHttp

### DIFF
--- a/marklogic-spark-connector/build.gradle
+++ b/marklogic-spark-connector/build.gradle
@@ -16,16 +16,17 @@ configurations {
 }
 
 dependencies {
+  // Need to compile against Spark, but its libraries are not part of the connector jar.
   compileOnly "org.apache.spark:spark-sql_2.13:${sparkVersion}"
+
+  // This is compileOnly as Spark will provide its own copy at runtime.
+  compileOnly "com.fasterxml.jackson.core:jackson-databind:2.17.2"
 
   shadowDependencies("com.marklogic:marklogic-client-api:7.2.0") {
     // Need to use the versions of Jackson preferred by Spark.
     exclude group: "com.fasterxml.jackson.core"
     exclude group: "com.fasterxml.jackson.dataformat"
   }
-
-  // This is compileOnly as Spark will provide its own copy at runtime.
-  compileOnly "com.fasterxml.jackson.core:jackson-databind:2.17.2"
 
   // For logging.
   shadowDependencies "org.slf4j:jcl-over-slf4j:2.0.17"
@@ -132,17 +133,6 @@ shadowJar {
   // artifact that is published as a dependency. That is desirable as it includes the relocated packages listed below,
   // which a dependent would otherwise have to manage themselves.
   archiveClassifier.set("")
-
-  // Spark uses an older version of OkHttp; see
-  // https://stackoverflow.com/questions/61147800/how-to-override-spark-jars-while-running-spark-submit-command-in-cluster-mode
-  // for more information on why these are relocated.
-  relocate "okhttp3", "marklogicspark.okhttp3"
-  relocate "okio", "marklogicspark.okio"
-
-  // Shadowing these as well to avoid issues where a user needs to use the "normal" Java Client with the
-  // regular OkHttp classes.
-  relocate "com.marklogic.client", "marklogicspark.marklogic.client"
-  relocate "com.burgstaller.okhttp", "marklogicspark.com.burgstaller.okhttp"
 }
 
 // Publishing setup - see https://docs.gradle.org/current/userguide/publishing_setup.html .


### PR DESCRIPTION
It's not in Spark 4, so don't need this shading anymore.
