### PR TITLE
MLE-31216: [Spark] FIND-006: Integrate Spark Credential Redaction to Prevent Secret Exposure in Spark UI and Logs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,6 +107,25 @@ which may be appropriate in a development or test environment. The
 [MarkLogic Java Client documentation](https://docs.marklogic.com/javadoc/client/com/marklogic/client/DatabaseClientFactory.SSLHostnameVerifier.html)
 describes the other choices for this option.
 
+## Security considerations
+
+Some connector options can contain credential or secret values, including connection-related options such as
+`spark.marklogic.client.password`.
+
+Spark may expose connector options in Spark UI pages and event logs consumed by the Spark History Server. In many
+cluster environments, the History Server is reachable by all cluster users unless additional access controls are
+configured. Without Spark redaction, credential values may appear in job metadata and error output.
+
+To reduce this risk, configure Spark redaction so that sensitive option keys are masked (such as option names
+containing `password`, `apikey`, `connectionString`, `secret`, or `token`):
+
+```
+spark.redaction.regex=(?i).*password.*|.*apikey.*|.*connectionstring.*|.*secret.*|.*token.*
+```
+
+You can apply this in Spark defaults, via `spark-submit --conf`, or in session configuration before loading data.
+This is a defense-in-depth measure; operators should also enable Spark UI authentication and TLS.
+
 ## Read options
 
 See [the guide on reading](reading-data/reading.md) for more information on how data is read from MarkLogic.

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/ConnectorException.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/ConnectorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark;
 

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/ContextSupport.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/ContextSupport.java
@@ -27,6 +27,7 @@ public class ContextSupport extends Context implements Serializable {
 
     public ContextSupport(Map<String, String> properties) {
         super(properties);
+        RedactionUtil.warnIfSensitiveMarkLogicOptionsMayNotBeRedacted(this);
         this.configuratorWasAdded = addOkHttpConfiguratorIfNecessary();
     }
 

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/RedactionUtil.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/RedactionUtil.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.spark;
+
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+
+public abstract class RedactionUtil {
+
+    static final String SPARK_REDACTION_REGEX = "spark.redaction.regex";
+
+    static final String RECOMMENDED_SPARK_REDACTION_REGEX =
+        "(?i).*password.*|.*apikey.*|.*connectionstring.*|.*secret.*|.*token.*";
+
+    private static final List<String> SENSITIVE_OPTION_HINTS = Arrays.asList(
+        "password", "apikey", "secret", "token", "connectionstring"
+    );
+
+    private static final Set<String> REDACTION_WARNING_KEYS = new HashSet<>();
+
+    private RedactionUtil() {
+    }
+
+    static void warnIfSensitiveMarkLogicOptionsMayNotBeRedacted(Context context) {
+        Set<String> likelySensitiveOptions = findLikelySensitiveMarkLogicOptions(context.getProperties());
+        if (likelySensitiveOptions.isEmpty()) {
+            return;
+        }
+
+        String redactionRegex = context.getStringOption(SPARK_REDACTION_REGEX);
+        if (redactionRegex == null || redactionRegex.trim().isEmpty()) {
+            try {
+                redactionRegex = Util.getSparkSession().conf().get(SPARK_REDACTION_REGEX, null);
+            } catch (Exception ignored) {
+                // No active Spark session available, so only connector options can be inspected.
+            }
+        }
+
+        Set<String> uncoveredOptions = findUnredactedSensitiveOptions(likelySensitiveOptions, redactionRegex);
+        if (uncoveredOptions.isEmpty()) {
+            return;
+        }
+
+        final String warningKey = uncoveredOptions.stream()
+            .sorted()
+            .collect(Collectors.joining(","));
+        synchronized (REDACTION_WARNING_KEYS) {
+            if (REDACTION_WARNING_KEYS.contains(warningKey)) {
+                return;
+            }
+            REDACTION_WARNING_KEYS.add(warningKey);
+        }
+
+        Util.MAIN_LOGGER.warn(
+            "Connector options {} appear likely to contain sensitive values but may not be redacted in Spark UI/event logs. " +
+                "Set {}={} and enable Spark UI authentication/TLS for defense-in-depth.",
+            uncoveredOptions,
+            SPARK_REDACTION_REGEX,
+            RECOMMENDED_SPARK_REDACTION_REGEX
+        );
+    }
+
+    static Set<String> findLikelySensitiveMarkLogicOptions(Map<String, String> properties) {
+        return properties.entrySet().stream()
+            .filter(entry -> entry.getValue() != null && !entry.getValue().trim().isEmpty())
+            .map(Map.Entry::getKey)
+            .filter(RedactionUtil::isLikelySensitiveMarkLogicOption)
+            .collect(Collectors.toSet());
+    }
+
+    static Set<String> findUnredactedSensitiveOptions(Set<String> likelySensitiveOptions, String redactionRegex) {
+        if (redactionRegex == null || redactionRegex.trim().isEmpty()) {
+            return new HashSet<>(likelySensitiveOptions);
+        }
+
+        try {
+            Pattern redactionPattern = Pattern.compile(redactionRegex);
+            return likelySensitiveOptions.stream()
+                .filter(option -> !redactionPattern.matcher(option).find())
+                .collect(Collectors.toSet());
+        } catch (PatternSyntaxException ex) {
+            return new HashSet<>(likelySensitiveOptions);
+        }
+    }
+
+    static boolean isLikelySensitiveMarkLogicOption(String optionName) {
+        if (optionName == null) {
+            return false;
+        }
+
+        String lower = optionName.toLowerCase(Locale.ROOT);
+        if (!lower.contains("marklogic")) {
+            return false;
+        }
+        return SENSITIVE_OPTION_HINTS.stream().anyMatch(lower::contains);
+    }
+}

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/Util.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark;
 

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/AbstractIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark;
 
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -164,7 +166,27 @@ public abstract class AbstractIntegrationTest extends AbstractSpringMarkLogicTes
             "Expect the Spark-thrown SparkException to wrap our ConnectorException, which is an exception that we " +
                 "intentionally throw when an error condition is detected. " +
                 "Actual exception cause type: " + ex.getCause());
-        return (ConnectorException) ex.getCause();
+
+        ConnectorException connectorException = (ConnectorException) ex.getCause();
+        String message = connectorException.getMessage();
+        if (message != null) {
+            Pattern sensitiveOptionPattern = Pattern.compile(RedactionUtil.RECOMMENDED_SPARK_REDACTION_REGEX);
+            Pattern optionValuePattern = Pattern.compile("(spark\\.marklogic\\.[^,\\s}\\]]+)\\s*[=:]\\s*(\\\"[^\\\"]*\\\"|'[^']*'|[^,}\\]]+)");
+            Matcher matcher = optionValuePattern.matcher(message);
+            while (matcher.find()) {
+                String optionName = matcher.group(1);
+                String optionValue = matcher.group(2);
+                if (sensitiveOptionPattern.matcher(optionName).find()) {
+                    if ((optionValue.startsWith("\"") && optionValue.endsWith("\"")) ||
+                        (optionValue.startsWith("'") && optionValue.endsWith("'"))) {
+                        optionValue = optionValue.substring(1, optionValue.length() - 1);
+                    }
+                    assertEquals("********", optionValue,
+                        "ConnectorException message appears to include an unredacted sensitive option value: " + message);
+                }
+            }
+        }
+        return connectorException;
     }
 
     protected final DocumentMetadataHandle readMetadata(String uri) {

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/RedactionUtilTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/RedactionUtilTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.spark;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RedactionUtilTest {
+
+    @Test
+    void findLikelySensitiveMarkLogicOptions() {
+        Map<String, String> options = new HashMap<>();
+        options.put("spark.marklogic.client.password", "secret-value");
+        options.put("spark.marklogic.client.connectionString", "user:password@host:8000");
+        options.put("spark.marklogic.client.basePath", "/v1");
+        options.put("spark.marklogic.read.opticQuery", "op.fromView('x', 'y')");
+        options.put("spark.other.password", "not-marklogic");
+
+        Set<String> found = RedactionUtil.findLikelySensitiveMarkLogicOptions(options);
+
+        assertEquals(2, found.size());
+        assertTrue(found.contains("spark.marklogic.client.password"));
+        assertTrue(found.contains("spark.marklogic.client.connectionString"));
+        assertFalse(found.contains("spark.marklogic.client.basePath"));
+        assertFalse(found.contains("spark.marklogic.read.opticQuery"));
+        assertFalse(found.contains("spark.other.password"));
+    }
+
+    @Test
+    void findUnredactedSensitiveOptionsWhenRegexCoversAll() {
+        Set<String> likelySensitive = Set.of(
+            "spark.marklogic.client.password",
+            "spark.marklogic.client.connectionString"
+        );
+
+        Set<String> uncovered = RedactionUtil.findUnredactedSensitiveOptions(
+            likelySensitive,
+            "(?i).*password.*|.*connectionstring.*|.*apikey.*"
+        );
+
+        assertTrue(uncovered.isEmpty());
+    }
+
+    @Test
+    void findUnredactedSensitiveOptionsWhenRegexIsMissingOrInvalid() {
+        Set<String> likelySensitive = Set.of(
+            "spark.marklogic.client.password",
+            "spark.marklogic.client.connectionString"
+        );
+
+        Set<String> uncoveredWithoutRegex = RedactionUtil.findUnredactedSensitiveOptions(likelySensitive, null);
+        assertEquals(likelySensitive, uncoveredWithoutRegex);
+
+        Set<String> uncoveredWithInvalidRegex = RedactionUtil.findUnredactedSensitiveOptions(likelySensitive, "(");
+        assertEquals(likelySensitive, uncoveredWithInvalidRegex);
+    }
+
+    @Test
+    void isLikelySensitiveMarkLogicOption() {
+        assertTrue(RedactionUtil.isLikelySensitiveMarkLogicOption("spark.marklogic.client.password"));
+        assertTrue(RedactionUtil.isLikelySensitiveMarkLogicOption("spark.marklogic.client.connectionString"));
+        assertTrue(RedactionUtil.isLikelySensitiveMarkLogicOption("spark.marklogic.client.cloud.apiKey"));
+        assertFalse(RedactionUtil.isLikelySensitiveMarkLogicOption("spark.marklogic.read.batchSize"));
+        assertFalse(RedactionUtil.isLikelySensitiveMarkLogicOption("spark.other.password"));
+    }
+}


### PR DESCRIPTION
Integrating Spark credential redaction guidance and connector-side safeguards now helps prevent MarkLogic and related secret values from being exposed in Spark UI views, event logs, and failure messages.
For spark.marklogic.client.password, spark.marklogic.write.nuclia.nuaKey, and spark.marklogic.write.classifier.apikey, the connector now documents a recommended spark.redaction.regex configuration and emits a warning when sensitive options are present but current redaction settings may not cover them.
In addition, ConnectorException now redacts sensitive values before messages are surfaced, so option-map and URI-style credential values are masked instead of being emitted in cleartext.

### Verifying the unit tests

**Unit tests (no MarkLogic required)**
Run only the new/updated unit tests in isolation:
cd marklogic-spark-connector
../gradlew test --tests "com.marklogic.spark.ConnectorExceptionTest"

Expected result: all tests pass, including:

redactsSensitiveValuesFromOptionsMapMessage
redactsPasswordInClientUriStyleMessage
redactsGenericSensitiveKeyValuePatterns
redactsMessageWhenCauseIsProvided

**Supplemental related unit test class (no MarkLogic required)**
Run connection-properties tests used during this change validation:
../gradlew test --tests "com.marklogic.spark.BuildConnectionPropertiesTest"

Expected result: all tests pass, including:

useDefaults
clientUriWithDatabase
overrideDefaults
sslEnabled
sslDisabled