### PR TITLE
MLE-31212 adds file path validation and a permit-list check

### DIFF
--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
@@ -179,6 +179,10 @@ public abstract class Options {
     public static final String WRITE_EXTERNAL_VARIABLE_DELIMITER = "spark.marklogic.write.externalVariableDelimiter";
     public static final String WRITE_VARS_PREFIX = "spark.marklogic.write.vars.";
 
+    // Semicolon-separated list of absolute directory paths that are permitted when reading script files.
+    // When set, the connector allows paths within these directories in addition to the JVM working directory.
+    public static final String SCRIPT_FILE_ALLOWED_PATHS = "spark.marklogic.scriptFile.allowedPaths";
+
     // For writing documents to MarkLogic.
     public static final String WRITE_ARCHIVE_PATH_FOR_FAILED_DOCUMENTS = "spark.marklogic.write.archivePathForFailedDocuments";
     public static final String WRITE_COLLECTIONS = "spark.marklogic.write.collections";

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
@@ -179,8 +179,21 @@ public abstract class Options {
     public static final String WRITE_EXTERNAL_VARIABLE_DELIMITER = "spark.marklogic.write.externalVariableDelimiter";
     public static final String WRITE_VARS_PREFIX = "spark.marklogic.write.vars.";
 
-    // Semicolon-separated list of absolute directory paths that are permitted when reading script files.
-    // When set, the connector allows paths within these directories in addition to the JVM working directory.
+    /**
+     * Semicolon-separated list of absolute directory paths that are permitted when reading local script files
+     * via options such as {@code READ_JAVASCRIPT_FILE}, {@code READ_XQUERY_FILE}, {@code WRITE_JAVASCRIPT_FILE},
+     * and {@code WRITE_XQUERY_FILE}.
+     * <p>
+     * By default, only paths within the JVM working directory are allowed. Setting this option extends the
+     * permit list to include additional directories. For example:
+     * {@code /opt/scripts;/mnt/shared/code} allows files under either directory.
+     * <p>
+     * This option exists to prevent path-traversal attacks (CWE-22) on shared Spark clusters, where a malicious
+     * job operator could otherwise supply a path such as {@code ../../.aws/credentials} to exfiltrate files
+     * readable by the Spark executor's OS user.
+     *
+     * @since 3.1.2
+     */
     public static final String SCRIPT_FILE_ALLOWED_PATHS = "spark.marklogic.scriptFile.allowedPaths";
 
     // For writing documents to MarkLogic.

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/core/ServerEvaluationCallFactory.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/core/ServerEvaluationCallFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.core;
 
@@ -7,13 +7,17 @@ import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.eval.ServerEvaluationCall;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Context;
+import com.marklogic.spark.Options;
 import org.apache.commons.io.FileUtils;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -121,24 +125,45 @@ public class ServerEvaluationCallFactory {
                 String xquery = properties.get(this.xqueryOptionName);
                 return client -> client.newServerEval().xquery(xquery);
             } else if (context.hasOption(this.javascriptFileOptionName)) {
-                String content = readFileToString(properties.get(this.javascriptFileOptionName));
+                List<Path> allowedPaths = buildAllowedPaths(context);
+                String content = readFileToString(properties.get(this.javascriptFileOptionName), allowedPaths);
                 return client -> client.newServerEval().javascript(content);
             } else if (context.hasOption(this.xqueryFileOptionName)) {
-                String content = readFileToString(properties.get(this.xqueryFileOptionName));
+                List<Path> allowedPaths = buildAllowedPaths(context);
+                String content = readFileToString(properties.get(this.xqueryFileOptionName), allowedPaths);
                 return client -> client.newServerEval().xquery(content);
             }
             return null;
         }
 
-        private static String readFileToString(String file) {
+        private List<Path> buildAllowedPaths(Context context) {
+            List<Path> paths = new ArrayList<>();
+            paths.add(Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize());
+            if (context.hasOption(Options.SCRIPT_FILE_ALLOWED_PATHS)) {
+                String[] extra = context.getStringOption(Options.SCRIPT_FILE_ALLOWED_PATHS).split(";");
+                for (String p : extra) {
+                    String trimmed = p.trim();
+                    if (!trimmed.isEmpty()) {
+                        paths.add(Paths.get(trimmed).toAbsolutePath().normalize());
+                    }
+                }
+            }
+            return paths;
+        }
+
+        private static String readFileToString(String file, List<Path> allowedPaths) {
+            Path canonical = Paths.get(file).toAbsolutePath().normalize();
+            boolean permitted = allowedPaths.stream().anyMatch(canonical::startsWith);
+            if (!permitted) {
+                throw new ConnectorException(String.format(
+                    "File path '%s' is not within the permitted directory. If this path is intentional, set the '%s' option to include the allowed directory.",
+                    canonical, Options.SCRIPT_FILE_ALLOWED_PATHS));
+            }
             try {
                 // commons-io is a Spark dependency, so safe to use.
-                return FileUtils.readFileToString(new File(file), Charset.defaultCharset());
+                return FileUtils.readFileToString(canonical.toFile(), Charset.defaultCharset());
             } catch (IOException e) {
-                String message = e.getMessage();
-                if (e instanceof NoSuchFileException) {
-                    message += " was not found.";
-                }
+                String message = e instanceof NoSuchFileException ? file + " was not found." : e.getMessage();
                 throw new ConnectorException(String.format("Cannot read from file %s; cause: %s", file, message), e);
             }
         }

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/ServerEvaluationCallFactoryTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/core/ServerEvaluationCallFactoryTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.spark.core;
+
+import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Context;
+import com.marklogic.spark.Options;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pure unit tests for ServerEvaluationCallFactory path-validation logic.
+ * No live MarkLogic connection is required.
+ */
+class ServerEvaluationCallFactoryTest {
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static ServerEvaluationCallFactory.Builder newJsFileBuilder() {
+        return new ServerEvaluationCallFactory.Builder()
+            .withJavascriptFileOptionName(Options.READ_JAVASCRIPT_FILE);
+    }
+
+    private static ServerEvaluationCallFactory.Builder newXqyFileBuilder() {
+        return new ServerEvaluationCallFactory.Builder()
+            .withXqueryFileOptionName(Options.READ_XQUERY_FILE);
+    }
+
+    private static ServerEvaluationCallFactory.Builder newWriteJsFileBuilder() {
+        return new ServerEvaluationCallFactory.Builder()
+            .withJavascriptFileOptionName(Options.WRITE_JAVASCRIPT_FILE);
+    }
+
+    private static ServerEvaluationCallFactory.Builder newWriteXqyFileBuilder() {
+        return new ServerEvaluationCallFactory.Builder()
+            .withXqueryFileOptionName(Options.WRITE_XQUERY_FILE);
+    }
+
+    private static Context contextWith(String key, String value) {
+        Map<String, String> props = new HashMap<>();
+        props.put(key, value);
+        return new Context(props);
+    }
+
+    private static Context contextWith(String k1, String v1, String k2, String v2) {
+        Map<String, String> props = new HashMap<>();
+        props.put(k1, v1);
+        props.put(k2, v2);
+        return new Context(props);
+    }
+
+    // -----------------------------------------------------------------------
+    // Happy-path: relative path within CWD
+    // -----------------------------------------------------------------------
+
+    @Test
+    void relativePathWithinCwd_buildSucceeds() {
+        // Uses a file that exists in the test resources directory, resolved relative to CWD
+        // (the Gradle test task runs with CWD = marklogic-spark-connector/marklogic-spark-connector)
+        Context context = contextWith(Options.READ_JAVASCRIPT_FILE,
+            "src/test/resources/custom-code/my-reader.js");
+
+        Optional<ServerEvaluationCallFactory> factory = newJsFileBuilder().build(context);
+
+        assertTrue(factory.isPresent(), "Build should succeed for a CWD-relative path");
+    }
+
+    @Test
+    void absolutePathWithinCwd_buildSucceeds() {
+        String cwd = System.getProperty("user.dir");
+        String absPath = cwd + "/src/test/resources/custom-code/my-reader.js";
+
+        Context context = contextWith(Options.READ_JAVASCRIPT_FILE, absPath);
+
+        Optional<ServerEvaluationCallFactory> factory = newJsFileBuilder().build(context);
+
+        assertTrue(factory.isPresent(), "Build should succeed for an absolute path inside CWD");
+    }
+
+    // -----------------------------------------------------------------------
+    // Path traversal — resolves outside CWD
+    // -----------------------------------------------------------------------
+
+    @Test
+    void dotDotTraversalOutsideCwd_throwsConnectorException() {
+        Context context = contextWith(Options.READ_JAVASCRIPT_FILE, "../../secret.js");
+
+        ConnectorException ex = assertThrows(ConnectorException.class,
+            () -> newJsFileBuilder().build(context));
+
+        assertTrue(ex.getMessage().contains("is not within the permitted directory"),
+            "Expected traversal error message, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(Options.SCRIPT_FILE_ALLOWED_PATHS),
+            "Error message should mention the SCRIPT_FILE_ALLOWED_PATHS option");
+    }
+
+    @Test
+    void xqueryFile_dotDotTraversalOutsideCwd_throwsConnectorException() {
+        Context context = contextWith(Options.READ_XQUERY_FILE, "../../secret.xqy");
+
+        ConnectorException ex = assertThrows(ConnectorException.class,
+            () -> newXqyFileBuilder().build(context));
+
+        assertTrue(ex.getMessage().contains("is not within the permitted directory"),
+            "Expected traversal error message, got: " + ex.getMessage());
+    }
+
+    @Test
+    void writeJavascriptFile_dotDotTraversalOutsideCwd_throwsConnectorException() {
+        Context context = contextWith(Options.WRITE_JAVASCRIPT_FILE, "../../secret.js");
+
+        ConnectorException ex = assertThrows(ConnectorException.class,
+            () -> newWriteJsFileBuilder().build(context));
+
+        assertTrue(ex.getMessage().contains("is not within the permitted directory"),
+            "Expected traversal error message for WRITE_JAVASCRIPT_FILE, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(Options.SCRIPT_FILE_ALLOWED_PATHS),
+            "Error message should mention the SCRIPT_FILE_ALLOWED_PATHS option");
+    }
+
+    @Test
+    void writeXqueryFile_dotDotTraversalOutsideCwd_throwsConnectorException() {
+        Context context = contextWith(Options.WRITE_XQUERY_FILE, "../../secret.xqy");
+
+        ConnectorException ex = assertThrows(ConnectorException.class,
+            () -> newWriteXqyFileBuilder().build(context));
+
+        assertTrue(ex.getMessage().contains("is not within the permitted directory"),
+            "Expected traversal error message for WRITE_XQUERY_FILE, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(Options.SCRIPT_FILE_ALLOWED_PATHS),
+            "Error message should mention the SCRIPT_FILE_ALLOWED_PATHS option");
+    }
+
+    // -----------------------------------------------------------------------
+    // Absolute path outside CWD (sensitive-file vector)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void absolutePathOutsideCwd_throwsConnectorException(@TempDir Path tempDir) throws IOException {
+        // Write a file in a temp dir that is guaranteed to be outside CWD
+        Path sensitiveFile = tempDir.resolve("credentials.txt");
+        Files.writeString(sensitiveFile, "secret");
+
+        Context context = contextWith(Options.READ_JAVASCRIPT_FILE, sensitiveFile.toString());
+
+        ConnectorException ex = assertThrows(ConnectorException.class,
+            () -> newJsFileBuilder().build(context));
+
+        assertTrue(ex.getMessage().contains("is not within the permitted directory"),
+            "Expected path-restriction error, got: " + ex.getMessage());
+    }
+
+    // -----------------------------------------------------------------------
+    // SCRIPT_FILE_ALLOWED_PATHS — explicit allow-list
+    // -----------------------------------------------------------------------
+
+    @Test
+    void allowedPathsOption_permitsFileInAllowedDirectory(@TempDir Path tempDir) throws IOException {
+        Path scriptFile = tempDir.resolve("my-script.js");
+        Files.writeString(scriptFile, "Sequence.from(['ok'])");
+
+        Context context = contextWith(
+            Options.READ_JAVASCRIPT_FILE, scriptFile.toString(),
+            Options.SCRIPT_FILE_ALLOWED_PATHS, tempDir.toAbsolutePath().toString());
+
+        Optional<ServerEvaluationCallFactory> factory = newJsFileBuilder().build(context);
+
+        assertTrue(factory.isPresent(), "Build should succeed when file is within an explicitly allowed directory");
+    }
+
+    @Test
+    void allowedPathsOption_multipleEntries_permitsFileInSecondEntry(@TempDir Path tempDir) throws IOException {
+        Path otherDir = tempDir.resolve("scripts");
+        Files.createDirectories(otherDir);
+        Path scriptFile = otherDir.resolve("reader.js");
+        Files.writeString(scriptFile, "Sequence.from(['ok'])");
+
+        // First entry is a different (non-matching) directory; second entry matches
+        String allowedPaths = tempDir.resolve("nonexistent").toAbsolutePath() + ";" + otherDir.toAbsolutePath();
+        Context context = contextWith(
+            Options.READ_JAVASCRIPT_FILE, scriptFile.toString(),
+            Options.SCRIPT_FILE_ALLOWED_PATHS, allowedPaths);
+
+        Optional<ServerEvaluationCallFactory> factory = newJsFileBuilder().build(context);
+
+        assertTrue(factory.isPresent(), "Build should succeed when path matches second entry in allowed list");
+    }
+
+    @Test
+    void allowedPathsOption_set_butPathOutsideIt_throwsConnectorException(@TempDir Path tempDir) throws IOException {
+        Path allowedDir = tempDir.resolve("allowed");
+        Files.createDirectories(allowedDir);
+
+        Path otherDir = tempDir.resolve("other");
+        Files.createDirectories(otherDir);
+        Path scriptFile = otherDir.resolve("sneaky.js");
+        Files.writeString(scriptFile, "xdmp.log('exfiltrated')");
+
+        Context context = contextWith(
+            Options.READ_JAVASCRIPT_FILE, scriptFile.toString(),
+            Options.SCRIPT_FILE_ALLOWED_PATHS, allowedDir.toAbsolutePath().toString());
+
+        ConnectorException ex = assertThrows(ConnectorException.class,
+            () -> newJsFileBuilder().build(context));
+
+        assertTrue(ex.getMessage().contains("is not within the permitted directory"),
+            "Expected path-restriction error, got: " + ex.getMessage());
+    }
+
+    // -----------------------------------------------------------------------
+    // Null-byte boundary test
+    // -----------------------------------------------------------------------
+
+    @Test
+    void pathWithNullByte_throwsException() {
+        // A null byte in the path should fail either at the ConnectorException
+        // validation stage or as an IOException from the filesystem.
+        Context context = contextWith(Options.READ_JAVASCRIPT_FILE,
+            "src/test/resources/custom-code/my-reader.js\u0000");
+
+        assertThrows(Exception.class, () -> newJsFileBuilder().build(context),
+            "A path with an embedded null byte should throw an exception");
+    }
+
+    // -----------------------------------------------------------------------
+    // Non-existent file within allowed paths — existing error message preserved
+    // -----------------------------------------------------------------------
+
+    @Test
+    void nonExistentFileWithinCwd_preservesWasNotFoundMessage() {
+        Context context = contextWith(Options.READ_JAVASCRIPT_FILE,
+            "src/test/resources/custom-code/does-not-exist.js");
+
+        ConnectorException ex = assertThrows(ConnectorException.class,
+            () -> newJsFileBuilder().build(context));
+
+        assertTrue(ex.getMessage().contains("was not found."),
+            "Expected 'was not found.' in error message, got: " + ex.getMessage());
+    }
+
+    @Test
+    void nonExistentFileExplicitlyAllowed_preservesWasNotFoundMessage(@TempDir Path tempDir) {
+        // File is in the allowed directory but does not actually exist on disk
+        Path nonExistentFile = tempDir.resolve("ghost.js");
+
+        Context context = contextWith(
+            Options.READ_JAVASCRIPT_FILE, nonExistentFile.toString(),
+            Options.SCRIPT_FILE_ALLOWED_PATHS, tempDir.toAbsolutePath().toString());
+
+        ConnectorException ex = assertThrows(ConnectorException.class,
+            () -> newJsFileBuilder().build(context));
+
+        assertTrue(ex.getMessage().contains("was not found."),
+            "Expected 'was not found.' in error message, got: " + ex.getMessage());
+    }
+}

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/customcode/ReadWithCustomCodeTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/customcode/ReadWithCustomCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.reader.customcode;
 
@@ -195,6 +195,28 @@ class ReadWithCustomCodeTest extends AbstractIntegrationTest {
                 "Actual message: " + ex.getCause().getMessage());
     }
 
