### PR TITLE
MLE-30009 MLE-30010 MLE-30011 address OpenNLP Tools v2.5.4 CVEs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ version=3.2.0-SNAPSHOT
 sparkVersion=4.1.1
 tikaVersion=3.2.3
 semaphoreVersion=5.10.0
-langchain4jVersion=1.11.0
+langchain4jVersion=1.17.2
 
 # Always have to make sure we use the same version of Jackson that Spark does.
 jacksonVersion=2.21.1

--- a/marklogic-spark-connector/build.gradle
+++ b/marklogic-spark-connector/build.gradle
@@ -97,8 +97,10 @@ dependencies {
     exclude module: "rocksdbjni"
   }
 
-  // Supports testing the embedder feature.
-  testImplementation "dev.langchain4j:langchain4j-embeddings-all-minilm-l6-v2:1.11.0-beta19"
+  // Pinned to 1.14.1-beta24 (uses ai.djl.huggingface:tokenizers:0.31.1) rather than ${langchain4jVersion}-beta27
+  // (uses tokenizers:0.36.0) because 0.36.0's libtokenizers.so requires GLIBC 2.29, which is not available on
+  // the CI build server. 1.15.0-beta25 was the first version to require GLIBC 2.29.
+  testImplementation "dev.langchain4j:langchain4j-embeddings-all-minilm-l6-v2:1.14.1-beta24"
 
   testImplementation "com.marklogic:ml-app-deployer:6.2.0"
   testImplementation "com.marklogic:marklogic-junit5:2.0.0"


### PR DESCRIPTION
- CVE-2026-40682 in OpenNLP Tools v2.5.4 (MarkLogic-DevExp-spark-connector)
- CVE-2026-42027 in OpenNLP Tools v2.5.4 (MarkLogic-DevExp-spark-connector)
- CVE-2026-42440 in OpenNLP Tools v2.5.4 (MarkLogic-DevExp-spark-connector)