### PR TITLE
MLE-31214 added XXE hardening to DOMHelper DocumentBuilderFactory

### DIFF
--- a/docs/writing.md
+++ b/docs/writing.md
@@ -211,6 +211,11 @@ Please see the [Flux import guide](https://marklogic.github.io/flux/import/impor
 features. While the features are primarily intended for use in Flux, they can both be used with the connector as well
 via the options described below. 
 
+**Security note:** To protect against XML External Entity (XXE) injection attacks (CWE-611), the connector's XML
+parser rejects any XML document that contains a `DOCTYPE` declaration. Attempting to write or split an XML document
+with a `DOCTYPE` declaration will result in an error. If your source XML uses a DTD, you must remove the `DOCTYPE`
+declaration before processing it with the connector.
+
 The options controlling the splitter feature are:
 
 | Option | Description | 

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/core/splitter/XmlChunkDocumentProducer.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/core/splitter/XmlChunkDocumentProducer.java
@@ -46,7 +46,7 @@ class XmlChunkDocumentProducer extends AbstractChunkDocumentProducer {
         this.xmlChunkConfig = new XmlChunkConfig(null, chunkConfig.getEmbeddingName(),
             chunkConfig.getEmbeddingXmlNamespace(), null, chunkConfig.isBase64EncodeVectors());
 
-        documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory = DOMHelper.newSecureDocumentBuilderFactory();
     }
 
     @Override

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/dom/DOMHelper.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/dom/DOMHelper.java
@@ -102,7 +102,11 @@ public class DOMHelper {
             factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
             factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-        } catch (ParserConfigurationException e) {
+
+            // Defense-in-depth: disallow any external access via JAXP properties.
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        } catch (ParserConfigurationException | IllegalArgumentException e) {
             throw new ConnectorException(
                 String.format("Unable to configure secure XML document builder; cause: %s", e.getMessage()), e);
         }

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/dom/DOMHelper.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/dom/DOMHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.dom;
 
@@ -41,7 +41,7 @@ public class DOMHelper {
     public DOMHelper(NamespaceContext namespaceContext) {
         // This can be reused for multiple calls, which will only be in the context of a single partition writer and
         // thus we don't need to worry about thread safety for it.
-        this.documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        this.documentBuilderFactory = newSecureDocumentBuilderFactory();
         this.documentBuilderFactory.setNamespaceAware(true);
         this.namespaceContext = namespaceContext;
     }
@@ -90,6 +90,24 @@ public class DOMHelper {
                 purposeForErrorMessage, xpathExpression, message), e
             );
         }
