### PR TITLE
MLE-30316 Allow configurable socket timeout for classification requests in Flux

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
-# Using 3.2.0-SNAPSHOT temporarily instead of 3.2-SNAPSHOT
-version=3.2.0-SNAPSHOT
+version=3.2-SNAPSHOT
 sparkVersion=4.1.1
 tikaVersion=3.2.3
 semaphoreVersion=5.10.0

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
@@ -601,7 +601,7 @@ public abstract class Options {
 
     /**
      * Defines the socket timeout in milliseconds for classification requests.
-     * Defaults to 10000 (10 seconds).
+     * When not set, the Semaphore library default is used (currently 10000 ms / 10 seconds).
      *
      * @since 3.1.2
      */

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
@@ -600,12 +600,18 @@ public abstract class Options {
     public static final String WRITE_CLASSIFIER_BATCH_SIZE = "spark.marklogic.write.classifier.batchSize";
 
     /**
-     * Defines the socket timeout in milliseconds for classification requests.
-     * When not set, the Semaphore library default is used (currently 10000 ms / 10 seconds).
+     * Defines the socket timeout in seconds for classification requests.
      *
      * @since 3.1.2
      */
     public static final String WRITE_CLASSIFIER_SOCKET_TIMEOUT = "spark.marklogic.write.classifier.socketTimeout";
+
+    /**
+     * Defines the connection timeout in seconds for classification requests.
+     *
+     * @since 3.1.2
+     */
+    public static final String WRITE_CLASSIFIER_CONNECTION_TIMEOUT = "spark.marklogic.write.classifier.connectionTimeout";
 
     /**
      * Allows for passing any additional options to the text classifier.

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
@@ -600,6 +600,14 @@ public abstract class Options {
     public static final String WRITE_CLASSIFIER_BATCH_SIZE = "spark.marklogic.write.classifier.batchSize";
 
     /**
+     * Defines the socket timeout in milliseconds for classification requests.
+     * Defaults to 10000 (10 seconds).
+     *
+     * @since 3.1.2
+     */
+    public static final String WRITE_CLASSIFIER_SOCKET_TIMEOUT = "spark.marklogic.write.classifier.socketTimeout";
+
+    /**
      * Allows for passing any additional options to the text classifier.
      *
      * @since 2.6.0

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/core/classifier/ConfigHelper.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/core/classifier/ConfigHelper.java
@@ -31,7 +31,7 @@ class ConfigHelper {
         this.protocol = "true".equalsIgnoreCase(context.getStringOption(Options.WRITE_CLASSIFIER_HTTP)) ? "http" : "https";
         this.classifierPath = fixPath(context.getStringOption(Options.WRITE_CLASSIFIER_PATH, "/"));
         this.tokenEndpoint = fixPath(context.getStringOption(Options.WRITE_CLASSIFIER_TOKEN_PATH, "/token"));
-        this.socketTimeoutMs = context.getIntOption(Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, -1, -1);
+        this.socketTimeoutMs = context.getIntOption(Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, -1, 1);
 
         context.getProperties().forEach((key, value) -> {
             if (key.startsWith(Options.WRITE_CLASSIFIER_OPTION_PREFIX)) {

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/core/classifier/ConfigHelper.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/core/classifier/ConfigHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.core.classifier;
 
@@ -22,6 +22,7 @@ class ConfigHelper {
     private final String protocol;
     private final String classifierPath;
     private final String tokenEndpoint;
+    private final int socketTimeoutMs;
     private final Map<String, String> additionalParameters = new HashMap<>();
 
     ConfigHelper(Context context) {
@@ -30,6 +31,7 @@ class ConfigHelper {
         this.protocol = "true".equalsIgnoreCase(context.getStringOption(Options.WRITE_CLASSIFIER_HTTP)) ? "http" : "https";
         this.classifierPath = fixPath(context.getStringOption(Options.WRITE_CLASSIFIER_PATH, "/"));
         this.tokenEndpoint = fixPath(context.getStringOption(Options.WRITE_CLASSIFIER_TOKEN_PATH, "/token"));
+        this.socketTimeoutMs = context.getIntOption(Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, -1, -1);
 
         context.getProperties().forEach((key, value) -> {
             if (key.startsWith(Options.WRITE_CLASSIFIER_OPTION_PREFIX)) {
@@ -49,6 +51,9 @@ class ConfigHelper {
         config.setHostPort(port);
         config.setProtocol(protocol);
         config.setHostPath(classifierPath);
+        if (socketTimeoutMs > 0) {
+            config.setSocketTimeoutMS(socketTimeoutMs);
+        }
         if (!this.additionalParameters.isEmpty()) {
             config.setAdditionalParameters(additionalParameters);
         }

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/core/classifier/ConfigHelper.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/core/classifier/ConfigHelper.java
@@ -22,7 +22,8 @@ class ConfigHelper {
     private final String protocol;
     private final String classifierPath;
     private final String tokenEndpoint;
-    private final int socketTimeoutMs;
+    private final int socketTimeoutSeconds;
+    private final int connectionTimeoutSeconds;
     private final Map<String, String> additionalParameters = new HashMap<>();
 
     ConfigHelper(Context context) {
@@ -31,7 +32,8 @@ class ConfigHelper {
         this.protocol = "true".equalsIgnoreCase(context.getStringOption(Options.WRITE_CLASSIFIER_HTTP)) ? "http" : "https";
         this.classifierPath = fixPath(context.getStringOption(Options.WRITE_CLASSIFIER_PATH, "/"));
         this.tokenEndpoint = fixPath(context.getStringOption(Options.WRITE_CLASSIFIER_TOKEN_PATH, "/token"));
-        this.socketTimeoutMs = context.getIntOption(Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, -1, 1);
+        this.socketTimeoutSeconds = context.getIntOption(Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, -1, 1);
+        this.connectionTimeoutSeconds = context.getIntOption(Options.WRITE_CLASSIFIER_CONNECTION_TIMEOUT, -1, 1);
 
         context.getProperties().forEach((key, value) -> {
             if (key.startsWith(Options.WRITE_CLASSIFIER_OPTION_PREFIX)) {
@@ -51,8 +53,11 @@ class ConfigHelper {
         config.setHostPort(port);
         config.setProtocol(protocol);
         config.setHostPath(classifierPath);
-        if (socketTimeoutMs > 0) {
-            config.setSocketTimeoutMS(socketTimeoutMs);
+        if (socketTimeoutSeconds > 0) {
+            config.setSocketTimeoutMS(socketTimeoutSeconds * 1000);
+        }
+        if (connectionTimeoutSeconds > 0) {
+            config.setConnectionTimeoutMS(connectionTimeoutSeconds * 1000);
         }
         if (!this.additionalParameters.isEmpty()) {
             config.setAdditionalParameters(additionalParameters);

--- a/marklogic-spark-connector/src/main/resources/marklogic-spark-messages.properties
+++ b/marklogic-spark-connector/src/main/resources/marklogic-spark-messages.properties
@@ -23,3 +23,4 @@ spark.marklogic.write.embedder.chunks.jsonPointer=
 spark.marklogic.write.embedder.chunks.xpath=
 spark.marklogic.write.embedder.batchSize=
 spark.marklogic.write.classifier.socketTimeout=
+spark.marklogic.write.classifier.connectionTimeout=

--- a/marklogic-spark-connector/src/main/resources/marklogic-spark-messages.properties
+++ b/marklogic-spark-connector/src/main/resources/marklogic-spark-messages.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Defines various messages for the connector. Intended to be inherited and overridden by the ETL tool via
 # marklogic-spark-messages_en.properties, where each option name can be associated with a CLI option in the ETL tool.
 spark.marklogic.client.uri=
@@ -22,3 +22,4 @@ spark.marklogic.write.splitter.sidecar.maxChunks=
 spark.marklogic.write.embedder.chunks.jsonPointer=
 spark.marklogic.write.embedder.chunks.xpath=
 spark.marklogic.write.embedder.batchSize=
+spark.marklogic.write.classifier.socketTimeout=

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/classifier/ConfigHelperTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/classifier/ConfigHelperTest.java
@@ -102,13 +102,13 @@ class ConfigHelperTest {
     void customSocketTimeout() {
         Map<String, String> properties = new HashMap<>() {{
             put(Options.WRITE_CLASSIFIER_HOST, "somehost");
-            put(Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, "30000");
+            put(Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, "30");
         }};
 
         ConfigHelper helper = new ConfigHelper(new Context(properties));
         ClassificationConfiguration config = helper.buildClassificationConfiguration();
-        assertEquals(30000, config.getSocketTimeoutMS(),
-            "When a socket timeout option is provided, the configured value should be set on ClassificationConfiguration.");
+        assertEquals(30_000, config.getSocketTimeoutMS(),
+            "Socket timeout of 30 seconds should be applied as 30000 ms.");
     }
 
     @Test
@@ -120,5 +120,42 @@ class ConfigHelperTest {
 
         assertThrows(ConnectorException.class, () -> new ConfigHelper(new Context(properties)),
             "A socket timeout of 0 should be rejected with a clear error rather than silently ignored.");
+    }
+
+    @Test
+    void defaultConnectionTimeout() {
+        Map<String, String> properties = new HashMap<>() {{
+            put(Options.WRITE_CLASSIFIER_HOST, "somehost");
+        }};
+
+        ConfigHelper helper = new ConfigHelper(new Context(properties));
+        ClassificationConfiguration config = helper.buildClassificationConfiguration();
+        int defaultConnectionTimeout = new ClassificationConfiguration().getConnectionTimeoutMS();
+        assertEquals(defaultConnectionTimeout, config.getConnectionTimeoutMS(),
+            "When no connection timeout option is provided, the Semaphore library default should be preserved.");
+    }
+
+    @Test
+    void customConnectionTimeout() {
+        Map<String, String> properties = new HashMap<>() {{
+            put(Options.WRITE_CLASSIFIER_HOST, "somehost");
+            put(Options.WRITE_CLASSIFIER_CONNECTION_TIMEOUT, "15");
+        }};
+
+        ConfigHelper helper = new ConfigHelper(new Context(properties));
+        ClassificationConfiguration config = helper.buildClassificationConfiguration();
+        assertEquals(15_000, config.getConnectionTimeoutMS(),
+            "Connection timeout of 15 seconds should be applied as 15000 ms.");
+    }
+
+    @Test
+    void invalidConnectionTimeout() {
+        Map<String, String> properties = new HashMap<>() {{
+            put(Options.WRITE_CLASSIFIER_HOST, "somehost");
+            put(Options.WRITE_CLASSIFIER_CONNECTION_TIMEOUT, "0");
+        }};
+
+        assertThrows(ConnectorException.class, () -> new ConfigHelper(new Context(properties)),
+            "A connection timeout of 0 should be rejected with a clear error.");
     }
 }

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/classifier/ConfigHelperTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/classifier/ConfigHelperTest.java
@@ -3,6 +3,7 @@
  */
 package com.marklogic.spark.core.classifier;
 
+import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Context;
 import com.marklogic.spark.Options;
 import com.smartlogic.classificationserver.client.ClassificationConfiguration;
@@ -14,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ConfigHelperTest {
 
@@ -106,5 +108,16 @@ class ConfigHelperTest {
         ClassificationConfiguration config = helper.buildClassificationConfiguration();
         assertEquals(30000, config.getSocketTimeoutMS(),
             "When a socket timeout option is provided, the configured value should be set on ClassificationConfiguration.");
+    }
+
+    @Test
+    void invalidSocketTimeout() {
+        Map<String, String> properties = new HashMap<>() {{
+            put(Options.WRITE_CLASSIFIER_HOST, "somehost");
+            put(Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, "0");
+        }};
+
+        assertThrows(ConnectorException.class, () -> new ConfigHelper(new Context(properties)),
+            "A socket timeout of 0 should be rejected with a clear error rather than silently ignored.");
     }
 }

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/classifier/ConfigHelperTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/classifier/ConfigHelperTest.java
@@ -93,9 +93,9 @@ class ConfigHelperTest {
 
         ConfigHelper helper = new ConfigHelper(new Context(properties));
         ClassificationConfiguration config = helper.buildClassificationConfiguration();
-        assertEquals(10000, config.getSocketTimeoutMS(),
-            "When no socket timeout option is provided, the Semaphore library default of 10000 ms should be preserved.");
-    }
+        int defaultSocketTimeout = new ClassificationConfiguration().getSocketTimeoutMS();
+        assertEquals(defaultSocketTimeout, config.getSocketTimeoutMS(),
+            "When no socket timeout option is provided, the Semaphore library default should be preserved.");
 
     @Test
     void customSocketTimeout() {

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/classifier/ConfigHelperTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/classifier/ConfigHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.core.classifier;
 
@@ -81,5 +81,30 @@ class ConfigHelperTest {
         Map<String, String> additionalParams = config.getAdditionalParameters();
         assertEquals("17", additionalParams.get("threshold"));
         assertEquals("ch1", additionalParams.get("language"));
+    }
+
+    @Test
+    void defaultSocketTimeout() {
+        Map<String, String> properties = new HashMap<>() {{
+            put(Options.WRITE_CLASSIFIER_HOST, "somehost");
+        }};
+
+        ConfigHelper helper = new ConfigHelper(new Context(properties));
+        ClassificationConfiguration config = helper.buildClassificationConfiguration();
+        assertEquals(10000, config.getSocketTimeoutMS(),
+            "When no socket timeout option is provided, the Semaphore library default of 10000 ms should be preserved.");
+    }
+
+    @Test
+    void customSocketTimeout() {
+        Map<String, String> properties = new HashMap<>() {{
+            put(Options.WRITE_CLASSIFIER_HOST, "somehost");
+            put(Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, "30000");
+        }};
+
+        ConfigHelper helper = new ConfigHelper(new Context(properties));
+        ClassificationConfiguration config = helper.buildClassificationConfiguration();
+        assertEquals(30000, config.getSocketTimeoutMS(),
+            "When a socket timeout option is provided, the configured value should be set on ClassificationConfiguration.");
     }
 }

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/classifier/ConfigHelperTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/classifier/ConfigHelperTest.java
@@ -96,6 +96,7 @@ class ConfigHelperTest {
         int defaultSocketTimeout = new ClassificationConfiguration().getSocketTimeoutMS();
         assertEquals(defaultSocketTimeout, config.getSocketTimeoutMS(),
             "When no socket timeout option is provided, the Semaphore library default should be preserved.");
+    }
 
     @Test
     void customSocketTimeout() {


### PR DESCRIPTION
### Problem

The Semaphore `ClassificationConfiguration` used by the connector had a hardcoded 10-second socket timeout with no way to override it. When classifying large or complex documents (e.g., PDFs with forced language settings), server-side processing can exceed this limit, resulting in timeout errors that cannot be resolved by reducing batch size.

### Solution

Added a new `spark.marklogic.write.classifier.socketTimeout` option that lets users configure the socket timeout in milliseconds for classification requests.

When the option is not set, the Semaphore library's default of 10,000 ms (10 seconds) is preserved — no behavior change for existing users.

### Changes

**Options.java**
- Added `WRITE_CLASSIFIER_SOCKET_TIMEOUT = "spark.marklogic.write.classifier.socketTimeout"` constant (`@since 3.1.2`).

**ConfigHelper.java**
- Added `socketTimeoutMs` field, read from the connector context with a sentinel default of `-1`.
- In `buildClassificationConfiguration()`, calls `config.setSocketTimeoutMS(socketTimeoutMs)` only when the value is `> 0`, leaving the Semaphore library's default untouched otherwise.

**ConfigHelperTest.java**
- `defaultSocketTimeout()` — verifies the Semaphore library default of 10,000 ms is preserved when the option is absent.
- `customSocketTimeout()` — verifies a configured value (e.g., 30,000 ms) is applied correctly.

### Testing

Unit tests only — no MarkLogic instance required. The timeout behavior is fully verifiable by asserting against `ClassificationConfiguration.getSocketTimeoutMS()`.

```
./gradlew :marklogic-spark-connector:test --tests com.marklogic.spark.core.classifier.ConfigHelperTest
```

All 6 tests pass.

### Notes

- This option is consumed by Flux via `--classifier-timeout` (see companion PR in the `flux` repository).
- Passing `socketTimeoutMS` via `--classifier-prop` would not work as a workaround — those values are sent as HTTP query parameters to the Semaphore endpoint, not applied as client-side socket configuration.

Jira Story: https://progresssoftware.atlassian.net/browse/MLE-30316