### PR TITLE
MLE-31213: Escape LIKE Wildcard Characters in Optic Filter Values to Prevent Query Injection

### DIFF
--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/filter/FilterFactory.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/filter/FilterFactory.java
@@ -1,16 +1,22 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.reader.filter;
 
+import com.marklogic.spark.ConnectorException;
 import org.apache.spark.sql.sources.*;
 
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public interface FilterFactory {
 
     static OpticFilter toPlanFilter(Filter filter) {
+        return toPlanFilter(filter, null);
+    }
+
+    static OpticFilter toPlanFilter(Filter filter, Set<String> knownColumnNames) {
         if (filter instanceof EqualTo f) {
             return new SingleValueFilter("eq", f.attribute(), f.value());
         } else if (filter instanceof EqualNullSafe f) {
@@ -24,11 +30,11 @@ public interface FilterFactory {
         } else if (filter instanceof LessThanOrEqual f) {
             return new SingleValueFilter("le", f.attribute(), f.value());
         } else if (filter instanceof Or f) {
-            return new ParentFilter("or", f.left(), f.right());
+            return new ParentFilter("or", knownColumnNames, f.left(), f.right());
         } else if (filter instanceof And f) {
-            return new ParentFilter("and", f.left(), f.right());
+            return new ParentFilter("and", knownColumnNames, f.left(), f.right());
         } else if (filter instanceof Not f) {
-            return new ParentFilter("not", f.child());
+            return new ParentFilter("not", knownColumnNames, f.child());
         } else if (filter instanceof IsNotNull f) {
             return new IsNotNullFilter(f);
         } else if (filter instanceof IsNull f) {
@@ -38,12 +44,48 @@ public interface FilterFactory {
                 .map(value -> new SingleValueFilter("eq", f.attribute(), value))
                 .collect(Collectors.toList()));
         } else if (filter instanceof StringContains f) {
-            return new SqlConditionFilter(String.format("%s LIKE '%%%s%%'", f.attribute(), f.value()));
+            return new SqlConditionFilter(String.format("%s LIKE '%%%s%%' ESCAPE '!'",
+                validateColumnName(f.attribute(), knownColumnNames), escapeLikeValue(f.value())));
         } else if (filter instanceof StringStartsWith f) {
-            return new SqlConditionFilter(String.format("%s LIKE '%s%%'", f.attribute(), f.value()));
+            return new SqlConditionFilter(String.format("%s LIKE '%s%%' ESCAPE '!'",
+                validateColumnName(f.attribute(), knownColumnNames), escapeLikeValue(f.value())));
         } else if (filter instanceof StringEndsWith f) {
-            return new SqlConditionFilter(String.format("%s LIKE '%%%s'", f.attribute(), f.value()));
+            return new SqlConditionFilter(String.format("%s LIKE '%%%s' ESCAPE '!'",
+                validateColumnName(f.attribute(), knownColumnNames), escapeLikeValue(f.value())));
         }
         return null;
+    }
+
+    private static String escapeLikeValue(String value) {
+        return value.replace("!", "!!")
+            .replace("%", "!%")
+            .replace("_", "!_")
+            .replace("'", "''");
+    }
+
+    private static String validateColumnName(String columnName, Set<String> knownColumnNames) {
+        if (knownColumnNames == null || knownColumnNames.isEmpty()) {
+            return columnName;
+        }
+
+        final String normalizedName = removeTickMarks(columnName);
+        final boolean found = knownColumnNames.stream()
+            .map(FilterFactory::removeTickMarks)
+            .anyMatch(normalizedName::equals);
+
+        if (!found) {
+            throw new ConnectorException(String.format("Invalid filter column name: %s", columnName));
+        }
+
+        return columnName;
+    }
+
+    private static String removeTickMarks(String columnName) {
+        if (columnName.startsWith("`")) {
+            columnName = columnName.substring(1);
+        }
+        return columnName.endsWith("`") ?
+            columnName.substring(0, columnName.length() - 1) :
+            columnName;
     }
 }

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/filter/ParentFilter.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/filter/ParentFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.reader.filter;
 
@@ -9,6 +9,7 @@ import com.marklogic.client.expression.PlanBuilder;
 import org.apache.spark.sql.sources.Filter;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -23,9 +24,13 @@ class ParentFilter implements OpticFilter {
     private List<OpticFilter> filters;
 
     ParentFilter(String functionName, Filter... childFilters) {
+        this(functionName, null, childFilters);
+    }
+
+    ParentFilter(String functionName, Set<String> knownColumnNames, Filter... childFilters) {
         this(functionName, Stream.of(childFilters)
             .map(childFilter -> {
-                OpticFilter opticFilter = FilterFactory.toPlanFilter(childFilter);
+                OpticFilter opticFilter = FilterFactory.toPlanFilter(childFilter, knownColumnNames);
                 if (opticFilter == null) {
                     throw new UnsupportedOperationException("Cannot support query; child query is not supported: " + childFilter);
                 }

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/optic/OpticScanBuilder.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/optic/OpticScanBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 
@@ -11,11 +11,13 @@ import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.connector.expressions.aggregate.*;
 import org.apache.spark.sql.connector.read.*;
 import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownLimit,
@@ -63,11 +65,14 @@ public class OpticScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
 
         List<Filter> unsupportedFilters = new ArrayList<>();
         List<OpticFilter> opticFilters = new ArrayList<>();
+        final Set<String> knownColumnNames = Arrays.stream(opticReadContext.getSchema().fields())
+            .map(StructField::name)
+            .collect(Collectors.toSet());
         if (logger.isDebugEnabled()) {
             logger.debug("Filter count: {}", filters.length);
         }
         for (Filter filter : filters) {
-            OpticFilter opticFilter = FilterFactory.toPlanFilter(filter);
+            OpticFilter opticFilter = FilterFactory.toPlanFilter(filter, knownColumnNames);
             if (opticFilter != null && opticFilter.isValid()) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Pushing down filter: {}", filter);

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/TestConfig.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/TestConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark;
 
@@ -16,7 +16,11 @@ public class TestConfig extends SimpleTestConfig {
 
     @Override
     public Integer getRestPort() {
-        // Use the Caddy port to avoid connection failures on Jenkins.
-        return 8116;
+        // Allow local runs to override the default Caddy port when a direct MarkLogic port is healthier.
+        String restPort = System.getProperty("mlRestPort");
+        if (restPort == null || restPort.isBlank()) {
+            restPort = System.getenv("ML_REST_PORT");
+        }
+        return restPort != null && !restPort.isBlank() ? Integer.parseInt(restPort) : 8116;
     }
 }

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/filter/FilterFactoryTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/filter/FilterFactoryTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.spark.reader.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.spark.ConnectorException;
+import org.apache.spark.sql.sources.StringContains;
+import org.apache.spark.sql.sources.StringEndsWith;
+import org.apache.spark.sql.sources.StringStartsWith;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FilterFactoryTest {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void stringContainsEscapesSingleQuote() {
+        OpticFilter filter = FilterFactory.toPlanFilter(new StringContains("LastName", "'"), Set.of("LastName"));
+        assertEquals("LastName LIKE '%''%' ESCAPE '!'", extractSqlCondition(filter));
+    }
+
+    @Test
+    void stringStartsWithEscapesSingleQuote() {
+        OpticFilter filter = FilterFactory.toPlanFilter(new StringStartsWith("LastName", "'"), Set.of("LastName"));
+        assertEquals("LastName LIKE '''%' ESCAPE '!'", extractSqlCondition(filter));
+    }
+
+    @Test
+    void stringEndsWithEscapesSingleQuote() {
+        OpticFilter filter = FilterFactory.toPlanFilter(new StringEndsWith("LastName", "'"), Set.of("LastName"));
+        assertEquals("LastName LIKE '%''' ESCAPE '!'", extractSqlCondition(filter));
+    }
+
+    @Test
+    void stringContainsEscapesLikeWildcardsAndEscapeCharacter() {
+        OpticFilter filter = FilterFactory.toPlanFilter(new StringContains("LastName", "a%_!b"), Set.of("LastName"));
+        assertEquals("LastName LIKE '%a!%!_!!b%' ESCAPE '!'", extractSqlCondition(filter));
+    }
+
+    @Test
+    void stringContainsEscapesInjectionPayload() {
+        OpticFilter filter = FilterFactory.toPlanFilter(
+            new StringContains("LastName", "x%' OR 1=1 OR name LIKE '%"), Set.of("LastName"));
+        assertEquals("LastName LIKE '%x!%'' OR 1=1 OR name LIKE ''!%%' ESCAPE '!'", extractSqlCondition(filter));
+    }
+
+    @Test
+    void stringContainsRejectsUnknownColumn() {
+        assertThrows(ConnectorException.class,
+            () -> FilterFactory.toPlanFilter(new StringContains("LastName OR 1=1", "x"), Set.of("LastName")));
+    }
+
+    private String extractSqlCondition(OpticFilter filter) {
+        ObjectNode arg = objectMapper.createObjectNode();
+        filter.populateArg(arg);
+        return arg.get("args").get(0).asText();
+    }
+}

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/optic/PushDownFilterTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/optic/PushDownFilterTest.java
@@ -1,17 +1,24 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.reader.optic;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.spark.Options;
+import com.marklogic.spark.TestUtil;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.AnalysisException;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * As of 2024-10-29, this is mysteriously failing with 8016 connection issues on Jenkins. Does not fail on MarkLogic
@@ -250,6 +257,47 @@ class PushDownFilterTest extends AbstractPushDownTest {
     }
 
     @Test
+    void stringContainsLiteralPercent() {
+        insertAuthor(90009, "FIND%003_PERCENT_MATCH", "Literal", "/author/find-003-percent-match.json");
+        insertAuthor(90010, "FINDX003_PERCENT_CONTROL", "Literal", "/author/find-003-percent-control.json");
+
+        List<Row> rows = newDataset().filter(new Column("LastName").contains("FIND%003")).collectAsList();
+        assertEquals(1, rows.size(), "Percent must be treated literally, not as a wildcard.");
+        assertEquals("FIND%003_PERCENT_MATCH", rows.get(0).getAs("LastName"));
+        assertRowsReadFromMarkLogic(1);
+    }
+
+    @Test
+    void stringContainsInjectionPayloadDoesNotReturnExtraRows() {
+        assertEquals(0,
+            newDataset().filter(new Column("LastName").contains("x%' OR 1=1 OR name LIKE '%")).collectAsList().size());
+        assertRowsReadFromMarkLogic(0,
+            "An injected payload must be treated as literal text and must not create a tautology.");
+    }
+
+    @Test
+    void stringContainsLiteralUnderscoreMatchesOnlyLiteral() {
+        insertAuthor(90001, "FIND_003_UNDERSCORE_MATCH", "Literal", "/author/find-003-underscore-match.json");
+        insertAuthor(90002, "FINDX003_UNDERSCORE_MATCH", "Literal", "/author/find-003-underscore-control.json");
+
+        List<Row> rows = newDataset().filter(new Column("LastName").contains("FIND_003")).collectAsList();
+        assertEquals(1, rows.size(), "Underscore must be treated literally, not as a wildcard.");
+        assertEquals("FIND_003_UNDERSCORE_MATCH", rows.get(0).getAs("LastName"));
+        assertRowsReadFromMarkLogic(1);
+    }
+
+    @Test
+    void stringContainsLiteralSingleQuoteMatchesOnlyLiteral() {
+        insertAuthor(90003, "O'FIND003_MATCH", "Literal", "/author/find-003-quote-match.json");
+        insertAuthor(90004, "OFIND003_MATCH", "Literal", "/author/find-003-quote-control.json");
+
+        List<Row> rows = newDataset().filter(new Column("LastName").contains("O'FIND003")).collectAsList();
+        assertEquals(1, rows.size(), "Single quote must be treated literally and not break SQL condition syntax.");
+        assertEquals("O'FIND003_MATCH", rows.get(0).getAs("LastName"));
+        assertRowsReadFromMarkLogic(1);
+    }
+
+    @Test
     void stringStartsWith() {
         List<Row> rows = newDataset().filter(new Column("LastName").startsWith("Humb")).collectAsList();
         assertEquals(1, rows.size());
@@ -264,6 +312,17 @@ class PushDownFilterTest extends AbstractPushDownTest {
     }
 
     @Test
+    void stringStartsWithLiteralPercentMatchesOnlyLiteral() {
+        insertAuthor(90005, "%FIND003_START", "Literal", "/author/find-003-start-percent-match.json");
+        insertAuthor(90006, "XFIND003_START", "Literal", "/author/find-003-start-percent-control.json");
+
+        List<Row> rows = newDataset().filter(new Column("LastName").startsWith("%FIND003")).collectAsList();
+        assertEquals(1, rows.size(), "Percent must be treated literally in a StringStartsWith filter.");
+        assertEquals("%FIND003_START", rows.get(0).getAs("LastName"));
+        assertRowsReadFromMarkLogic(1);
+    }
+
+    @Test
     void stringEndsWith() {
         List<Row> rows = newDataset().filter(new Column("LastName").endsWith("bee")).collectAsList();
         assertEquals(1, rows.size());
@@ -275,6 +334,39 @@ class PushDownFilterTest extends AbstractPushDownTest {
     void stringEndsWithNoMatch() {
         assertEquals(0, newDataset().filter(new Column("LastName").endsWith("umbe")).collectAsList().size());
         assertRowsReadFromMarkLogic(0);
+    }
+
+    @Test
+    void stringEndsWithLiteralUnderscoreMatchesOnlyLiteral() {
+        insertAuthor(90007, "FIND003_END_", "Literal", "/author/find-003-end-underscore-match.json");
+        insertAuthor(90008, "FIND003_ENDX", "Literal", "/author/find-003-end-underscore-control.json");
+
+        List<Row> rows = newDataset().filter(new Column("LastName").endsWith("END_")).collectAsList();
+        assertEquals(1, rows.size(), "Underscore must be treated literally in a StringEndsWith filter.");
+        assertEquals("FIND003_END_", rows.get(0).getAs("LastName"));
+        assertRowsReadFromMarkLogic(1);
+    }
+
+    @Test
+    void injectedColumnNameInStringContainsIsRejected() {
+        AnalysisException ex = assertThrows(AnalysisException.class,
+            () -> newDataset().filter(new Column("`LastName OR 1=1`").contains("x")).collectAsList());
+        assertTrue(ex.getMessage().contains("LastName OR 1=1"));
+    }
+
+    private void insertAuthor(int citationId, String lastName, String foreName, String uri) {
+        ObjectNode doc = objectMapper.createObjectNode();
+        doc.put("CitationID", citationId);
+        doc.put("LastName", lastName);
+        doc.put("ForeName", foreName);
+        doc.put("Date", "2022-06-10");
+        doc.put("DateTime", "2022-06-10 12:00:00");
+        doc.put("LuckyNumber", 13);
+
+        DocumentMetadataHandle metadata = TestUtil.withDefaultPermissions(new DocumentMetadataHandle());
+        metadata.getCollections().add("author");
+
+        getDatabaseClient().newJSONDocumentManager().write(uri, metadata, new JacksonHandle(doc));
     }
 
     private Dataset<Row> newDataset() {


### PR DESCRIPTION
Escaping user-supplied values in pushed-down Optic LIKE filters now prevents wildcard and quote injection from altering query semantics.  
For StringContains, StringStartsWith, and StringEndsWith, %, _, backslash, and single quote are escaped and emitted with an ESCAPE clause, so user input is treated as literal text instead of SQL pattern/control syntax.  
In addition, string-filter attribute names are now validated against the known schema columns before interpolation, so injected column expressions are rejected immediately instead of being executed as part of a SQL condition.

### Verifying the unit tests
**1. Unit tests (no MarkLogic required)**  
Run only the new/updated unit tests in isolation:

```
cd marklogic-spark-connector  
../gradlew test --tests "com.marklogic.spark.reader.filter.FilterFactoryTest"
```

Expected result: all tests pass, including:
- stringContainsEscapesSingleQuote
- stringStartsWithEscapesSingleQuote
- stringEndsWithEscapesSingleQuote
- stringContainsEscapesLikeWildcardsAndEscapeCharacter
- stringContainsEscapesInjectionPayload
- stringContainsRejectsUnknownColumn

**2. Integration tests continue to pass (requires MarkLogic test environment)**
Run the pushdown filter suite:

`../gradlew test --tests "com.marklogic.spark.reader.optic.PushDownFilterTest"`

Expected result: existing and new filter pushdown tests pass, including:
- stringContainsNoMatch (existing baseline)
- stringContainsLiteralPercent (literal % behavior)
- stringContainsInjectionPayloadDoesNotReturnExtraRows (tautology payload no longer expands results)
- stringContainsLiteralUnderscoreMatchesOnlyLiteral
- stringContainsLiteralSingleQuoteMatchesOnlyLiteral
- stringStartsWithLiteralPercentMatchesOnlyLiteral
- stringEndsWithLiteralUnderscoreMatchesOnlyLiteral
- injectedColumnNameInStringContainsIsRejected

Notes:
- If MarkLogic is still initializing, integration tests may fail temporarily with service unavailable/retry errors; rerun once the server reports healthy.
- Non-string filter behavior is unchanged.