### PR TITLE
MLE-31167 Bump jacksonVersion to 2.22.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ semaphoreVersion=5.10.0
 langchain4jVersion=1.17.2
 
 # Always have to make sure we use the same version of Jackson that Spark does.
-jacksonVersion=2.21.1
+jacksonVersion=2.22.1
 
 # Define these on the command line to publish to OSSRH
 # See https://central.sonatype.org/publish/publish-gradle/#credentials for more information


### PR DESCRIPTION
Bumping jacksonVersion from 2.21.1 to 2.22.1.

Jira Story: https://progresssoftware.atlassian.net/browse/MLE-31167