### PR TITLE
MLE-31218: Add configurable zip bomb protection to all zip-reading paths

### DIFF
--- a/docs/reading-data/reading-files/zip-files.md
+++ b/docs/reading-data/reading-files/zip-files.md
@@ -7,7 +7,7 @@ nav_order: 4
 ---
 
 The MarkLogic connector has special handling for ZIP files, enabling each entry in a ZIP file to be read as a separate
-row and eventually written to MarkLogic as a separate document. 
+row and eventually written to MarkLogic as a separate document.
 
 ## Table of contents
 {: .no_toc .text-delta }
@@ -17,7 +17,7 @@ row and eventually written to MarkLogic as a separate document.
 
 ## Specifying ZIP files to read
 
-To configure the connector to read each entry in one or more ZIP files as separate rows, set the 
+To configure the connector to read each entry in one or more ZIP files as separate rows, set the
 `spark.marklogic.read.files.compression` option to a value of `zip`:
 
 ```
@@ -27,22 +27,67 @@ df = spark.read.format("marklogic") \
 df.show()
 ```
 
-The connector will return 1 row per entry in each zip file, with each row conforming to the 
-[Spark Binary data source schema](https://spark.apache.org/docs/latest/sql-data-sources-binaryFile.html). Each row 
+The connector will return 1 row per entry in each zip file, with each row conforming to the
+[Spark Binary data source schema](https://spark.apache.org/docs/latest/sql-data-sources-binaryFile.html). Each row
 will have a `path` column with a value based on the path of the ZIP file and the name of the ZIP entry.
 
-To see the full path - which you will likely want to customize if writing these rows as documents to 
+To see the full path - which you will likely want to customize if writing these rows as documents to
 MarkLogic - try the following:
 
 ```
 df.select("path").show(20, 0, True)
 ```
 
-Please see [the guide on writing data](../../writing.md) for information on how "file rows" can then be written to 
+Please see [the guide on writing data](../../writing.md) for information on how "file rows" can then be written to
 MarkLogic as documents.
+
+## Zip bomb protection
+
+When reading ZIP files from untrusted sources, the connector can be configured to guard against
+[zip bombs](https://en.wikipedia.org/wiki/Zip_bomb) — specially crafted archives that expand to an enormous
+amount of data and can exhaust executor memory. Both limits are disabled by default (opt-in).
+
+To limit the maximum number of uncompressed bytes read from any single entry, set
+`spark.marklogic.read.zip.maxUncompressedEntryBytes`:
+
+```
+df = spark.read.format("marklogic") \
+  .option("spark.marklogic.read.files.compression", "zip") \
+  .option("spark.marklogic.read.zip.maxUncompressedEntryBytes", 268435456) \
+  .load("data/untrusted.zip")
+```
+
+A value of `268435456` (256 MB) is a reasonable starting point for most use cases. If a single entry exceeds
+this limit, the connector throws an error. Set to `0` or any value less than `1` to disable.
+
+To limit the maximum number of entries iterated in a single archive, set
+`spark.marklogic.read.zip.maxEntryCount`:
+
+```
+df = spark.read.format("marklogic") \
+  .option("spark.marklogic.read.files.compression", "zip") \
+  .option("spark.marklogic.read.zip.maxEntryCount", 100000) \
+  .load("data/untrusted.zip")
+```
+
+A value of `100000` is a reasonable starting point for most use cases. Set to `0` or any value less than `1`
+to disable.
+
+Both options may be combined:
+
+```
+df = spark.read.format("marklogic") \
+  .option("spark.marklogic.read.files.compression", "zip") \
+  .option("spark.marklogic.read.zip.maxUncompressedEntryBytes", 268435456) \
+  .option("spark.marklogic.read.zip.maxEntryCount", 100000) \
+  .load("data/untrusted.zip")
+```
+
+These options also apply when reading archives (`spark.marklogic.read.files.type=archive` or `mlcp_archive`),
+aggregate XML ZIP files, and RDF ZIP files.
 
 ## Error handling
 
 Due to how the underlying Java support for reading ZIP files works, files that are not valid ZIP files do not result
 in any errors being thrown. Instead, the Java support simply does not return any rows for any file that it cannot read
-as a ZIP file. 
+as a ZIP file.

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
@@ -135,8 +135,9 @@ public abstract class Options {
 
     /**
      * Maximum number of uncompressed bytes that may be read from a single zip archive entry.
-     * Defaults to -1 (disabled). Set to a positive integer to enable protection; a value of 268,435,456
-     * (256 MB) is a reasonable starting point for most use cases.
+     * Defaults to 0 (disabled). Any value less than 1 disables the limit. Set to a positive
+     * integer to enable protection; a value of 268,435,456 (256 MB) is a reasonable starting
+     * point for most use cases.
      *
      * @since 3.1.2
      */
@@ -144,8 +145,9 @@ public abstract class Options {
 
     /**
      * Maximum number of entries that may be iterated in a single zip archive.
-     * Defaults to -1 (disabled). Set to a positive integer to enable protection; a value of 100,000
-     * is a reasonable starting point for most use cases.
+     * Defaults to 0 (disabled). Any value less than 1 disables the limit. Set to a positive
+     * integer to enable protection; a value of 100,000 is a reasonable starting point for most
+     * use cases.
      *
      * @since 3.1.2
      */

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
@@ -135,7 +135,8 @@ public abstract class Options {
 
     /**
      * Maximum number of uncompressed bytes that may be read from a single zip archive entry.
-     * Defaults to 268,435,456 (256 MB). Set to -1 to disable the limit.
+     * Defaults to -1 (disabled). Set to a positive integer to enable protection; a value of 268,435,456
+     * (256 MB) is a reasonable starting point for most use cases.
      *
      * @since 3.1.2
      */
@@ -143,7 +144,8 @@ public abstract class Options {
 
     /**
      * Maximum number of entries that may be iterated in a single zip archive.
-     * Defaults to 100,000. Set to -1 to disable the limit.
+     * Defaults to -1 (disabled). Set to a positive integer to enable protection; a value of 100,000
+     * is a reasonable starting point for most use cases.
      *
      * @since 3.1.2
      */

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/Options.java
@@ -133,6 +133,22 @@ public abstract class Options {
     public static final String READ_FILES_ABORT_ON_FAILURE = "spark.marklogic.read.files.abortOnFailure";
     public static final String READ_ARCHIVES_CATEGORIES = "spark.marklogic.read.archives.categories";
 
+    /**
+     * Maximum number of uncompressed bytes that may be read from a single zip archive entry.
+     * Defaults to 268,435,456 (256 MB). Set to -1 to disable the limit.
+     *
+     * @since 3.1.2
+     */
+    public static final String READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES = "spark.marklogic.read.zip.maxUncompressedEntryBytes";
+
+    /**
+     * Maximum number of entries that may be iterated in a single zip archive.
+     * Defaults to 100,000. Set to -1 to disable the limit.
+     *
+     * @since 3.1.2
+     */
+    public static final String READ_ZIP_MAX_ENTRY_COUNT = "spark.marklogic.read.zip.maxEntryCount";
+
     // "Aggregate" = an XML document containing N child elements, each of which should become a row / document.
     // "xml" is included in the name in anticipation of eventually supporting "aggregate JSON" - i.e. an array of N
     // objects, where each object should become a row / document (this is different from JSON lines format).

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/ArchiveFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/ArchiveFileReader.java
@@ -73,7 +73,7 @@ public class ArchiveFileReader implements PartitionReader<InternalRow> {
 
             zipEntryCount++;
             int maxEntryCount = fileContext.getZipMaxEntryCount();
-            if (maxEntryCount >= 0 && zipEntryCount > maxEntryCount) {
+            if (maxEntryCount > 0 && zipEntryCount > maxEntryCount) {
                 throw new ConnectorException(String.format(
                     "Zip archive entry count exceeds the maximum of %d entries. " +
                         "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/ArchiveFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/ArchiveFileReader.java
@@ -32,6 +32,7 @@ public class ArchiveFileReader implements PartitionReader<InternalRow> {
     private ZipInputStream currentZipInputStream;
     private int nextFilePathIndex;
     private InternalRow nextRowToReturn;
+    private int zipEntryCount = 0;
 
     // Legacy = content first, then metadata.
     private Boolean isLegacyFormat;
@@ -68,6 +69,15 @@ public class ArchiveFileReader implements PartitionReader<InternalRow> {
             ZipEntry nextZipEntry = FileUtil.findNextFileEntry(currentZipInputStream);
             if (nextZipEntry == null) {
                 return openNextFileAndReadNextEntry();
+            }
+
+            zipEntryCount++;
+            int maxEntryCount = fileContext.getZipMaxEntryCount();
+            if (maxEntryCount >= 0 && zipEntryCount > maxEntryCount) {
+                throw new ConnectorException(String.format(
+                    "Zip archive entry count exceeds the maximum of %d entries. " +
+                        "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                    maxEntryCount, Options.READ_ZIP_MAX_ENTRY_COUNT));
             }
 
             if (isLegacyFormat == null) {
@@ -199,6 +209,7 @@ public class ArchiveFileReader implements PartitionReader<InternalRow> {
         final boolean isStreamingDuringRead = StreamingMode.STREAM_DURING_READER_PHASE.equals(this.streamingMode);
         this.currentFilePath = filePartition.getPaths().get(nextFilePathIndex);
         nextFilePathIndex++;
+        this.zipEntryCount = 0;
 
         if (!isStreamingDuringRead) {
             this.currentZipInputStream = new ZipInputStream(fileContext.openFile(this.currentFilePath));

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/ArchiveFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/ArchiveFileReader.java
@@ -76,7 +76,7 @@ public class ArchiveFileReader implements PartitionReader<InternalRow> {
             if (maxEntryCount > 0 && zipEntryCount > maxEntryCount) {
                 throw new ConnectorException(String.format(
                     "Zip archive entry count exceeds the maximum of %d entries. " +
-                        "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                        "Use connector option '%s' to increase the limit. Set to 0 or less to disable.",
                     maxEntryCount, Options.READ_ZIP_MAX_ENTRY_COUNT));
             }
 

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileContext.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileContext.java
@@ -81,38 +81,22 @@ public class FileContext extends ContextSupport implements Serializable {
 
     /**
      * @return the maximum number of uncompressed bytes to read from a single zip entry;
-     *         -1 means unlimited (the default). Zip bomb protection is opt-in: set a positive
-     *         integer to enable the limit.
-     * @throws ConnectorException if the configured value is 0 or a negative number other than -1,
-     *         since those values have no meaningful interpretation.
+     *         any value less than 1 means unlimited (the default is 0). Zip bomb protection
+     *         is opt-in: set a positive integer to enable the limit.
      */
     public long getZipMaxUncompressedEntryBytes() {
         String val = getStringOption(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES);
-        long limit = val != null ? Long.parseLong(val) : -1L;
-        if (limit == 0 || (limit < 0 && limit != -1L)) {
-            throw new ConnectorException(String.format(
-                "Invalid value '%s' for option '%s': must be -1 (disabled) or a positive integer.",
-                val, Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES));
-        }
-        return limit;
+        return val != null ? Long.parseLong(val) : 0L;
     }
 
     /**
      * @return the maximum number of entries to iterate in a single zip archive;
-     *         -1 means unlimited (the default). Zip bomb protection is opt-in: set a positive
-     *         integer to enable the limit.
-     * @throws ConnectorException if the configured value is 0 or a negative number other than -1,
-     *         since those values have no meaningful interpretation.
+     *         any value less than 1 means unlimited (the default is 0). Zip bomb protection
+     *         is opt-in: set a positive integer to enable the limit.
      */
     public int getZipMaxEntryCount() {
         String val = getStringOption(Options.READ_ZIP_MAX_ENTRY_COUNT);
-        int limit = val != null ? Integer.parseInt(val) : -1;
-        if (limit == 0 || (limit < 0 && limit != -1)) {
-            throw new ConnectorException(String.format(
-                "Invalid value '%s' for option '%s': must be -1 (disabled) or a positive integer.",
-                val, Options.READ_ZIP_MAX_ENTRY_COUNT));
-        }
-        return limit;
+        return val != null ? Integer.parseInt(val) : 0;
     }
 
     /**
@@ -126,14 +110,14 @@ public class FileContext extends ContextSupport implements Serializable {
      */
     public InputStream boundedZipEntryStream(InputStream in) {
         long maxBytes = getZipMaxUncompressedEntryBytes();
-        return maxBytes >= 0 ? new MaxBytesInputStream(in, maxBytes) : in;
+        return maxBytes > 0 ? new MaxBytesInputStream(in, maxBytes) : in;
     }
 
     byte[] readBytes(InputStream inputStream) throws IOException {
         // Only apply the zip entry byte limit when reading from a zip-based format
         // (compression=zip, type=archive, or type=mlcp_archive). Non-zip callers such as
         // GenericFileReader and GzipFileReader must not be subject to the zip-specific limit.
-        long maxBytes = isZipBasedRead() ? getZipMaxUncompressedEntryBytes() : -1L;
+        long maxBytes = isZipBasedRead() ? getZipMaxUncompressedEntryBytes() : 0L;
         byte[] bytes = FileUtil.readBytes(inputStream, maxBytes);
         return this.encoding != null ? new String(bytes, this.encoding).getBytes() : bytes;
     }

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileContext.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileContext.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.ContextSupport;
 import com.marklogic.spark.Options;
+import com.marklogic.spark.Util;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -79,8 +80,52 @@ public class FileContext extends ContextSupport implements Serializable {
         return getBooleanOption(Options.READ_FILES_ABORT_ON_FAILURE, true);
     }
 
+    /**
+     * @return the maximum number of uncompressed bytes to read from a single zip entry;
+     *         -1 means unlimited. Defaults to 256 MB.
+     */
+    public long getZipMaxUncompressedEntryBytes() {
+        String val = getStringOption(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES);
+        if (val != null && Long.parseLong(val) < 0) {
+            Util.MAIN_LOGGER.warn("Zip bomb protection is disabled (option '{}' = {}). " +
+                "Only set this on sources you fully trust.",
+                Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, val);
+            return -1L;
+        }
+        return val != null ? Long.parseLong(val) : 268_435_456L;
+    }
+
+    /**
+     * @return the maximum number of entries to iterate in a single zip archive;
+     *         -1 means unlimited. Defaults to 100,000.
+     */
+    public int getZipMaxEntryCount() {
+        String val = getStringOption(Options.READ_ZIP_MAX_ENTRY_COUNT);
+        if (val != null && Integer.parseInt(val) < 0) {
+            Util.MAIN_LOGGER.warn("Zip bomb protection is disabled (option '{}' = {}). " +
+                "Only set this on sources you fully trust.",
+                Options.READ_ZIP_MAX_ENTRY_COUNT, val);
+            return -1;
+        }
+        return val != null ? Integer.parseInt(val) : 100_000;
+    }
+
+    /**
+     * Wraps the given stream in a {@link MaxBytesInputStream} if the zip byte limit is configured,
+     * otherwise returns the stream unchanged. Callers (such as XML and RDF parsers in sub-packages)
+     * should use this instead of instantiating {@code MaxBytesInputStream} directly, since that
+     * class is package-private to {@code com.marklogic.spark.reader.file}.
+     *
+     * @param in the raw zip entry stream
+     * @return a byte-limited wrapper, or {@code in} if the limit is disabled (-1)
+     */
+    public InputStream boundedZipEntryStream(InputStream in) {
+        long maxBytes = getZipMaxUncompressedEntryBytes();
+        return maxBytes >= 0 ? new MaxBytesInputStream(in, maxBytes) : in;
+    }
+
     byte[] readBytes(InputStream inputStream) throws IOException {
-        byte[] bytes = FileUtil.readBytes(inputStream);
+        byte[] bytes = FileUtil.readBytes(inputStream, getZipMaxUncompressedEntryBytes());
         return this.encoding != null ? new String(bytes, this.encoding).getBytes() : bytes;
     }
 

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileContext.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileContext.java
@@ -106,7 +106,7 @@ public class FileContext extends ContextSupport implements Serializable {
      * class is package-private to {@code com.marklogic.spark.reader.file}.
      *
      * @param in the raw zip entry stream
-     * @return a byte-limited wrapper, or {@code in} if the limit is disabled (-1)
+     * @return a byte-limited wrapper, or {@code in} if the limit is disabled (any value less than 1)
      */
     public InputStream boundedZipEntryStream(InputStream in) {
         long maxBytes = getZipMaxUncompressedEntryBytes();

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileContext.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileContext.java
@@ -6,7 +6,6 @@ package com.marklogic.spark.reader.file;
 import com.marklogic.spark.ConnectorException;
 import com.marklogic.spark.ContextSupport;
 import com.marklogic.spark.Options;
-import com.marklogic.spark.Util;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -82,32 +81,38 @@ public class FileContext extends ContextSupport implements Serializable {
 
     /**
      * @return the maximum number of uncompressed bytes to read from a single zip entry;
-     *         -1 means unlimited. Defaults to 256 MB.
+     *         -1 means unlimited (the default). Zip bomb protection is opt-in: set a positive
+     *         integer to enable the limit.
+     * @throws ConnectorException if the configured value is 0 or a negative number other than -1,
+     *         since those values have no meaningful interpretation.
      */
     public long getZipMaxUncompressedEntryBytes() {
         String val = getStringOption(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES);
-        if (val != null && Long.parseLong(val) < 0) {
-            Util.MAIN_LOGGER.warn("Zip bomb protection is disabled (option '{}' = {}). " +
-                "Only set this on sources you fully trust.",
-                Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, val);
-            return -1L;
+        long limit = val != null ? Long.parseLong(val) : -1L;
+        if (limit == 0 || (limit < 0 && limit != -1L)) {
+            throw new ConnectorException(String.format(
+                "Invalid value '%s' for option '%s': must be -1 (disabled) or a positive integer.",
+                val, Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES));
         }
-        return val != null ? Long.parseLong(val) : 268_435_456L;
+        return limit;
     }
 
     /**
      * @return the maximum number of entries to iterate in a single zip archive;
-     *         -1 means unlimited. Defaults to 100,000.
+     *         -1 means unlimited (the default). Zip bomb protection is opt-in: set a positive
+     *         integer to enable the limit.
+     * @throws ConnectorException if the configured value is 0 or a negative number other than -1,
+     *         since those values have no meaningful interpretation.
      */
     public int getZipMaxEntryCount() {
         String val = getStringOption(Options.READ_ZIP_MAX_ENTRY_COUNT);
-        if (val != null && Integer.parseInt(val) < 0) {
-            Util.MAIN_LOGGER.warn("Zip bomb protection is disabled (option '{}' = {}). " +
-                "Only set this on sources you fully trust.",
-                Options.READ_ZIP_MAX_ENTRY_COUNT, val);
-            return -1;
+        int limit = val != null ? Integer.parseInt(val) : -1;
+        if (limit == 0 || (limit < 0 && limit != -1)) {
+            throw new ConnectorException(String.format(
+                "Invalid value '%s' for option '%s': must be -1 (disabled) or a positive integer.",
+                val, Options.READ_ZIP_MAX_ENTRY_COUNT));
         }
-        return val != null ? Integer.parseInt(val) : 100_000;
+        return limit;
     }
 
     /**
@@ -125,8 +130,24 @@ public class FileContext extends ContextSupport implements Serializable {
     }
 
     byte[] readBytes(InputStream inputStream) throws IOException {
-        byte[] bytes = FileUtil.readBytes(inputStream, getZipMaxUncompressedEntryBytes());
+        // Only apply the zip entry byte limit when reading from a zip-based format
+        // (compression=zip, type=archive, or type=mlcp_archive). Non-zip callers such as
+        // GenericFileReader and GzipFileReader must not be subject to the zip-specific limit.
+        long maxBytes = isZipBasedRead() ? getZipMaxUncompressedEntryBytes() : -1L;
+        byte[] bytes = FileUtil.readBytes(inputStream, maxBytes);
         return this.encoding != null ? new String(bytes, this.encoding).getBytes() : bytes;
+    }
+
+    /**
+     * @return true when the current read context is a zip-based format — i.e. compression=zip,
+     *         type=archive, or type=mlcp_archive. Used to scope the zip byte limit to zip readers only.
+     */
+    private boolean isZipBasedRead() {
+        if (isZip()) {
+            return true;
+        }
+        String fileType = getStringOption(Options.READ_FILES_TYPE);
+        return "archive".equalsIgnoreCase(fileType) || "mlcp_archive".equalsIgnoreCase(fileType);
     }
 
     private boolean isFileGzipped(String filePath, boolean guessIfGzipped) {

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileContext.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileContext.java
@@ -86,7 +86,15 @@ public class FileContext extends ContextSupport implements Serializable {
      */
     public long getZipMaxUncompressedEntryBytes() {
         String val = getStringOption(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES);
-        return val != null ? Long.parseLong(val) : 0L;
+        if (val == null) {
+            return 0L;
+        }
+        try {
+            return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+            throw new ConnectorException(String.format(
+                "Invalid value for %s: %s", Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, val));
+        }
     }
 
     /**
@@ -96,7 +104,15 @@ public class FileContext extends ContextSupport implements Serializable {
      */
     public int getZipMaxEntryCount() {
         String val = getStringOption(Options.READ_ZIP_MAX_ENTRY_COUNT);
-        return val != null ? Integer.parseInt(val) : 0;
+        if (val == null) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(val);
+        } catch (NumberFormatException e) {
+            throw new ConnectorException(String.format(
+                "Invalid value for %s: %s", Options.READ_ZIP_MAX_ENTRY_COUNT, val));
+        }
     }
 
     /**

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileUtil.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileUtil.java
@@ -52,7 +52,7 @@ public interface FileUtil {
             if (maxBytes > 0 && totalRead > maxBytes) {
                 throw new ConnectorException(String.format(
                     "Zip entry uncompressed size exceeds the maximum of %d bytes. " +
-                        "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                        "Use connector option '%s' to increase the limit. Set to 0 or less to disable.",
                     maxBytes, Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES));
             }
             baos.write(buffer, 0, read);

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileUtil.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileUtil.java
@@ -26,18 +26,18 @@ public interface FileUtil {
      * @throws IOException
      */
     static byte[] readBytes(InputStream inputStream) throws IOException {
-        return readBytes(inputStream, -1L);
+        return readBytes(inputStream, 0L);
     }
 
     /**
      * Reads all bytes from {@code inputStream} into a byte array, enforcing an optional upper bound on the
-     * number of bytes read. Pass {@code -1} for {@code maxBytes} to disable the limit.
+     * number of bytes read. Pass {@code 0} (or any value less than 1) for {@code maxBytes} to disable the limit.
      *
      * <p>Uses a 4096-byte read buffer (an improvement over the legacy 1024-byte buffer used prior to 3.1.2),
      * which benefits all callers including non-zip readers.
      *
      * @param inputStream the stream to drain
-     * @param maxBytes    the maximum number of bytes to allow; -1 means unlimited
+     * @param maxBytes    the maximum number of bytes to allow; any value less than 1 means unlimited
      * @return the bytes read
      * @throws IOException          on I/O errors
      * @throws ConnectorException   when {@code maxBytes} is non-negative and the limit is exceeded

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileUtil.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileUtil.java
@@ -49,7 +49,7 @@ public interface FileUtil {
         int read;
         while ((read = inputStream.read(buffer)) != -1) {
             totalRead += read;
-            if (maxBytes >= 0 && totalRead > maxBytes) {
+            if (maxBytes > 0 && totalRead > maxBytes) {
                 throw new ConnectorException(String.format(
                     "Zip entry uncompressed size exceeds the maximum of %d bytes. " +
                         "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileUtil.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/FileUtil.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Options;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -25,19 +26,45 @@ public interface FileUtil {
      * @throws IOException
      */
     static byte[] readBytes(InputStream inputStream) throws IOException {
-        byte[] buffer = new byte[1024];
+        return readBytes(inputStream, -1L);
+    }
+
+    /**
+     * Reads all bytes from {@code inputStream} into a byte array, enforcing an optional upper bound on the
+     * number of bytes read. Pass {@code -1} for {@code maxBytes} to disable the limit.
+     *
+     * <p>Uses a 4096-byte read buffer (an improvement over the legacy 1024-byte buffer used prior to 3.1.2),
+     * which benefits all callers including non-zip readers.
+     *
+     * @param inputStream the stream to drain
+     * @param maxBytes    the maximum number of bytes to allow; -1 means unlimited
+     * @return the bytes read
+     * @throws IOException          on I/O errors
+     * @throws ConnectorException   when {@code maxBytes} is non-negative and the limit is exceeded
+     */
+    static byte[] readBytes(InputStream inputStream, long maxBytes) throws IOException {
+        byte[] buffer = new byte[4096];
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        long totalRead = 0;
         int read;
         while ((read = inputStream.read(buffer)) != -1) {
+            totalRead += read;
+            if (maxBytes >= 0 && totalRead > maxBytes) {
+                throw new ConnectorException(String.format(
+                    "Zip entry uncompressed size exceeds the maximum of %d bytes. " +
+                        "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                    maxBytes, Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES));
+            }
             baos.write(buffer, 0, read);
         }
         return baos.toByteArray();
     }
 
-    // The suppressed Sonar warning is for a potential "Zip bomb" attack when accessing a zip entry. The recommended
-    // fixes involve checking the zip of the entry. That is not possible as the ZipInputStream returns -1 for both the
-    // size and compressed size.
-    @SuppressWarnings("java:S5042")
+    // ZipInputStream does not expose entry size metadata (getSize() / getCompressedSize() return -1 before content
+    // is read). Compensating controls are applied by all callers:
+    //   - Per-entry byte limit: enforced in FileContext.readBytes() for the direct-read path, and via
+    //     MaxBytesInputStream for the XML and RDF parser paths (READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES).
+    //   - Per-archive entry count: enforced by each reader before calling this method (READ_ZIP_MAX_ENTRY_COUNT).
     static ZipEntry findNextFileEntry(ZipInputStream zipInputStream) throws IOException {
         ZipEntry entry = zipInputStream.getNextEntry();
         if (entry == null) {

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/MaxBytesInputStream.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/MaxBytesInputStream.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.spark.reader.file;
+
+import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Options;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * An {@code InputStream} wrapper that throws a {@link ConnectorException} when more than
+ * {@code maxBytes} bytes have been read. Intentionally does <em>not</em> propagate
+ * {@code close()} to the underlying stream, so that the wrapped {@link java.util.zip.ZipInputStream}
+ * remains open and can be advanced to subsequent zip entries after this wrapper is discarded.
+ */
+class MaxBytesInputStream extends FilterInputStream {
+
+    private final long maxBytes;
+    private long bytesRead = 0;
+
+    MaxBytesInputStream(InputStream in, long maxBytes) {
+        super(in);
+        this.maxBytes = maxBytes;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int b = super.read();
+        if (b != -1) {
+            checkLimit(1);
+        }
+        return b;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int n = super.read(b, off, len);
+        if (n > 0) {
+            checkLimit(n);
+        }
+        return n;
+    }
+
+    /**
+     * Intentionally does not close the underlying stream. The caller (e.g. a zip-reading loop) retains
+     * ownership of the {@link java.util.zip.ZipInputStream} and is responsible for closing it.
+     */
+    @Override
+    public void close() {
+        // Do not propagate close to the underlying ZipInputStream.
+    }
+
+    private void checkLimit(int n) {
+        bytesRead += n;
+        if (bytesRead > maxBytes) {
+            throw new ConnectorException(String.format(
+                "Zip entry uncompressed size exceeds the maximum of %d bytes. " +
+                    "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                maxBytes, Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES));
+        }
+    }
+}

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/MaxBytesInputStream.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/MaxBytesInputStream.java
@@ -45,6 +45,28 @@ class MaxBytesInputStream extends FilterInputStream {
     }
 
     /**
+     * Overrides {@link FilterInputStream#skip} to route skipped bytes through {@link #read} so
+     * the byte counter is kept up to date. The default {@code FilterInputStream.skip} delegates
+     * directly to the underlying stream and would bypass limit enforcement.
+     */
+    @Override
+    public long skip(long n) throws IOException {
+        byte[] buffer = new byte[(int) Math.min(n, 4096L)];
+        long remaining = n;
+        long totalSkipped = 0;
+        while (remaining > 0) {
+            int toRead = (int) Math.min(remaining, buffer.length);
+            int bytesRead = read(buffer, 0, toRead);
+            if (bytesRead == -1) {
+                break;
+            }
+            totalSkipped += bytesRead;
+            remaining -= bytesRead;
+        }
+        return totalSkipped;
+    }
+
+    /**
      * Intentionally does not close the underlying stream. The caller (e.g. a zip-reading loop) retains
      * ownership of the {@link java.util.zip.ZipInputStream} and is responsible for closing it.
      */

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/MaxBytesInputStream.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/MaxBytesInputStream.java
@@ -80,7 +80,7 @@ class MaxBytesInputStream extends FilterInputStream {
         if (bytesRead > maxBytes) {
             throw new ConnectorException(String.format(
                 "Zip entry uncompressed size exceeds the maximum of %d bytes. " +
-                    "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                    "Use connector option '%s' to increase the limit. Set to 0 or less to disable.",
                 maxBytes, Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES));
         }
     }

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
@@ -135,7 +135,7 @@ class MlcpArchiveFileReader implements PartitionReader<InternalRow> {
             if (maxEntryCount > 0 && zipEntryCount > maxEntryCount) {
                 throw new ConnectorException(String.format(
                     "Zip archive entry count exceeds the maximum of %d entries. " +
-                        "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                        "Use connector option '%s' to increase the limit. Set to 0 or less to disable.",
                     maxEntryCount, Options.READ_ZIP_MAX_ENTRY_COUNT));
             }
         }
@@ -184,10 +184,10 @@ class MlcpArchiveFileReader implements PartitionReader<InternalRow> {
         // the number of metadata entries (which would effectively limit documents, not entries).
         zipEntryCount++;
         int maxEntryCount = fileContext.getZipMaxEntryCount();
-        if (maxEntryCount >= 0 && zipEntryCount > maxEntryCount) {
+        if (maxEntryCount > 0 && zipEntryCount > maxEntryCount) {
             throw new ConnectorException(String.format(
                 "Zip archive entry count exceeds the maximum of %d entries. " +
-                    "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                    "Use connector option '%s' to increase the limit. Set to 0 or less to disable.",
                 maxEntryCount, Options.READ_ZIP_MAX_ENTRY_COUNT));
         }
 

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.reader.file;
 
@@ -29,6 +29,7 @@ class MlcpArchiveFileReader implements PartitionReader<InternalRow> {
     private ZipInputStream currentZipInputStream;
     private int nextFilePathIndex;
     private InternalRow nextRowToReturn;
+    private int zipEntryCount = 0;
 
     MlcpArchiveFileReader(FilePartition filePartition, FileContext fileContext) {
         this.filePartition = filePartition;
@@ -102,6 +103,7 @@ class MlcpArchiveFileReader implements PartitionReader<InternalRow> {
         this.currentFilePath = filePartition.getPaths().get(nextFilePathIndex);
         nextFilePathIndex++;
         this.currentZipInputStream = new ZipInputStream(fileContext.openFile(this.currentFilePath));
+        this.zipEntryCount = 0;
     }
 
     private boolean openNextFileAndReadNextEntry() {
@@ -116,8 +118,9 @@ class MlcpArchiveFileReader implements PartitionReader<InternalRow> {
     private ZipEntry getNextMetadataEntry() {
         // MLCP always includes a metadata entry, even if the user asks for no metadata. And the metadata entry is
         // always first.
+        ZipEntry entry;
         try {
-            return FileUtil.findNextFileEntry(currentZipInputStream);
+            entry = FileUtil.findNextFileEntry(currentZipInputStream);
         } catch (IOException e) {
             String message = String.format("Unable to read from zip file: %s; cause: %s", this.currentFilePath, e.getMessage());
             if (fileContext.isReadAbortOnFailure()) {
@@ -126,6 +129,17 @@ class MlcpArchiveFileReader implements PartitionReader<InternalRow> {
             Util.MAIN_LOGGER.warn(message);
             return null;
         }
+        if (entry != null) {
+            zipEntryCount++;
+            int maxEntryCount = fileContext.getZipMaxEntryCount();
+            if (maxEntryCount >= 0 && zipEntryCount > maxEntryCount) {
+                throw new ConnectorException(String.format(
+                    "Zip archive entry count exceeds the maximum of %d entries. " +
+                        "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                    maxEntryCount, Options.READ_ZIP_MAX_ENTRY_COUNT));
+            }
+        }
+        return entry;
     }
 
     private MlcpMetadata readMetadataEntry(ZipEntry metadataZipEntry) {

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
@@ -132,7 +132,7 @@ class MlcpArchiveFileReader implements PartitionReader<InternalRow> {
         if (entry != null) {
             zipEntryCount++;
             int maxEntryCount = fileContext.getZipMaxEntryCount();
-            if (maxEntryCount >= 0 && zipEntryCount > maxEntryCount) {
+            if (maxEntryCount > 0 && zipEntryCount > maxEntryCount) {
                 throw new ConnectorException(String.format(
                     "Zip archive entry count exceeds the maximum of %d entries. " +
                         "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/MlcpArchiveFileReader.java
@@ -179,6 +179,18 @@ class MlcpArchiveFileReader implements PartitionReader<InternalRow> {
             Util.MAIN_LOGGER.warn(message);
             return null;
         }
+
+        // Count the content entry so the limit reflects the true raw zip entry count, not just
+        // the number of metadata entries (which would effectively limit documents, not entries).
+        zipEntryCount++;
+        int maxEntryCount = fileContext.getZipMaxEntryCount();
+        if (maxEntryCount >= 0 && zipEntryCount > maxEntryCount) {
+            throw new ConnectorException(String.format(
+                "Zip archive entry count exceeds the maximum of %d entries. " +
+                    "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                maxEntryCount, Options.READ_ZIP_MAX_ENTRY_COUNT));
+        }
+
         return contentZipEntry;
     }
 

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
@@ -91,6 +91,10 @@ class RdfZipFileReader implements PartitionReader<InternalRow> {
             if (fileContext.isReadAbortOnFailure()) {
                 throw cex;
             }
+            // Clear the current reader before retrying. Without this, next() would call
+            // currentRdfStreamReader.hasNext() again on the same exhausted/limited stream,
+            // causing MaxBytesInputStream to throw again immediately and loop forever.
+            currentRdfStreamReader = null;
             Util.MAIN_LOGGER.warn(cex.getMessage());
             return next();
         } catch (Exception ex) {

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
@@ -57,7 +57,7 @@ class RdfZipFileReader implements PartitionReader<InternalRow> {
 
                 zipEntryCount++;
                 int maxEntryCount = fileContext.getZipMaxEntryCount();
-                if (maxEntryCount >= 0 && zipEntryCount > maxEntryCount) {
+                if (maxEntryCount > 0 && zipEntryCount > maxEntryCount) {
                     throw new ConnectorException(String.format(
                         "Zip archive entry count exceeds the maximum of %d entries. " +
                             "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Options;
 import com.marklogic.spark.Util;
 import org.apache.commons.io.IOUtils;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -27,6 +28,7 @@ class RdfZipFileReader implements PartitionReader<InternalRow> {
     private CustomZipInputStream currentZipInputStream;
     private RdfStreamReader currentRdfStreamReader;
     private int nextFilePathIndex;
+    private int zipEntryCount = 0;
 
     RdfZipFileReader(FilePartition filePartition, FileContext fileContext) {
         this.filePartition = filePartition;
@@ -52,12 +54,23 @@ class RdfZipFileReader implements PartitionReader<InternalRow> {
                     currentZipInputStream = null;
                     return next();
                 }
+
+                zipEntryCount++;
+                int maxEntryCount = fileContext.getZipMaxEntryCount();
+                if (maxEntryCount >= 0 && zipEntryCount > maxEntryCount) {
+                    throw new ConnectorException(String.format(
+                        "Zip archive entry count exceeds the maximum of %d entries. " +
+                            "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                        maxEntryCount, Options.READ_ZIP_MAX_ENTRY_COUNT));
+                }
+
                 if (logger.isTraceEnabled()) {
                     logger.trace("Reading entry {} in {}", zipEntry.getName(), this.currentFilePath);
                 }
+                InputStream entryStream = fileContext.boundedZipEntryStream(this.currentZipInputStream);
                 this.currentRdfStreamReader = RdfUtil.isQuadsFile(zipEntry.getName()) ?
-                    new QuadStreamReader(zipEntry.getName(), currentZipInputStream) :
-                    new TripleStreamReader(zipEntry.getName(), currentZipInputStream);
+                    new QuadStreamReader(zipEntry.getName(), entryStream) :
+                    new TripleStreamReader(zipEntry.getName(), entryStream);
                 return next();
             }
 
@@ -70,6 +83,15 @@ class RdfZipFileReader implements PartitionReader<InternalRow> {
             this.currentFilePath = filePartition.getPaths().get(nextFilePathIndex);
             nextFilePathIndex++;
             this.currentZipInputStream = new CustomZipInputStream(fileContext.openFile(currentFilePath));
+            this.zipEntryCount = 0;
+            return next();
+        } catch (ConnectorException cex) {
+            // Re-throw our own ConnectorException directly to preserve the descriptive error message.
+            // Wrapping it in a second ConnectorException would bury the actionable limit message.
+            if (fileContext.isReadAbortOnFailure()) {
+                throw cex;
+            }
+            Util.MAIN_LOGGER.warn(cex.getMessage());
             return next();
         } catch (Exception ex) {
             if (fileContext.isReadAbortOnFailure()) {

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/RdfZipFileReader.java
@@ -60,7 +60,7 @@ class RdfZipFileReader implements PartitionReader<InternalRow> {
                 if (maxEntryCount > 0 && zipEntryCount > maxEntryCount) {
                     throw new ConnectorException(String.format(
                         "Zip archive entry count exceeds the maximum of %d entries. " +
-                            "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                            "Use connector option '%s' to increase the limit. Set to 0 or less to disable.",
                         maxEntryCount, Options.READ_ZIP_MAX_ENTRY_COUNT));
                 }
 

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
@@ -63,7 +63,7 @@ public class ZipFileReader implements PartitionReader<InternalRow> {
         if (currentZipEntry != null) {
             zipEntryCount++;
             int maxEntryCount = fileContext.getZipMaxEntryCount();
-            if (maxEntryCount >= 0 && zipEntryCount > maxEntryCount) {
+            if (maxEntryCount > 0 && zipEntryCount > maxEntryCount) {
                 throw new ConnectorException(String.format(
                     "Zip archive entry count exceeds the maximum of %d entries. " +
                         "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.reader.file;
 
 import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Options;
 import com.marklogic.spark.reader.document.DocumentRowBuilder;
 import org.apache.commons.crypto.utils.IoUtils;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -33,6 +34,7 @@ public class ZipFileReader implements PartitionReader<InternalRow> {
     private String currentFilePath;
     private ZipInputStream currentZipInputStream;
     private ZipEntry currentZipEntry;
+    private int zipEntryCount = 0;
 
     ZipFileReader(FilePartition filePartition, FileContext fileContext) {
         this(filePartition, fileContext, fileContext.isStreamingFiles() ? StreamingMode.STREAM_DURING_READER_PHASE : null);
@@ -59,6 +61,14 @@ public class ZipFileReader implements PartitionReader<InternalRow> {
         }
 
         if (currentZipEntry != null) {
+            zipEntryCount++;
+            int maxEntryCount = fileContext.getZipMaxEntryCount();
+            if (maxEntryCount >= 0 && zipEntryCount > maxEntryCount) {
+                throw new ConnectorException(String.format(
+                    "Zip archive entry count exceeds the maximum of %d entries. " +
+                        "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                    maxEntryCount, Options.READ_ZIP_MAX_ENTRY_COUNT));
+            }
             return true;
         }
         close();
@@ -125,6 +135,7 @@ public class ZipFileReader implements PartitionReader<InternalRow> {
         this.currentFilePath = filePartition.getPaths().get(nextFilePathIndex);
         nextFilePathIndex++;
         this.currentZipInputStream = new ZipInputStream(fileContext.openFile(this.currentFilePath));
+        this.zipEntryCount = 0;
     }
 
     private byte[] readZipEntry() {

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/ZipFileReader.java
@@ -66,7 +66,7 @@ public class ZipFileReader implements PartitionReader<InternalRow> {
             if (maxEntryCount > 0 && zipEntryCount > maxEntryCount) {
                 throw new ConnectorException(String.format(
                     "Zip archive entry count exceeds the maximum of %d entries. " +
-                        "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                        "Use connector option '%s' to increase the limit. Set to 0 or less to disable.",
                     maxEntryCount, Options.READ_ZIP_MAX_ENTRY_COUNT));
             }
             return true;

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/xml/ZipAggregateXmlFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/xml/ZipAggregateXmlFileReader.java
@@ -122,7 +122,7 @@ public class ZipAggregateXmlFileReader implements PartitionReader<InternalRow> {
 
             zipEntryCount++;
             int maxEntryCount = fileContext.getZipMaxEntryCount();
-            if (maxEntryCount >= 0 && zipEntryCount > maxEntryCount) {
+            if (maxEntryCount > 0 && zipEntryCount > maxEntryCount) {
                 throw new ConnectorException(String.format(
                     "Zip archive entry count exceeds the maximum of %d entries. " +
                         "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/xml/ZipAggregateXmlFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/xml/ZipAggregateXmlFileReader.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.spark.reader.file.xml;
 
 import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Options;
 import com.marklogic.spark.Util;
 import com.marklogic.spark.reader.file.FileContext;
 import com.marklogic.spark.reader.file.FilePartition;
@@ -15,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -28,6 +30,9 @@ public class ZipAggregateXmlFileReader implements PartitionReader<InternalRow> {
 
     // Used solely for a default URI prefix.
     private int entryCounter;
+
+    // Tracks total entries iterated for zip bomb protection (READ_ZIP_MAX_ENTRY_COUNT).
+    private int zipEntryCount = 0;
 
     private InternalRow rowToReturn;
 
@@ -86,6 +91,7 @@ public class ZipAggregateXmlFileReader implements PartitionReader<InternalRow> {
         this.currentFilePath = filePartition.getPaths().get(nextFilePathIndex);
         nextFilePathIndex++;
         this.currentZipInputStream = new ZipInputStream(fileContext.openFile(this.currentFilePath));
+        this.zipEntryCount = 0;
     }
 
     /**
@@ -113,14 +119,26 @@ public class ZipAggregateXmlFileReader implements PartitionReader<InternalRow> {
             if (zipEntry == null) {
                 return false;
             }
+
+            zipEntryCount++;
+            int maxEntryCount = fileContext.getZipMaxEntryCount();
+            if (maxEntryCount >= 0 && zipEntryCount > maxEntryCount) {
+                throw new ConnectorException(String.format(
+                    "Zip archive entry count exceeds the maximum of %d entries. " +
+                        "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                    maxEntryCount, Options.READ_ZIP_MAX_ENTRY_COUNT));
+            }
+
             if (logger.isTraceEnabled()) {
                 logger.trace("Reading entry {} in {}", zipEntry.getName(), this.currentFilePath);
             }
             entryCounter++;
             String identifierForError = "entry " + zipEntry.getName() + " in " + this.currentFilePath;
 
+            InputStream entryStream = fileContext.boundedZipEntryStream(this.currentZipInputStream);
+
             try {
-                aggregateXMLSplitter = new AggregateXmlSplitter(identifierForError, this.currentZipInputStream, this.fileContext);
+                aggregateXMLSplitter = new AggregateXmlSplitter(identifierForError, entryStream, this.fileContext);
                 // Fail fast if the next entry is not valid XML.
                 aggregateXMLSplitter.hasNext();
                 return true;

--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/xml/ZipAggregateXmlFileReader.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/reader/file/xml/ZipAggregateXmlFileReader.java
@@ -125,7 +125,7 @@ public class ZipAggregateXmlFileReader implements PartitionReader<InternalRow> {
             if (maxEntryCount > 0 && zipEntryCount > maxEntryCount) {
                 throw new ConnectorException(String.format(
                     "Zip archive entry count exceeds the maximum of %d entries. " +
-                        "Use connector option '%s' to increase or disable this limit (set to -1 to disable).",
+                        "Use connector option '%s' to increase the limit. Set to 0 or less to disable.",
                     maxEntryCount, Options.READ_ZIP_MAX_ENTRY_COUNT));
             }
 

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/file/ReadZipBombProtectionTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/file/ReadZipBombProtectionTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Verifies that the zip bomb protection limits — READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES and
  * READ_ZIP_MAX_ENTRY_COUNT — are enforced across all zip-reading code paths when explicitly enabled.
- * Both limits default to -1 (disabled) and are opt-in.
+ * Both limits default to 0 (disabled) and are opt-in.
  *
  * <p>Test zip files used:
  * <ul>
@@ -79,7 +79,7 @@ class ReadZipBombProtectionTest extends AbstractIntegrationTest {
 
     @Test
     void genericZip_defaultBehaviorAllowsUnlimitedRead() {
-        // Both limits default to -1 (disabled), so all entries must be read without any configuration.
+        // Both limits default to 0 (disabled), so all entries must be read without any configuration.
         List<?> rows = newSparkSession().read()
             .format(CONNECTOR_IDENTIFIER)
             .option(Options.READ_FILES_COMPRESSION, "zip")

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/file/ReadZipBombProtectionTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/file/ReadZipBombProtectionTest.java
@@ -200,4 +200,40 @@ class ReadZipBombProtectionTest extends AbstractIntegrationTest {
             .collectAsList();
         assertEquals(4, rows.size(), "Any negative value should disable the limit: all 4 entries should be read.");
     }
+
+    // -----------------------------------------------------------------------
+    // Invalid (non-numeric) option values
+    // -----------------------------------------------------------------------
+
+    @Test
+    void invalidByteLimitStringThrowsConnectorException() {
+        ConnectorException ex = assertThrowsConnectorException(() ->
+            newSparkSession().read()
+                .format(CONNECTOR_IDENTIFIER)
+                .option(Options.READ_FILES_COMPRESSION, "zip")
+                .option(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, "not-a-number")
+                .load("src/test/resources/zip-files/mixed-files.zip")
+                .collectAsList()
+        );
+        assertTrue(ex.getMessage().contains("Invalid value for"),
+            "Expected invalid-value message, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES),
+            "Error message should include the option name; got: " + ex.getMessage());
+    }
+
+    @Test
+    void invalidEntryCountStringThrowsConnectorException() {
+        ConnectorException ex = assertThrowsConnectorException(() ->
+            newSparkSession().read()
+                .format(CONNECTOR_IDENTIFIER)
+                .option(Options.READ_FILES_COMPRESSION, "zip")
+                .option(Options.READ_ZIP_MAX_ENTRY_COUNT, "not-a-number")
+                .load("src/test/resources/zip-files/mixed-files.zip")
+                .collectAsList()
+        );
+        assertTrue(ex.getMessage().contains("Invalid value for"),
+            "Expected invalid-value message, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(Options.READ_ZIP_MAX_ENTRY_COUNT),
+            "Error message should include the option name; got: " + ex.getMessage());
+    }
 }

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/file/ReadZipBombProtectionTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/file/ReadZipBombProtectionTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.spark.reader.file;
+
+import com.marklogic.spark.AbstractIntegrationTest;
+import com.marklogic.spark.ConnectorException;
+import com.marklogic.spark.Options;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that the zip bomb protection limits — READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES and
+ * READ_ZIP_MAX_ENTRY_COUNT — are enforced across all zip-reading code paths.
+ *
+ * <p>Test zip files used:
+ * <ul>
+ *   <li>{@code zip-files/mixed-files.zip} — 4 entries (hello.json=23B, hello.txt=12B, hello.xml=21B, hello2.txt.gz=43B)
+ *   <li>{@code aggregate-zips/employee-aggregates.zip} — 2 XML aggregate entries (412B and 222B uncompressed)
+ *   <li>{@code rdf/each-rdf-file-type.zip} — 7 RDF entries (smallest: semantics.nq=759B)
+ * </ul>
+ */
+class ReadZipBombProtectionTest extends AbstractIntegrationTest {
+
+    // -----------------------------------------------------------------------
+    // Generic zip (ZipFileReader path)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void genericZip_byteLimitThrowsConnectorException() {
+        // hello.json is 23 bytes uncompressed; a limit of 10 must trigger an error.
+        ConnectorException ex = assertThrowsConnectorException(() ->
+            newSparkSession().read()
+                .format(CONNECTOR_IDENTIFIER)
+                .option(Options.READ_FILES_COMPRESSION, "zip")
+                .option(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, "10")
+                .load("src/test/resources/zip-files/mixed-files.zip")
+                .collectAsList()
+        );
+        assertTrue(ex.getMessage().contains("Zip entry uncompressed size exceeds"),
+            "Expected byte-limit message, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES),
+            "Error message should include the option name so the user knows how to fix it.");
+    }
+
+    @Test
+    void genericZip_entryCountLimitThrowsConnectorException() {
+        // mixed-files.zip has 4 entries; a limit of 2 must trigger an error on the 3rd entry.
+        ConnectorException ex = assertThrowsConnectorException(() ->
+            newSparkSession().read()
+                .format(CONNECTOR_IDENTIFIER)
+                .option(Options.READ_FILES_COMPRESSION, "zip")
+                .option(Options.READ_ZIP_MAX_ENTRY_COUNT, "2")
+                .load("src/test/resources/zip-files/mixed-files.zip")
+                .collectAsList()
+        );
+        assertTrue(ex.getMessage().contains("Zip archive entry count exceeds"),
+            "Expected entry-count message, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(Options.READ_ZIP_MAX_ENTRY_COUNT),
+            "Error message should include the option name so the user knows how to fix it.");
+    }
+
+    @Test
+    void genericZip_generousLimitAllowsNormalRead() {
+        // A generous byte limit should not prevent normal operation.
+        List<?> rows = newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.READ_FILES_COMPRESSION, "zip")
+            .option(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, "1048576") // 1 MB
+            .option(Options.READ_ZIP_MAX_ENTRY_COUNT, "1000")
+            .load("src/test/resources/zip-files/mixed-files.zip")
+            .collectAsList();
+        assertEquals(4, rows.size(), "All 4 entries should be read successfully within the generous limits.");
+    }
+
+    @Test
+    void genericZip_disablingLimitsWithNegativeOne() {
+        // Both limits disabled via -1; all entries must be read.
+        List<?> rows = newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.READ_FILES_COMPRESSION, "zip")
+            .option(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, "-1")
+            .option(Options.READ_ZIP_MAX_ENTRY_COUNT, "-1")
+            .load("src/test/resources/zip-files/mixed-files.zip")
+            .collectAsList();
+        assertEquals(4, rows.size(), "Limits disabled with -1: all 4 entries should be read.");
+    }
+
+    // -----------------------------------------------------------------------
+    // Aggregate XML zip (ZipAggregateXmlFileReader path — internal bypass check)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void xmlZip_byteLimitThrowsConnectorException() {
+        // employee-aggregates.zip first entry is 412 bytes; a limit of 100 must trigger an error.
+        // This verifies the MaxBytesInputStream wrapping on the XML parser path (CWE-409 gap).
+        ConnectorException ex = assertThrowsConnectorException(() ->
+            newSparkSession().read()
+                .format(CONNECTOR_IDENTIFIER)
+                .option(Options.READ_FILES_COMPRESSION, "zip")
+                .option(Options.READ_AGGREGATES_XML_ELEMENT, "employee")
+                .option(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, "100")
+                .load("src/test/resources/aggregate-zips/employee-aggregates.zip")
+                .collectAsList()
+        );
+        // The ConnectorException here may be the "Unable to process zip file" wrapper; the limit message
+        // is in the cause. Accept either form.
+        String combinedMessage = ex.getMessage()
+            + (ex.getCause() != null ? " " + ex.getCause().getMessage() : "");
+        assertTrue(
+            combinedMessage.contains("Zip entry uncompressed size exceeds")
+                || combinedMessage.contains("Zip archive entry count exceeds"),
+            "Expected a zip protection error, got: " + combinedMessage);
+    }
+
+    @Test
+    void xmlZip_entryCountLimitThrowsConnectorException() {
+        // employee-aggregates.zip has 2 entries; a limit of 1 must trigger an error on the 2nd.
+        ConnectorException ex = assertThrowsConnectorException(() ->
+            newSparkSession().read()
+                .format(CONNECTOR_IDENTIFIER)
+                .option(Options.READ_FILES_COMPRESSION, "zip")
+                .option(Options.READ_AGGREGATES_XML_ELEMENT, "employee")
+                .option(Options.READ_ZIP_MAX_ENTRY_COUNT, "1")
+                .load("src/test/resources/aggregate-zips/employee-aggregates.zip")
+                .collectAsList()
+        );
+        assertTrue(ex.getMessage().contains("Zip archive entry count exceeds"),
+            "Expected entry-count message, got: " + ex.getMessage());
+    }
+
+    // -----------------------------------------------------------------------
+    // RDF zip (RdfZipFileReader path — internal bypass check)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void rdfZip_byteLimitThrowsConnectorException() {
+        // each-rdf-file-type.zip first entry (englishlocale.ttl) is 1309 bytes; limit of 500 must trigger.
+        // This verifies the MaxBytesInputStream wrapping on the RDF parser path.
+        ConnectorException ex = assertThrowsConnectorException(() ->
+            newSparkSession().read()
+                .format(CONNECTOR_IDENTIFIER)
+                .option(Options.READ_FILES_COMPRESSION, "zip")
+                .option(Options.READ_FILES_TYPE, "rdf")
+                .option(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, "500")
+                .load("src/test/resources/rdf/each-rdf-file-type.zip")
+                .collectAsList()
+        );
+        // RdfZipFileReader re-throws ConnectorException directly without wrapping it in a second
+        // ConnectorException, so the limit message is on ex.getMessage() itself.
+        assertTrue(ex.getMessage().contains("Zip entry uncompressed size exceeds"),
+            "Expected byte-limit message, got: " + ex.getMessage());
+    }
+
+    @Test
+    void rdfZip_entryCountLimitThrowsConnectorException() {
+        // each-rdf-file-type.zip has 7 entries; a limit of 3 must trigger an error on the 4th.
+        ConnectorException ex = assertThrowsConnectorException(() ->
+            newSparkSession().read()
+                .format(CONNECTOR_IDENTIFIER)
+                .option(Options.READ_FILES_COMPRESSION, "zip")
+                .option(Options.READ_FILES_TYPE, "rdf")
+                .option(Options.READ_ZIP_MAX_ENTRY_COUNT, "3")
+                .load("src/test/resources/rdf/each-rdf-file-type.zip")
+                .collectAsList()
+        );
+        // RdfZipFileReader re-throws ConnectorException directly without wrapping it in a second
+        // ConnectorException.
+        assertTrue(ex.getMessage().contains("Zip archive entry count exceeds"),
+            "Expected entry-count message, got: " + ex.getMessage());
+    }
+}

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/file/ReadZipBombProtectionTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/file/ReadZipBombProtectionTest.java
@@ -172,70 +172,32 @@ class ReadZipBombProtectionTest extends AbstractIntegrationTest {
     }
 
     // -----------------------------------------------------------------------
-    // Input validation — invalid option values
+    // Zero and negative values are treated as "disabled" (same as default)
     // -----------------------------------------------------------------------
 
     @Test
-    void invalidByteLimitZero_throwsConnectorException() {
-        ConnectorException ex = assertThrowsConnectorException(() ->
-            newSparkSession().read()
-                .format(CONNECTOR_IDENTIFIER)
-                .option(Options.READ_FILES_COMPRESSION, "zip")
-                .option(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, "0")
-                .load("src/test/resources/zip-files/mixed-files.zip")
-                .collectAsList()
-        );
-        assertTrue(ex.getMessage().contains("Invalid value '0'"),
-            "Expected invalid-value message for 0, got: " + ex.getMessage());
-        assertTrue(ex.getMessage().contains(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES),
-            "Error message should include the option name.");
+    void genericZip_zeroValueTreatedAsDisabled() {
+        // 0 is semantically equivalent to the default (disabled). All 4 entries must be read.
+        List<?> rows = newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.READ_FILES_COMPRESSION, "zip")
+            .option(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, "0")
+            .option(Options.READ_ZIP_MAX_ENTRY_COUNT, "0")
+            .load("src/test/resources/zip-files/mixed-files.zip")
+            .collectAsList();
+        assertEquals(4, rows.size(), "A value of 0 should disable the limit: all 4 entries should be read.");
     }
 
     @Test
-    void invalidByteLimitNegative_throwsConnectorException() {
-        ConnectorException ex = assertThrowsConnectorException(() ->
-            newSparkSession().read()
-                .format(CONNECTOR_IDENTIFIER)
-                .option(Options.READ_FILES_COMPRESSION, "zip")
-                .option(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, "-5")
-                .load("src/test/resources/zip-files/mixed-files.zip")
-                .collectAsList()
-        );
-        assertTrue(ex.getMessage().contains("Invalid value '-5'"),
-            "Expected invalid-value message for -5, got: " + ex.getMessage());
-        assertTrue(ex.getMessage().contains(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES),
-            "Error message should include the option name.");
-    }
-
-    @Test
-    void invalidEntryCountZero_throwsConnectorException() {
-        ConnectorException ex = assertThrowsConnectorException(() ->
-            newSparkSession().read()
-                .format(CONNECTOR_IDENTIFIER)
-                .option(Options.READ_FILES_COMPRESSION, "zip")
-                .option(Options.READ_ZIP_MAX_ENTRY_COUNT, "0")
-                .load("src/test/resources/zip-files/mixed-files.zip")
-                .collectAsList()
-        );
-        assertTrue(ex.getMessage().contains("Invalid value '0'"),
-            "Expected invalid-value message for 0, got: " + ex.getMessage());
-        assertTrue(ex.getMessage().contains(Options.READ_ZIP_MAX_ENTRY_COUNT),
-            "Error message should include the option name.");
-    }
-
-    @Test
-    void invalidEntryCountNegative_throwsConnectorException() {
-        ConnectorException ex = assertThrowsConnectorException(() ->
-            newSparkSession().read()
-                .format(CONNECTOR_IDENTIFIER)
-                .option(Options.READ_FILES_COMPRESSION, "zip")
-                .option(Options.READ_ZIP_MAX_ENTRY_COUNT, "-5")
-                .load("src/test/resources/zip-files/mixed-files.zip")
-                .collectAsList()
-        );
-        assertTrue(ex.getMessage().contains("Invalid value '-5'"),
-            "Expected invalid-value message for -5, got: " + ex.getMessage());
-        assertTrue(ex.getMessage().contains(Options.READ_ZIP_MAX_ENTRY_COUNT),
-            "Error message should include the option name.");
+    void genericZip_negativeValueTreatedAsDisabled() {
+        // Any value < 1 (including -1 and -5) disables the limit. All 4 entries must be read.
+        List<?> rows = newSparkSession().read()
+            .format(CONNECTOR_IDENTIFIER)
+            .option(Options.READ_FILES_COMPRESSION, "zip")
+            .option(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, "-1")
+            .option(Options.READ_ZIP_MAX_ENTRY_COUNT, "-5")
+            .load("src/test/resources/zip-files/mixed-files.zip")
+            .collectAsList();
+        assertEquals(4, rows.size(), "Any negative value should disable the limit: all 4 entries should be read.");
     }
 }

--- a/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/file/ReadZipBombProtectionTest.java
+++ b/marklogic-spark-connector/src/test/java/com/marklogic/spark/reader/file/ReadZipBombProtectionTest.java
@@ -14,7 +14,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Verifies that the zip bomb protection limits — READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES and
- * READ_ZIP_MAX_ENTRY_COUNT — are enforced across all zip-reading code paths.
+ * READ_ZIP_MAX_ENTRY_COUNT — are enforced across all zip-reading code paths when explicitly enabled.
+ * Both limits default to -1 (disabled) and are opt-in.
  *
  * <p>Test zip files used:
  * <ul>
@@ -77,16 +78,14 @@ class ReadZipBombProtectionTest extends AbstractIntegrationTest {
     }
 
     @Test
-    void genericZip_disablingLimitsWithNegativeOne() {
-        // Both limits disabled via -1; all entries must be read.
+    void genericZip_defaultBehaviorAllowsUnlimitedRead() {
+        // Both limits default to -1 (disabled), so all entries must be read without any configuration.
         List<?> rows = newSparkSession().read()
             .format(CONNECTOR_IDENTIFIER)
             .option(Options.READ_FILES_COMPRESSION, "zip")
-            .option(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, "-1")
-            .option(Options.READ_ZIP_MAX_ENTRY_COUNT, "-1")
             .load("src/test/resources/zip-files/mixed-files.zip")
             .collectAsList();
-        assertEquals(4, rows.size(), "Limits disabled with -1: all 4 entries should be read.");
+        assertEquals(4, rows.size(), "Default behavior (limits disabled) should read all 4 entries.");
     }
 
     // -----------------------------------------------------------------------
@@ -107,13 +106,12 @@ class ReadZipBombProtectionTest extends AbstractIntegrationTest {
                 .collectAsList()
         );
         // The ConnectorException here may be the "Unable to process zip file" wrapper; the limit message
-        // is in the cause. Accept either form.
+        // is in the cause. Accept either form, but only the byte-limit message — accepting the entry-count
+        // message here would mask a regression where the byte-limit path is not actually exercised.
         String combinedMessage = ex.getMessage()
             + (ex.getCause() != null ? " " + ex.getCause().getMessage() : "");
-        assertTrue(
-            combinedMessage.contains("Zip entry uncompressed size exceeds")
-                || combinedMessage.contains("Zip archive entry count exceeds"),
-            "Expected a zip protection error, got: " + combinedMessage);
+        assertTrue(combinedMessage.contains("Zip entry uncompressed size exceeds"),
+            "Expected byte-limit message, got: " + combinedMessage);
     }
 
     @Test
@@ -171,5 +169,73 @@ class ReadZipBombProtectionTest extends AbstractIntegrationTest {
         // ConnectorException.
         assertTrue(ex.getMessage().contains("Zip archive entry count exceeds"),
             "Expected entry-count message, got: " + ex.getMessage());
+    }
+
+    // -----------------------------------------------------------------------
+    // Input validation — invalid option values
+    // -----------------------------------------------------------------------
+
+    @Test
+    void invalidByteLimitZero_throwsConnectorException() {
+        ConnectorException ex = assertThrowsConnectorException(() ->
+            newSparkSession().read()
+                .format(CONNECTOR_IDENTIFIER)
+                .option(Options.READ_FILES_COMPRESSION, "zip")
+                .option(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, "0")
+                .load("src/test/resources/zip-files/mixed-files.zip")
+                .collectAsList()
+        );
+        assertTrue(ex.getMessage().contains("Invalid value '0'"),
+            "Expected invalid-value message for 0, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES),
+            "Error message should include the option name.");
+    }
+
+    @Test
+    void invalidByteLimitNegative_throwsConnectorException() {
+        ConnectorException ex = assertThrowsConnectorException(() ->
+            newSparkSession().read()
+                .format(CONNECTOR_IDENTIFIER)
+                .option(Options.READ_FILES_COMPRESSION, "zip")
+                .option(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES, "-5")
+                .load("src/test/resources/zip-files/mixed-files.zip")
+                .collectAsList()
+        );
+        assertTrue(ex.getMessage().contains("Invalid value '-5'"),
+            "Expected invalid-value message for -5, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(Options.READ_ZIP_MAX_UNCOMPRESSED_ENTRY_BYTES),
+            "Error message should include the option name.");
+    }
+
+    @Test
+    void invalidEntryCountZero_throwsConnectorException() {
+        ConnectorException ex = assertThrowsConnectorException(() ->
+            newSparkSession().read()
+                .format(CONNECTOR_IDENTIFIER)
+                .option(Options.READ_FILES_COMPRESSION, "zip")
+                .option(Options.READ_ZIP_MAX_ENTRY_COUNT, "0")
+                .load("src/test/resources/zip-files/mixed-files.zip")
+                .collectAsList()
+        );
+        assertTrue(ex.getMessage().contains("Invalid value '0'"),
+            "Expected invalid-value message for 0, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(Options.READ_ZIP_MAX_ENTRY_COUNT),
+            "Error message should include the option name.");
+    }
+
+    @Test
+    void invalidEntryCountNegative_throwsConnectorException() {
+        ConnectorException ex = assertThrowsConnectorException(() ->
+            newSparkSession().read()
+                .format(CONNECTOR_IDENTIFIER)
+                .option(Options.READ_FILES_COMPRESSION, "zip")
+                .option(Options.READ_ZIP_MAX_ENTRY_COUNT, "-5")
+                .load("src/test/resources/zip-files/mixed-files.zip")
+                .collectAsList()
+        );
+        assertTrue(ex.getMessage().contains("Invalid value '-5'"),
+            "Expected invalid-value message for -5, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(Options.READ_ZIP_MAX_ENTRY_COUNT),
+            "Error message should include the option name.");
     }
 }


### PR DESCRIPTION

**Description:**

Addresses CWE-409 (FIND-008) from the Spark MarkLogic Connector security findings report. CVSS score: 7.5 High.

Prior to this change, no compensating controls existed for zip bomb attacks across any of the five zip-reading paths. The existing `@SuppressWarnings("java:S5042")` on `FileUtil.findNextFileEntry()` was also misplaced — that method only advances the entry iterator and never reads bytes, so the suppression had no protective effect.

Two new configurable options are added. Both default to `0` (disabled) to avoid a breaking change in this patch release — protection is opt-in:

| Option | Default | Recommended value |
|---|---|---|
| `spark.marklogic.read.zip.maxUncompressedEntryBytes` | `0` (disabled) | `268435456` (256 MB) |
| `spark.marklogic.read.zip.maxEntryCount` | `0` (disabled) | `100000` |

Any value less than `1` (including `0` and negatives) disables the limit. Set to a positive integer to enable protection. Both limits apply per archive and reset when moving to the next file in a partition.

The byte limit is enforced in `FileUtil.readBytes()` for the direct-read paths (`ZipFileReader`, `ArchiveFileReader`, `MlcpArchiveFileReader`) and via a new `MaxBytesInputStream` wrapper for the XML and RDF parser paths (`ZipAggregateXmlFileReader`, `RdfZipFileReader`), which previously consumed bytes without going through `readBytes()` at all. The entry count limit is tracked independently in each reader. `@SuppressWarnings("java:S5042")` is removed and replaced with a comment describing the two compensating controls now in place.

Streaming paths (`ZipFileIterator`, `ArchiveFileIterator`) are not covered — in streaming mode bytes flow directly to MarkLogic over the network without being buffered on the executor heap.

---

**Running the new tests**

These are integration tests requiring a running MarkLogic instance:

```bash
# Start the environment if not already running
docker compose up -d
./gradlew -i mlWaitTillReady mlDeploy

# Run only the new tests (10 total)
./gradlew :marklogic-spark-connector:test \
  --tests "com.marklogic.spark.reader.file.ReadZipBombProtectionTest"

# Run the full set of zip-related tests to confirm no regressions
./gradlew :marklogic-spark-connector:test \
  --tests "com.marklogic.spark.reader.file.ReadZipBombProtectionTest" \
  --tests "com.marklogic.spark.reader.file.ReadZipFilesTest" \
  --tests "com.marklogic.spark.reader.file.ReadAggregateXmlZipFilesTest" \
  --tests "com.marklogic.spark.reader.file.ReadRdfZipFilesTest" \
  --tests "com.marklogic.spark.reader.file.ReadMlcpArchiveFilesTest"
```

> **Note:** `ReadMlcpArchiveFilesTest.mlcpArchivesContainingAllFourTypesOfDocuments` fails on Windows due to a pre-existing Hadoop native I/O issue unrelated to this change.

---

Linked ticket: [MLE-31218](https://progresssoftware.atlassian.net/browse/MLE-31218)


[MLE-31218]: https://progresssoftware.atlassian.net/browse/MLE-31218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