### PR TITLE
MLE-31212 add security notes to online documents

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,9 +130,9 @@ The following options control how the connector reads rows from MarkLogic via cu
 | --- | --- |
 | spark.marklogic.read.invoke | The path to a module to invoke; the module must be in your application's modules database. |
 | spark.marklogic.read.javascript | JavaScript code to execute. |
-| spark.marklogic.read.javascriptFile | Local file path containing JavaScript code to execute. |
+| spark.marklogic.read.javascriptFile | Local file path containing JavaScript code to execute; the file is read from the Spark executor's local filesystem and access is governed by OS-level file permissions. |
 | spark.marklogic.read.xquery | XQuery code to execute. |
-| spark.marklogic.read.xqueryFile | Local file path containing XQuery code to execute. |
+| spark.marklogic.read.xqueryFile | Local file path containing XQuery code to execute; the file is read from the Spark executor's local filesystem and access is governed by OS-level file permissions. |
 | spark.marklogic.read.vars. | Prefix for user-defined variables to be sent to the custom code. |
 
 If you are using Spark's streaming support with custom code, or you need to break up your custom code query into 
@@ -142,9 +142,9 @@ multiple queries, the following options can also be used to control how partitio
 | --- | --- |
 | spark.marklogic.read.partitions.invoke | The path to a module to invoke; the module must be in your application's modules database. |
 | spark.marklogic.read.partitions.javascript | JavaScript code to execute. |
-| spark.marklogic.read.partitions.javascriptFile | Local file path containing JavaScript code to execute. |
+| spark.marklogic.read.partitions.javascriptFile | Local file path containing JavaScript code to execute; the file is read from the Spark executor's local filesystem and access is governed by OS-level file permissions. |
 | spark.marklogic.read.partitions.xquery | XQuery code to execute. |
-| spark.marklogic.read.partitions.xqueryFile | Local file path containing XQuery code to execute. |
+| spark.marklogic.read.partitions.xqueryFile | Local file path containing XQuery code to execute; the file is read from the Spark executor's local filesystem and access is governed by OS-level file permissions. |
 | spark.marklogic.read.partitions.vars. | Prefix for user-defined variables to be sent to the partition code. |
 
 ### Read options for documents
@@ -219,9 +219,9 @@ The following options control how rows can be processed with custom code in Mark
 | spark.marklogic.write.batchSize | The number of rows sent in a call to MarkLogic; defaults to 1. |
 | spark.marklogic.write.invoke | The path to a module to invoke; the module must be in your application's modules database. |
 | spark.marklogic.write.javascript | JavaScript code to execute. |
-| spark.marklogic.write.javascriptFile | Local file path containing JavaScript code to execute. |
+| spark.marklogic.write.javascriptFile | Local file path containing JavaScript code to execute; the file is read from the Spark executor's local filesystem and access is governed by OS-level file permissions. |
 | spark.marklogic.write.xquery | XQuery code to execute. |
-| spark.marklogic.write.xqueryFile | Local file path containing XQuery code to execute. |
+| spark.marklogic.write.xqueryFile | Local file path containing XQuery code to execute; the file is read from the Spark executor's local filesystem and access is governed by OS-level file permissions. |
 | spark.marklogic.write.externalVariableName | Name of the external variable in custom code that is populated with row values; defaults to `URI`. |
 | spark.marklogic.write.externalVariableDelimiter | Delimiter used when multiple row values are sent in a single call; defaults to a comma. |
 | spark.marklogic.write.vars. | Prefix for user-defined variables to be sent to the custom code. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -142,9 +142,9 @@ multiple queries, the following options can also be used to control how partitio
 | --- | --- |
 | spark.marklogic.read.partitions.invoke | The path to a module to invoke; the module must be in your application's modules database. |
 | spark.marklogic.read.partitions.javascript | JavaScript code to execute. |
-| spark.marklogic.read.partitions.javascriptFile | Local file path containing JavaScript code to execute; the file is read from the Spark executor's local filesystem and access is governed by OS-level file permissions. |
+| spark.marklogic.read.partitions.javascriptFile | Local file path containing JavaScript code to execute; the file is read from the Spark driver's local filesystem and access is governed by OS-level file permissions. |
 | spark.marklogic.read.partitions.xquery | XQuery code to execute. |
