### PR TITLE
PDP-1256 Commit listener now accepts a map of params

### DIFF
--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
@@ -154,12 +154,24 @@ public abstract class Options {
     /**
      * @since 3.2.0
      */
-    public static final String WRITE_COMMIT_RESULTS_CONSUMER_CLASSNAME = "spark.marklogic.write.commitResultsConsumer.className";
+    public static final String WRITE_BATCH_LISTENER_PARAM_PREFIX = "spark.marklogic.write.batchListener.param.";
 
     /**
+     * Class name of an implementation of the Java Consumer interface that receives a map of commit results after
+     * the write process has finished. The implementation must declare a constructor that receives a
+     * Map<String, String> of parameters, which can be passed via options with the prefix defined
+     * by WRITE_COMMIT_LISTENER_PARAM_PREFIX.
+     *
      * @since 3.2.0
      */
-    public static final String WRITE_BATCH_LISTENER_PARAM_PREFIX = "spark.marklogic.write.batchListener.param.";
+    public static final String WRITE_COMMIT_LISTENER_CLASSNAME = "spark.marklogic.write.commitListener.className";
+
+    /**
+     * Prefix for params to pass in a Map<String, String> to the constructor of the commit listener class.
+     *
+     * @since 3.2.0
+     */
+    public static final String WRITE_COMMIT_LISTENER_PARAM_PREFIX = "spark.marklogic.write.commitListener.param.";
 
     // For logging progress when writing documents or processing with custom code. Defines the interval at which
     // progress should be logged - e.g. a value of 10,000 will result in a message being logged on every 10,000 items

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/MarkLogicWrite.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/MarkLogicWrite.java
@@ -25,15 +25,16 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 public class MarkLogicWrite implements BatchWrite, StreamingWrite {
 
     private final WriteContext writeContext;
-    private final Consumer<Map<String, Object>> commitResultsConsumer;
+    private final Consumer<Map<String, Object>> commitListener;
 
     MarkLogicWrite(WriteContext writeContext) {
         this.writeContext = writeContext;
-        this.commitResultsConsumer = instantiateCommitResultsConsumer();
+        this.commitListener = instantiateCommitListener();
     }
 
     @Override
@@ -65,13 +66,7 @@ public class MarkLogicWrite implements BatchWrite, StreamingWrite {
                 }
             }
 
-            if (commitResultsConsumer != null) {
-                Map<String, Object> resultsMap = new HashMap<>();
-                resultsMap.put("successCount", commitResults.successCount);
-                resultsMap.put("failureCount", commitResults.failureCount);
-                resultsMap.put("skippedCount", commitResults.skippedCount);
-                commitResultsConsumer.accept(resultsMap);
-            }
+            invokeCommitListener(commitResults);
 
             if (Util.MAIN_LOGGER.isInfoEnabled()) {
                 Util.MAIN_LOGGER.info("Success count: {}", commitResults.successCount);
@@ -153,27 +148,52 @@ public class MarkLogicWrite implements BatchWrite, StreamingWrite {
     }
 
     @SuppressWarnings("unchecked")
-    private Consumer<Map<String, Object>> instantiateCommitResultsConsumer() {
-        String className = writeContext.getProperties().get(Options.WRITE_COMMIT_RESULTS_CONSUMER_CLASSNAME);
+    private Consumer<Map<String, Object>> instantiateCommitListener() {
+        String className = writeContext.getProperties().get(Options.WRITE_COMMIT_LISTENER_CLASSNAME);
         String trimmedClassName = className != null ? className.trim() : null;
         if (trimmedClassName != null && !trimmedClassName.isEmpty()) {
             try {
                 Class<?> clazz = Class.forName(trimmedClassName);
-                Object instance = clazz.getDeclaredConstructor().newInstance();
+                Map<String, String> params = buildCommitListenerParamsMap();
+                Object instance = clazz.getDeclaredConstructor(Map.class).newInstance(params);
                 if (instance instanceof Consumer) {
                     return (Consumer<Map<String, Object>>) instance;
                 } else {
                     throw new ConnectorException(String.format(
-                        "Class %s does not implement Consumer interface", trimmedClassName));
+                        "Commit listener %s does not implement Consumer interface", trimmedClassName));
                 }
             } catch (ConnectorException ce) {
                 throw ce;
             } catch (Exception e) {
                 throw new ConnectorException(String.format(
-                    "Unable to instantiate commit results consumer: %s; cause: %s", trimmedClassName, e.getMessage()), e);
+                    "Unable to instantiate commit listener: %s; cause: %s", trimmedClassName, e.getMessage()), e);
             }
         }
         return null;
     }
 
