### PR TITLE
MLE-31185 Bump logback-classic to 1.5.37

### DIFF
--- a/marklogic-spark-connector/build.gradle
+++ b/marklogic-spark-connector/build.gradle
@@ -108,7 +108,7 @@ dependencies {
   // For asserting on log messages.
   testImplementation "io.github.hakky54:logcaptor:2.12.5"
 
-  testImplementation "ch.qos.logback:logback-classic:1.5.32"
+  testImplementation "ch.qos.logback:logback-classic:1.5.37"
   testImplementation "org.skyscreamer:jsonassert:1.5.3"
 
   testImplementation "org.apache.tika:tika-parser-microsoft-module:${tikaVersion}"


### PR DESCRIPTION
Bump logback-classic from 1.5.32 to 1.5.37.

Jira Story: https://progresssoftware.atlassian.net/browse/MLE-31185