### PR TITLE
MLE-31217 Enforce Emmbedding Model Class Interface

### DIFF
--- a/marklogic-spark-connector/src/main/java/com/marklogic/langchain4j/Langchain4jFactory.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/langchain4j/Langchain4jFactory.java
@@ -77,7 +77,7 @@ public class Langchain4jFactory implements TextSplitterFactory, EmbeddingProduce
             if (!Function.class.isAssignableFrom(clazz)) {
                 throw new ConnectorException(String.format(
                     "Class '%s' specified for option '%s' does not implement java.util.function.Function; " +
-                    "the class must implement Function<Map<String, String>, EmbeddingModel>.",
+                    "expected a Function whose apply(Map<String, String> options) method returns an EmbeddingModel.",
                     className, Options.WRITE_EMBEDDER_MODEL_FUNCTION_CLASS_NAME));
             }
             Object instance = clazz.getDeclaredConstructor().newInstance();

--- a/marklogic-spark-connector/src/main/java/com/marklogic/langchain4j/Langchain4jFactory.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/langchain4j/Langchain4jFactory.java
@@ -69,7 +69,11 @@ public class Langchain4jFactory implements TextSplitterFactory, EmbeddingProduce
 
         final String className = context.getStringOption(Options.WRITE_EMBEDDER_MODEL_FUNCTION_CLASS_NAME);
         try {
-            Class<?> clazz = Class.forName(className, false, Thread.currentThread().getContextClassLoader());
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            if (classLoader == null) {
+                classLoader = Langchain4jFactory.class.getClassLoader();
+            }
+            Class<?> clazz = Class.forName(className, false, classLoader);
             if (!Function.class.isAssignableFrom(clazz)) {
                 throw new ConnectorException(String.format(
                     "Class '%s' specified for option '%s' does not implement java.util.function.Function; " +

--- a/marklogic-spark-connector/src/main/java/com/marklogic/langchain4j/Langchain4jFactory.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/langchain4j/Langchain4jFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.langchain4j;
 
@@ -69,11 +69,20 @@ public class Langchain4jFactory implements TextSplitterFactory, EmbeddingProduce
 
         final String className = context.getStringOption(Options.WRITE_EMBEDDER_MODEL_FUNCTION_CLASS_NAME);
         try {
-            Object instance = Class.forName(className).getDeclaredConstructor().newInstance();
+            Class<?> clazz = Class.forName(className, false, Thread.currentThread().getContextClassLoader());
+            if (!Function.class.isAssignableFrom(clazz)) {
+                throw new ConnectorException(String.format(
+                    "Class '%s' specified for option '%s' does not implement java.util.function.Function; " +
+                    "the class must implement Function<Map<String, String>, EmbeddingModel>.",
+                    className, Options.WRITE_EMBEDDER_MODEL_FUNCTION_CLASS_NAME));
+            }
+            Object instance = clazz.getDeclaredConstructor().newInstance();
             @SuppressWarnings("unchecked")
             Function<Map<String, String>, EmbeddingModel> modelFunction = (Function<Map<String, String>, EmbeddingModel>) instance;
             Map<String, String> embedderOptions = makeEmbedderOptions(context);
             return Optional.of(modelFunction.apply(embedderOptions));
+        } catch (ConnectorException ex) {
+            throw ex;
         } catch (Exception ex) {
             String message = ex.getMessage();
             if (ex instanceof ClassNotFoundException) {

--- a/marklogic-spark-connector/src/test/java/com/marklogic/langchain4j/MakeEmbeddingModelTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/langchain4j/MakeEmbeddingModelTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.langchain4j;
+
+import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Context;
+import com.marklogic.spark.Options;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MakeEmbeddingModelTest {
+
+    private static final String VALID_FUNCTION_CLASS =
+        "com.marklogic.langchain4j.StubEmbeddingModelFunction";
+
+    /**
+     * AC3: A class that exists but does NOT implement Function must cause a ConnectorException to be thrown
+     * immediately, before getDeclaredConstructor().newInstance() is ever called.
+     * java.lang.String is used as a convenient existing class that does not implement Function.
+     */
+    @Test
+    void classExistsButDoesNotImplementFunction() {
+        Context context = contextWithOption(Options.WRITE_EMBEDDER_MODEL_FUNCTION_CLASS_NAME, "java.lang.String");
+
+        ConnectorException ex = assertThrows(ConnectorException.class,
+            () -> Langchain4jFactory.makeEmbeddingModel(context));
+
+        String message = ex.getMessage();
+        assertTrue(message.contains("java.lang.String"),
+            "Error message should contain the class name; was: " + message);
+        assertTrue(message.contains("java.util.function.Function"),
+            "Error message should name the required interface; was: " + message);
+        assertTrue(message.contains(Options.WRITE_EMBEDDER_MODEL_FUNCTION_CLASS_NAME),
+            "Error message should name the option; was: " + message);
+        // Must NOT be wrapped in the generic 'Unable to instantiate' message
+        assertFalse(message.startsWith("Unable to instantiate class"),
+            "ConnectorException should be thrown directly, not wrapped; was: " + message);
+    }
+
+    /**
+     * AC4: A valid Function class must be resolved and return a non-empty Optional without errors.
+     */
+    @Test
+    void validFunctionClassSucceeds() {
+        Context context = contextWithOption(Options.WRITE_EMBEDDER_MODEL_FUNCTION_CLASS_NAME, VALID_FUNCTION_CLASS);
+
+        Optional<EmbeddingModel> result = Langchain4jFactory.makeEmbeddingModel(context);
+
+        assertTrue(result.isPresent(), "A valid function class should produce an EmbeddingModel");
+    }
+
+    private static Context contextWithOption(String key, String value) {
+        Map<String, String> options = new HashMap<>();
+        options.put(key, value);
+        return new Context(options);
+    }
+}

--- a/marklogic-spark-connector/src/test/java/com/marklogic/langchain4j/StubEmbeddingModelFunction.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/langchain4j/StubEmbeddingModelFunction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.langchain4j;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Minimal stub used in unit tests to verify that a valid Function class is accepted without errors.
+ * Does not load any native ONNX or DJL resources.
+ */
+public class StubEmbeddingModelFunction implements Function<Map<String, String>, EmbeddingModel>, EmbeddingModel {
+
+    @Override
+    public EmbeddingModel apply(Map<String, String> options) {
+        return this;
+    }
+
+    @Override
+    public int dimension() {
+        return 0;
+    }
+
+    @Override
+    public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
+        return Response.from(List.of());
+    }
+}

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/embedding/AddEmbeddingsToJsonTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/embedding/AddEmbeddingsToJsonTest.java
@@ -105,7 +105,7 @@ class AddEmbeddingsToJsonTest extends AbstractEmbeddingTest {
 
     @Test
     void passOptionsToEmbeddingModelFunction() {
-        DataFrameWriter writer = readDocument("/marklogic-docs/java-client-intro.json")
+        DataFrameWriter<Row> writer = readDocument("/marklogic-docs/java-client-intro.json")
             .write().format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.WRITE_SPLITTER_JSON_POINTERS, "/text")
@@ -116,10 +116,10 @@ class AddEmbeddingsToJsonTest extends AbstractEmbeddingTest {
             .mode(SaveMode.Append);
 
         ConnectorException ex = assertThrowsConnectorException(writer::save);
-        assertEquals("Unable to instantiate class for creating an embedding model; class name: com.marklogic.spark.writer.embedding.MinilmEmbeddingModelFunction; " +
-                "cause: Intentional error.", ex.getMessage(),
+        assertEquals("Intentional error.", ex.getMessage(),
             "This test verifies that a custom option can be sent to the embedding model function class. In this " +
-                "case, we expect our custom class to throw an error when it receives the 'throwError' option.");
+                "case, we expect our custom class to throw an error when it receives the 'throwError' option. " +
+                "A ConnectorException thrown by the function's apply() method is re-thrown directly without wrapping.");
     }
 
     @Test


### PR DESCRIPTION
Specifying an arbitrary class from the JVM classpath — whether accidentally or maliciously — now fails with a clear, immediate error rather than silently instantiating a class whose constructor may have unintended side effects or act as a gadget-chain entry point.

## Verifying the unit tests

### 1. Unit tests (no MarkLogic required)

Run only the new unit tests in isolation:

```bash
cd marklogic-spark-connector
../gradlew test --tests "com.marklogic.langchain4j.MakeEmbeddingModelTest"
```

**Expected result:** 2 tests pass — `classExistsButDoesNotImplementFunction` and `validFunctionClassSucceeds`.
---

### 2.  Existing integration tests continue to pass

Run the full embedding test suite (requires MarkLogic 12+):

```bash
../gradlew test --tests "com.marklogic.spark.writer.embedding.*"
```

**Expected result:** All tests in `AddEmbeddingsToJsonTest`, `AddEmbeddingsToXmlTest`, and `AddEmbeddingsFromTextTest` pass, including:

- `invalidEmbeddingModelFunctionClass` — still produces `"Unable to instantiate class ... cause: Could not load class not.valid"` (non-existent class path unchanged)
- All tests using `MinilmEmbeddingModelFunction` and `TestEmbeddingModel` — produce embeddings as before

---

### 3. Full connector test run

```bash
../gradlew :marklogic-spark-connector:test
```

All tests should pass. The two new unit tests are pure in-process and do not require MarkLogic.