+
+    @Test
+    void readJavascriptFileWithPathTraversalRejected() {
+        ConnectorException ex = assertThrowsConnectorException(
+            () -> readRows(Options.READ_JAVASCRIPT_FILE, "../../secret.js"));
+
+        assertTrue(ex.getMessage().contains("is not within the permitted directory"),
+            "Expected path traversal error, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(Options.SCRIPT_FILE_ALLOWED_PATHS),
+            "Error message should mention the SCRIPT_FILE_ALLOWED_PATHS option");
+    }
+
+    @Test
+    void readXQueryFileWithPathTraversalRejected() {
+        ConnectorException ex = assertThrowsConnectorException(
+            () -> readRows(Options.READ_XQUERY_FILE, "../../secret.xqy"));
+
+        assertTrue(ex.getMessage().contains("is not within the permitted directory"),
+            "Expected path traversal error, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(Options.SCRIPT_FILE_ALLOWED_PATHS),
+            "Error message should mention the SCRIPT_FILE_ALLOWED_PATHS option");
+    }
 
     private List<Row> readRows(String option, String value) {
         return startRead()

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/document/ReadUrisViaSecondaryQueryTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/document/ReadUrisViaSecondaryQueryTest.java
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.reader.document;
 
 import com.marklogic.spark.AbstractIntegrationTest;
 import com.marklogic.spark.Options;
+import org.apache.spark.sql.DataFrameReader;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -62,7 +63,8 @@ class ReadUrisViaSecondaryQueryTest extends AbstractIntegrationTest {
         File tempFile = new File(tempDir.toFile(), "findAuthorUrisViaCitationId.js");
         FileCopyUtils.copy(JAVASCRIPT_QUERY.getBytes(StandardCharsets.UTF_8), tempFile);
 
-        verifySecondaryQuery(Options.READ_SECONDARY_URIS_JAVASCRIPT_FILE, tempFile.getAbsolutePath());
+        verifySecondaryQuery(Options.READ_SECONDARY_URIS_JAVASCRIPT_FILE, tempFile.getAbsolutePath(),
+            tempDir.toAbsolutePath().toString());
     }
 
     @Test
@@ -70,7 +72,8 @@ class ReadUrisViaSecondaryQueryTest extends AbstractIntegrationTest {
         File tempFile = new File(tempDir.toFile(), "findAuthorUrisViaCitationId.xqy");
         FileCopyUtils.copy(XQUERY_QUERY.getBytes(StandardCharsets.UTF_8), tempFile);
 
-        verifySecondaryQuery(Options.READ_SECONDARY_URIS_XQUERY_FILE, tempFile.getAbsolutePath());
+        verifySecondaryQuery(Options.READ_SECONDARY_URIS_XQUERY_FILE, tempFile.getAbsolutePath(),
+            tempDir.toAbsolutePath().toString());
     }
 
     @Test
@@ -93,14 +96,21 @@ class ReadUrisViaSecondaryQueryTest extends AbstractIntegrationTest {
     }
 
     private void verifySecondaryQuery(String optionName, String optionValue) {
-        List<Row> rows = newSparkSession().read()
+        verifySecondaryQuery(optionName, optionValue, null);
+    }
+
+    private void verifySecondaryQuery(String optionName, String optionValue, String allowedPaths) {
+        DataFrameReader reader = newSparkSession().read()
             .format(CONNECTOR_IDENTIFIER)
             .option(Options.CLIENT_URI, makeClientUri())
             .option(Options.READ_DOCUMENTS_URIS, """
                 /author/author1.json
                 /author/author2.json""")
-            .option(optionName, optionValue)
-            .load()
+            .option(optionName, optionValue);
+        if (allowedPaths != null) {
+            reader.option(Options.SCRIPT_FILE_ALLOWED_PATHS, allowedPaths);
+        }
+        List<Row> rows = reader.load()
             .select("uri")
             .collectAsList();
 

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/customcode/ProcessWithCustomCodeTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/writer/customcode/ProcessWithCustomCodeTest.java
@@ -5,6 +5,7 @@ package com.marklogic.spark.writer.customcode;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.junit5.XmlNode;
+import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.Options;
 import com.marklogic.spark.writer.AbstractWriteTest;
 import com.marklogic.spark.writer.CommitResultsTestConsumer;
@@ -180,6 +181,19 @@ class ProcessWithCustomCodeTest extends AbstractWriteTest {
 
         assertEquals(3, CommitResultsTestConsumer.failureCount.get());
         assertEquals(0, CommitResultsTestConsumer.successCount.get());
+    }
+
+    @Test
+    void writeJavascriptFileWithPathTraversalRejected() {
+        ConnectorException ex = assertThrowsConnectorException(() ->
+            newWriterWithDefaultConfig("three-uris.csv", 2)
+                .option(Options.WRITE_JAVASCRIPT_FILE, "../../secret.js")
+                .save());
+
+        assertTrue(ex.getMessage().contains("is not within the permitted directory"),
+            "Expected path traversal error, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(Options.SCRIPT_FILE_ALLOWED_PATHS),
+            "Error message should mention the SCRIPT_FILE_ALLOWED_PATHS option");
     }
 
     private void verifyThreeJsonDocumentsWereWritten() {


### PR DESCRIPTION
ServerEvaluationCallFactory.readFileToString() previously read files whose paths were supplied directly from user-controlled Spark options (**--javascript-file, --xquery-file, --write-javascript-file, --write-xquery-file)** with no path validation. On a shared Spark cluster, a malicious job operator could supply an arbitrary path (e.g. ../../.aws/credentials) and cause the connector to silently transmit that file's contents to MarkLogic as executable code.

The fix adds path canonicalization and a permit-list check:

The canonical path must start with at least one permitted root. The default permitted root is the JVM working directory (user.dir). Additional directories can be allowed via the new **spark.marklogic.scriptFile.allowedPaths** option (semicolon-delimited list of absolute paths).

If the check fails, a ConnectorException is thrown with a clear message that names the SCRIPT_FILE_ALLOWED_PATHS option so the user knows how to resolve the error intentionally. Example:

com.marklogic.spark.ConnectorException: File path 'C:\tmp\my-reader.js' is not within the permitted directory.If this path is intentional, set the 'spark.marklogic.scriptFile.allowedPaths' option to include the allowed directory.

The existing IO-error message ("Cannot read from file %s; cause: %s") is preserved unchanged; the "was not found" variant now correctly echoes the original relative path rather than the resolved absolute path.

**New unit tests (no MarkLogic required) — all 13 pass**

.\gradlew.bat :marklogic-spark-connector:test --tests "com.marklogic.spark.core.ServerEvaluationCallFactoryTest" --rerun
BUILD SUCCESSFUL

**New and existing integration tests (requires MarkLogic) — all pass against live cluster**

.\gradlew.bat :marklogic-spark-connector:test --tests "com.marklogic.spark.reader.customcode.ReadWithCustomCodeTest" --rerun
BUILD SUCCESSFUL  (18 tests, 0 failures)

.\gradlew.bat :marklogic-spark-connector:test --tests "com.marklogic.spark.writer.customcode.ProcessWithCustomCodeTest"
BUILD SUCCESSFUL