+    }
+
+    public static DocumentBuilderFactory newSecureDocumentBuilderFactory() {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        try {
+            // Disallows DOCTYPE declarations entirely, which prevents all XXE attacks.
+            // Recommended by OWASP and mirrored by Sonar rule java:S2755.
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        } catch (ParserConfigurationException e) {
+            throw new ConnectorException(
+                String.format("Unable to configure secure XML document builder; cause: %s", e.getMessage()), e);
+        }
+        factory.setExpandEntityReferences(false);
+        return factory;
     }
 
     public static TransformerFactory newTransformerFactory() throws TransformerConfigurationException {

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilder.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/DocBuilder.java
@@ -27,7 +27,6 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.*;
@@ -153,7 +152,7 @@ public class DocBuilder {
     public void addClassificationToXmlDocument(Document document, String uri, byte[] classification) {
         try {
             if (documentBuilder == null) {
-                documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+                documentBuilder = DOMHelper.newSecureDocumentBuilderFactory().newDocumentBuilder();
             }
             Document classificationXml = documentBuilder.parse(new ByteArrayInputStream(classification));
             Node classificationNode = document.createElementNS(Util.DEFAULT_XML_NAMESPACE, "classification");

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/dom/DOMHelperTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/dom/DOMHelperTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.spark.dom;
+
+import com.marklogic.spark.ConnectorException;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DOMHelperTest {
+
+    private final DOMHelper domHelper = new DOMHelper(null);
+
+    @Test
+    void validXmlIsParsedSuccessfully() {
+        Document doc = domHelper.parseXmlString("<root><child>hello</child></root>", null);
+        assertNotNull(doc);
+        assertEquals("root", doc.getDocumentElement().getLocalName());
+    }
+
+    @Test
+    void domHelperFactoryIsNamespaceAware() {
+        // DOMHelper sets namespace-awareness explicitly after obtaining the secure factory.
+        // Callers that do not need it (e.g. XmlChunkDocumentProducer, DocBuilder) omit it,
+        // preserving their original non-namespace-aware behaviour.
+        DOMHelper helper = new DOMHelper(null);
+        Document doc = helper.parseXmlString("<ns:root xmlns:ns='urn:test'/>", null);
+        assertNotNull(doc);
+        assertEquals("root", doc.getDocumentElement().getLocalName());
+    }
+
+    @Test
+    void xmlWithDoctypeIsRejected() {
+        String xml = "<?xml version=\"1.0\"?><!DOCTYPE root [<!ELEMENT root (#PCDATA)>]><root>hello</root>";
+        ConnectorException ex = assertThrows(ConnectorException.class,
+            () -> domHelper.parseXmlString(xml, "/test.xml"));
+        assertTrue(ex.getMessage().contains("/test.xml"),
+            "Error message should include the source URI; actual: " + ex.getMessage());
+    }
+
+    @Test
+    void xxeFileEntityIsRejected() {
+        // Attempts to read a local file via an XXE SYSTEM entity
+        String xml = "<?xml version=\"1.0\"?>" +
+            "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>" +
+            "<root>&xxe;</root>";
+        ConnectorException ex = assertThrows(ConnectorException.class,
+            () -> domHelper.parseXmlString(xml, "/test.xml"));
+        // The error must not contain the file contents — just the rejection message
+        assertFalse(ex.getMessage().contains("root:"),
+            "Error message must not contain file contents; actual: " + ex.getMessage());
+    }
+
+    @Test
+    void billionLaughsIsRejected() {
+        // Recursive entity expansion attack — would exhaust heap if not blocked
+        String xml = "<?xml version=\"1.0\"?>" +
+            "<!DOCTYPE lolz [" +
+            "  <!ENTITY lol \"lol\">" +
+            "  <!ENTITY lol2 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">" +
+            "  <!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">" +
+            "  <!ENTITY lol4 \"&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;\">" +
+            "]>" +
+            "<root>&lol4;</root>";
+        assertThrows(ConnectorException.class,
+            () -> domHelper.parseXmlString(xml, "/test.xml"));
+    }
+}


### PR DESCRIPTION
**Summary**

Three DocumentBuilderFactory.newInstance() call sites in the connector created XML parsers with no XXE (XML External Entity) protection. Without hardening, a malicious XML document submitted to the connector could exfiltrate local files via  entity references, trigger SSRF via outbound HTTP/FTP entity resolution, or cause a DoS via recursive entity expansion (billion laughs). This is CWE-611 / OWASP A05:2021.

The fix introduces DOMHelper.newSecureDocumentBuilderFactory(), a static factory method that applies full OWASP-recommended hardening — mirroring the pattern already used by DOMHelper.newTransformerFactory() for TransformerFactory. All three unsafe call sites are updated to use it.

A Copilot code-review suggestion to also set ACCESS_EXTERNAL_DTD and ACCESS_EXTERNAL_SCHEMA (already applied to TransformerFactory) was accepted and included as defence-in-depth.

**Breaking change: XML documents containing a DOCTYPE declaration will now be rejected with a ConnectorException. This is the correct security trade-off; the user documentation has been updated accordingly.**


**Unit tests (no MarkLogic required)**

.\gradlew.bat :marklogic-spark-connector:test --tests "com.marklogic.spark.dom.DOMHelperTest" --rerun

DOMHelperTest > validXmlIsParsedSuccessfully()     PASSED
DOMHelperTest > domHelperFactoryIsNamespaceAware()  PASSED
DOMHelperTest > xmlWithDoctypeIsRejected()          PASSED
DOMHelperTest > xxeFileEntityIsRejected()           PASSED
DOMHelperTest > billionLaughsIsRejected()           PASSED
BUILD SUCCESSFUL

**XML integration suites (MarkLogic required) — no regressions**

.\gradlew.bat :marklogic-spark-connector:test \
  --tests "com.marklogic.spark.writer.splitter.SplitXmlDocumentTest" \
  --tests "com.marklogic.spark.writer.classifier.AddClassificationToXmlTest" \
  --tests "com.marklogic.spark.writer.embedding.AddEmbeddingsToXmlTest" \
  --tests "com.marklogic.spark.writer.WriteXmlRowsTest" --rerun
  
WriteXmlRowsTest             4/4   PASSED
AddClassificationToXmlTest   4/4   PASSED
AddEmbeddingsToXmlTest      14/14  PASSED
SplitXmlDocumentTest        16/16  PASSED  (1 SKIPPED — pre-existing @Disabled)
BUILD SUCCESSFUL in 58s