+    private Map<String, String> buildCommitListenerParamsMap() {
+        return writeContext.getProperties().entrySet().stream()
+            .filter(entry -> entry.getKey().startsWith(Options.WRITE_COMMIT_LISTENER_PARAM_PREFIX))
+            .filter(entry -> entry.getValue() != null)
+            .collect(Collectors.toMap(
+                entry -> entry.getKey().substring(Options.WRITE_COMMIT_LISTENER_PARAM_PREFIX.length()),
+                Map.Entry::getValue
+            ));
+    }
+
+    private void invokeCommitListener(CommitResults commitResults) {
+        if (commitListener != null) {
+            Map<String, Object> resultsMap = new HashMap<>();
+            resultsMap.put("successCount", commitResults.successCount);
+            resultsMap.put("failureCount", commitResults.failureCount);
+            resultsMap.put("skippedCount", commitResults.skippedCount);
+            try {
+                commitListener.accept(resultsMap);
+            } catch (Exception e) {
+                final String message = "Commit listener failed; cause: ".formatted(e.getMessage());
+                Util.MAIN_LOGGER.warn(message, e);
+            }
+        }
+    }
 }

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/CommitResultsTestConsumer.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/CommitResultsTestConsumer.java
@@ -16,6 +16,12 @@ public class CommitResultsTestConsumer implements Consumer<Map<String, Object>> 
     public static final AtomicInteger failureCount = new AtomicInteger(0);
     public static final AtomicInteger skippedCount = new AtomicInteger(0);
 
