### PR TITLE
MLE-31169 Bump Netty to use 4.2.16.Final

### DIFF
--- a/marklogic-spark-connector/build.gradle
+++ b/marklogic-spark-connector/build.gradle
@@ -27,7 +27,7 @@ configurations.configureEach {
      // This is a test-only / compile-only dependency, but doing this as it helps ensure tests pass as Flux
      // will need it bumped for sure.
      if (details.requested.group.equals("io.netty") and (details.requested.version.startsWith("4.1.") || details.requested.version.startsWith("4.2."))) {
-       details.useVersion "4.2.13.Final"
+       details.useVersion "4.2.16.Final"
        details.because "Forcing Spark 4.1.x to use latest Netty to minimize CVEs"
      }
    }


### PR DESCRIPTION
Bump Netty from 4.2.13.Final to 4.2.16 Final to reduce CVEs

Jira Story: https://progresssoftware.atlassian.net/browse/MLE-31169