-| spark.marklogic.read.partitions.xqueryFile | Local file path containing XQuery code to execute; the file is read from the Spark executor's local filesystem and access is governed by OS-level file permissions. |
+| spark.marklogic.read.partitions.xqueryFile | Local file path containing XQuery code to execute; the file is read from the Spark driver's local filesystem and access is governed by OS-level file permissions. |
 | spark.marklogic.read.partitions.vars. | Prefix for user-defined variables to be sent to the partition code. |
 
 ### Read options for documents

--- a/docs/reading-data/custom-code.md
+++ b/docs/reading-data/custom-code.md
@@ -61,6 +61,10 @@ must be a file path that can be resolved by the Spark environment running the co
 into your application's modules database. Its content will be read in and then evaluated in the same fashion as
 when specifying code via `spark.marklogic.read.javascript` or `spark.marklogic.read.xquery`.
 
+**Security note:** These options read files from the local filesystem of the Spark executor process. The connector
+does not restrict which paths may be specified. Access to files on the executor host is determined by the OS-level
+file permissions of the user running the Spark executor; ensure appropriate permissions are in place on the executor host.
+
 
 ## Custom code schemas
 
@@ -115,6 +119,9 @@ your query into many smaller queries, you can use one of the following options t
 - `spark.marklogic.read.partitions.xquery`
 - `spark.marklogic.read.partitions.xqueryFile` (New in 2.3.0)
 - `spark.marklogic.read.partitions.vars.` (New in 3.0.0)
+
+**Security note:** The `*File` options above read files from the local filesystem of the Spark executor process. Access
+to files on the executor host is determined by the OS-level file permissions of the user running the Spark executor.
 
 If one of the above options is defined, the connector will execute the code associated with the option and expect a
 sequence of values to be returned. You can return any values you want to define partitions; the connector does not care

--- a/docs/reading-data/custom-code.md
+++ b/docs/reading-data/custom-code.md
@@ -120,8 +120,8 @@ your query into many smaller queries, you can use one of the following options t
 - `spark.marklogic.read.partitions.xqueryFile` (New in 2.3.0)
 - `spark.marklogic.read.partitions.vars.` (New in 3.0.0)
 
-**Security note:** The `*File` options above read files from the local filesystem of the Spark executor process. Access
-to files on the executor host is determined by the OS-level file permissions of the user running the Spark executor.
+**Security note:** The `*File` options above read files from the local filesystem of the Spark driver process. Access
+to files on the driver host is determined by the OS-level file permissions of the user running the Spark driver.
 
 If one of the above options is defined, the connector will execute the code associated with the option and expect a
 sequence of values to be returned. You can return any values you want to define partitions; the connector does not care

--- a/docs/reading-data/documents.md
+++ b/docs/reading-data/documents.md
@@ -295,6 +295,10 @@ You can specify local file paths containing either JavaScript or XQuery code via
 .option("spark.marklogic.read.secondaryUris.javascriptFile", "/path/to/findRelatedAuthors.js") \
 ```
 
+**Security note:** These options read files from the local filesystem of the Spark executor process. The connector
+does not restrict which paths may be specified. Access to files on the executor host is determined by the OS-level
+file permissions of the user running the Spark executor; ensure appropriate permissions are in place on the executor host.
+
 ### Custom external variables
 
 You can pass external variables to your secondary query code by configuring options with names starting with `spark.marklogic.read.secondaryUris.vars.`. The remainder of the option name will be used as the external variable name:

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -414,6 +414,10 @@ must be a file path that can be resolved by the Spark environment running the co
 into your application's modules database. Its content will be read in and then evaluated in the same fashion as
 when specifying code via `spark.marklogic.write.javascript` or `spark.marklogic.write.xquery`.
 
+**Security note:** These options read files from the local filesystem of the Spark executor process. The connector
+does not restrict which paths may be specified. Access to files on the executor host is determined by the OS-level
+file permissions of the user running the Spark executor; ensure appropriate permissions are in place on the executor host.
+
 ### Processing multiple rows in a single call
 
 By default, a single row is sent by the connector to your custom code. In many use cases, particularly when writing


### PR DESCRIPTION
Added security notes directing users to rely on OS-level file permissions for access control.