### PR TITLE
MLE-29540 Overriding thrift as runtime dependency

### DIFF
--- a/marklogic-spark-connector/build.gradle
+++ b/marklogic-spark-connector/build.gradle
@@ -12,9 +12,6 @@ configurations {
       // Test-only dependency; resolves https://nvd.nist.gov/vuln/detail/CVE-2026-23907
       force "org.apache.pdfbox:pdfbox:3.0.7"
 
-      // jena-arq dependency; resolves several CVEs in 0.22.0
-      force "org.apache.thrift:libthrift:0.23.0"
-
       // Test-only dependencies of Tika, resolves CVEs from 1.81
       force "org.bouncycastle:bcprov-jdk18on:1.84"
       force "org.bouncycastle:bcjmail-jdk18on:1.84"
@@ -37,6 +34,13 @@ configurations.configureEach {
  }
 
 dependencies {
+  // Overrides are needed here for runtime dependencies so that Flux picks up the overridden dependency as well.
+  constraints {
+    implementation("org.apache.thrift:libthrift:0.23.0") {
+      because "Bumping from 0.22.0 to 0.23.0 to eliminate several CVEs; this is brought in by jena-arq."
+    }
+  }
+
   // Need to compile against Spark, but its libraries are not part of the connector jar.
   // CVEs recorded in Black Duck against Spark and its dependencies will be remediated as "not affected" because this
   // is a compileOnly dependency.


### PR DESCRIPTION
This ensures that the bumped version of thrift is used by Flux as well.
