### PR TITLE
MLE-31221 Reduce false positives for token refresh

### DIFF
--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/core/classifier/TokenRefreshHandler.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/core/classifier/TokenRefreshHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.core.classifier;
 
@@ -9,6 +9,7 @@ import com.smartlogic.classificationserver.client.ClassificationException;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 /**
  * Handles token refresh logic when a 401 error is received from the classification server.
@@ -16,6 +17,10 @@ import java.util.function.Supplier;
  * the ClassificationClient.
  */
 record TokenRefreshHandler(Supplier<String> tokenGenerator, Consumer<String> tokenSetter) {
+
+    // Word-boundary regex ensures "401" matches only as a standalone token, not as part of
+    // a longer number such as "4010".
+    private static final Pattern HTTP_401_PATTERN = Pattern.compile("\\b401\\b");
 
     <T> T executeWithTokenRefresh(SupplierWithException<T> operation, String errorContext) throws ClassificationException {
         try {
@@ -32,11 +37,11 @@ record TokenRefreshHandler(Supplier<String> tokenGenerator, Consumer<String> tok
 
     boolean isTokenExpired(ClassificationException ex) {
         // The Classification server currently - December 2025 - responds with "401 received from classification server".
-        // Looking for that entire message is likely brittle as it could change at any time. So just checking for the
-        // presence of "401". Worst case, we may attempt a token refresh when not needed.
+        // A word-boundary match on "401" avoids false positives from error codes that merely contain
+        // "401" as a substring (e.g. "Error 4010: invalid parameter").
         return tokenGenerator != null &&
             ex.getMessage() != null &&
-            ex.getMessage().contains("401");
+            HTTP_401_PATTERN.matcher(ex.getMessage()).find();
     }
 
     private void refreshToken() {

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/classifier/TokenRefreshHandlerTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/classifier/TokenRefreshHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.core.classifier;
 
@@ -118,13 +118,26 @@ class TokenRefreshHandlerTest {
         TokenRefreshHandler handler = new TokenRefreshHandler(() -> "token", token -> {
         });
 
-        ClassificationException ex401 = new ClassificationException("Noise.. 401 Noise...");
-        assertTrue(handler.isTokenExpired(ex401), "The expectation is that the presence of just '401' " +
-            "in the message indicates an expired token. This avoids checking a much longer message that could change " +
-            "at any time. And worst case, we may attempt a token refresh when not needed.");
+        // Exact server format
+        assertTrue(handler.isTokenExpired(new ClassificationException("401 received from classification server")));
+        // "401" anywhere in the message, surrounded by non-digit characters
+        assertTrue(handler.isTokenExpired(new ClassificationException("Noise.. 401 Noise...")));
 
-        ClassificationException exOther = new ClassificationException("Some other error");
-        assertFalse(handler.isTokenExpired(exOther));
+        assertFalse(handler.isTokenExpired(new ClassificationException("Some other error")));
+    }
+
+    @Test
+    void partialNumberDoesNotTriggerTokenRefresh() {
+        // "4010" contains "401" as a substring but must NOT be treated as an HTTP 401.
+        TokenRefreshHandler handler = new TokenRefreshHandler(() -> "token", token -> {
+        });
+
+        assertFalse(handler.isTokenExpired(new ClassificationException("Error 4010: invalid parameter")),
+            "A message containing '401' only as part of a longer number should not trigger a token refresh");
+        assertFalse(handler.isTokenExpired(new ClassificationException("4010")),
+            "'4010' with no surrounding text should not match the word-boundary pattern for 401");
+        assertFalse(handler.isTokenExpired(new ClassificationException("x4010x")),
+            "'4010' embedded in alphanumeric text should not trigger a token refresh");
     }
 
     @Test

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/classifier/TokenRefreshHandlerTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/classifier/TokenRefreshHandlerTest.java
@@ -120,7 +120,7 @@ class TokenRefreshHandlerTest {
 
         // Exact server format
         assertTrue(handler.isTokenExpired(new ClassificationException("401 received from classification server")));
-        // "401" anywhere in the message, surrounded by non-digit characters
+        // "401" anywhere in the message, delimited by non-word characters (word-boundary match)
         assertTrue(handler.isTokenExpired(new ClassificationException("Noise.. 401 Noise...")));
 
         assertFalse(handler.isTokenExpired(new ClassificationException("Some other error")));


### PR DESCRIPTION
The connector should trigger a token refresh only when it receives a genuine HTTP 401 Unauthorized response indicating token expiry — not for any other error that happens to contain the string "401".

Verified by partialNumberDoesNotTriggerTokenRefresh() test.