+    public static Map<String, String> params;
+
+    public CommitResultsTestConsumer(Map<String, String> params) {
+        CommitResultsTestConsumer.params = params;
+    }
+
     @Override
     public void accept(Map<String, Object> results) {
         successCount.set((Integer) results.get("successCount"));
@@ -27,5 +33,6 @@ public class CommitResultsTestConsumer implements Consumer<Map<String, Object>> 
         successCount.set(0);
         failureCount.set(0);
         skippedCount.set(0);
+        params = null;
     }
 }

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/IncrementalWriteTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/IncrementalWriteTest.java
@@ -117,7 +117,7 @@ class IncrementalWriteTest extends AbstractWriteTest {
                 // Setting this to false normally causes the BatchRetrier to kick in and retry failed batches,
                 // but it shouldn't due to the filter error being non-retryable.
                 .option(Options.WRITE_ABORT_ON_FAILURE, false)
-                .option(Options.WRITE_COMMIT_RESULTS_CONSUMER_CLASSNAME, "com.marklogic.spark.writer.CommitResultsTestConsumer")
+                .option(Options.WRITE_COMMIT_LISTENER_CLASSNAME, "com.marklogic.spark.writer.CommitResultsTestConsumer")
                 .mode(SaveMode.Append)
                 .save();
 

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/MarkLogicWriteTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/MarkLogicWriteTest.java
@@ -18,9 +18,9 @@ import static org.junit.jupiter.api.Assertions.*;
 class MarkLogicWriteTest {
 
     @Test
-    void commitResultsConsumerNotImplementingConsumerInterface() {
+    void commitListenerNotImplementingConsumerInterface() {
         Map<String, String> props = new HashMap<>();
-        props.put(Options.WRITE_COMMIT_RESULTS_CONSUMER_CLASSNAME, NotAConsumer.class.getName());
+        props.put(Options.WRITE_COMMIT_LISTENER_CLASSNAME, NotAConsumer.class.getName());
 
         WriteContext writeContext = new WriteContext(new StructType().add("test", DataTypes.StringType), props);
 
@@ -30,31 +30,31 @@ class MarkLogicWriteTest {
     }
 
     @Test
-    void commitResultsConsumerWithNoZeroArgConstructor() {
+    void commitListenerWithNoMapConstructor() {
         Map<String, String> props = new HashMap<>();
-        props.put(Options.WRITE_COMMIT_RESULTS_CONSUMER_CLASSNAME, NoZeroArgConstructor.class.getName());
+        props.put(Options.WRITE_COMMIT_LISTENER_CLASSNAME, NoMapConstructor.class.getName());
 
         WriteContext writeContext = new WriteContext(new StructType().add("test", DataTypes.StringType), props);
 
         ConnectorException ex = assertThrows(ConnectorException.class, () -> new MarkLogicWrite(writeContext));
-        assertTrue(ex.getMessage().contains("Unable to instantiate commit results consumer"),
+        assertTrue(ex.getMessage().contains("Unable to instantiate commit listener"),
             "Unexpected error message: " + ex.getMessage());
     }
 
     @Test
-    void commitResultsConsumerNotFound() {
+    void commitListenerNotFound() {
         Map<String, String> props = new HashMap<>();
-        props.put(Options.WRITE_COMMIT_RESULTS_CONSUMER_CLASSNAME, "com.example.NonExistentClass");
+        props.put(Options.WRITE_COMMIT_LISTENER_CLASSNAME, "com.example.NonExistentClass");
 
         WriteContext writeContext = new WriteContext(new StructType().add("test", DataTypes.StringType), props);
 
         ConnectorException ex = assertThrows(ConnectorException.class, () -> new MarkLogicWrite(writeContext));
-        assertTrue(ex.getMessage().contains("Unable to instantiate commit results consumer"),
+        assertTrue(ex.getMessage().contains("Unable to instantiate commit listener"),
             "Unexpected error message: " + ex.getMessage());
     }
 
     @Test
-    void commitResultsConsumerNotSpecified() {
+    void commitListenerNotSpecified() {
         Map<String, String> props = new HashMap<>();
         WriteContext writeContext = new WriteContext(new StructType().add("test", DataTypes.StringType), props);
 
@@ -63,9 +63,9 @@ class MarkLogicWriteTest {
     }
 
     @Test
-    void commitResultsConsumerWithEmptyString() {
+    void commitListenerWithEmptyString() {
         Map<String, String> props = new HashMap<>();
-        props.put(Options.WRITE_COMMIT_RESULTS_CONSUMER_CLASSNAME, "   ");
+        props.put(Options.WRITE_COMMIT_LISTENER_CLASSNAME, "   ");
 
         WriteContext writeContext = new WriteContext(new StructType().add("test", DataTypes.StringType), props);
 
@@ -73,15 +73,34 @@ class MarkLogicWriteTest {
         assertDoesNotThrow(() -> new MarkLogicWrite(writeContext));
     }
 
-    // Test helper classes
+    @Test
+    void commitListenerWithParams() {
+        Map<String, String> props = new HashMap<>();
+        props.put(Options.WRITE_COMMIT_LISTENER_CLASSNAME, CommitResultsTestConsumer.class.getName());
+        props.put(Options.WRITE_COMMIT_LISTENER_PARAM_PREFIX + "param1", "value1");
+        props.put(Options.WRITE_COMMIT_LISTENER_PARAM_PREFIX + "param2", "value2");
 
-    public static class NotAConsumer {
-        public NotAConsumer() {
+        try {
+            WriteContext writeContext = new WriteContext(new StructType().add("test", DataTypes.StringType), props);
+            new MarkLogicWrite(writeContext);
+            Map<String, String> params = CommitResultsTestConsumer.params;
+            assertEquals(2, params.size());
+            assertEquals("value1", params.get("param1"));
+            assertEquals("value2", params.get("param2"));
+        } finally {
+            CommitResultsTestConsumer.reset();
         }
     }
 
-    public static class NoZeroArgConstructor implements Consumer<Map<String, Object>> {
-        public NoZeroArgConstructor(String requiredArg) {
+    // Test helper classes
+
+    public static class NotAConsumer {
+        public NotAConsumer(Map<String, String> params) {
+        }
+    }
+
+    public static class NoMapConstructor implements Consumer<Map<String, Object>> {
+        public NoMapConstructor() {
         }
 
         @Override

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/WriteArchiveOfFailedDocumentsTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/WriteArchiveOfFailedDocumentsTest.java
@@ -38,7 +38,7 @@ class WriteArchiveOfFailedDocumentsTest extends AbstractWriteTest {
             .option(Options.WRITE_URI_SUFFIX, ".json")
             .option(Options.WRITE_ABORT_ON_FAILURE, false)
             .option(Options.WRITE_ARCHIVE_PATH_FOR_FAILED_DOCUMENTS, tempDir.toFile().getAbsolutePath())
-            .option(Options.WRITE_COMMIT_RESULTS_CONSUMER_CLASSNAME, "com.marklogic.spark.writer.CommitResultsTestConsumer")
+            .option(Options.WRITE_COMMIT_LISTENER_CLASSNAME, "com.marklogic.spark.writer.CommitResultsTestConsumer")
         );
 
         assertCollectionSize("Only the JSON document should have succeeded; error messages should have been logged " +

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/WriteRowsTest.java
@@ -268,7 +268,7 @@ class WriteRowsTest extends AbstractWriteTest {
             // will in fact succeed (if it's stuck in a batch with other bad rows, it'll fail too).
             .option(Options.WRITE_BATCH_SIZE, 1)
             .option(Options.WRITE_ABORT_ON_FAILURE, false)
-            .option(Options.WRITE_COMMIT_RESULTS_CONSUMER_CLASSNAME, "com.marklogic.spark.writer.CommitResultsTestConsumer")
+            .option(Options.WRITE_COMMIT_LISTENER_CLASSNAME, "com.marklogic.spark.writer.CommitResultsTestConsumer")
             .save();
 
         assertCollectionSize("9 of the batches should have failed, with the 10th batch succeeding", COLLECTION, 1);

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/customcode/ProcessWithCustomCodeTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/customcode/ProcessWithCustomCodeTest.java
@@ -175,7 +175,7 @@ class ProcessWithCustomCodeTest extends AbstractWriteTest {
         newWriterWithDefaultConfig("three-uris.csv", 2)
             .option(Options.WRITE_JAVASCRIPT, "var URI; throw Error('Boom!');")
             .option(Options.WRITE_ABORT_ON_FAILURE, "false")
-            .option(Options.WRITE_COMMIT_RESULTS_CONSUMER_CLASSNAME, "com.marklogic.spark.writer.CommitResultsTestConsumer")
+            .option(Options.WRITE_COMMIT_LISTENER_CLASSNAME, "com.marklogic.spark.writer.CommitResultsTestConsumer")
             .save();
 
         assertEquals(3, CommitResultsTestConsumer.failureCount.get());


### PR DESCRIPTION
Renamed from "consumer" to "listener" as well for consistency in the options as opposed to being specific to the implementation class name.
