### PR TITLE
MLE-31220 temporarily remove SonarQube scan

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,16 +27,6 @@ def runtests(){
   junit '**/build/**/*.xml'
 }
 
-def runSonarScan(){
-    sh label:'run-sonar', script: '''#!/bin/bash
-      export JAVA_HOME=$JAVA17_HOME_DIR
-      export GRADLE_USER_HOME=$WORKSPACE/$GRADLE_DIR
-      export PATH=$GRADLE_USER_HOME:$JAVA_HOME/bin:$PATH
-      cd marklogic-spark-connector
-     ./gradlew sonar -Dsonar.projectKey='marklogic_marklogic-spark-connector_AY1bXn6J_50_odbCDKMX' -Dsonar.projectName='ML-DevExp-marklogic-spark-connector' || true
-    '''
-}
-
 def tearDownDocker() {
   updateWorkspacePermissions()
   sh label:'mlcleanup', script: '''#!/bin/bash
@@ -71,9 +61,6 @@ pipeline{
   stages{
 
     stage('tests'){
-      environment{
-        scannerHome = tool 'SONAR_Progress'
-      }
       agent {label 'devExpLinuxPool'}
       steps{
         cleanupDocker()
@@ -86,9 +73,6 @@ pipeline{
             MARKLOGIC_LOGS_VOLUME=/tmp docker-compose up -d --build
           '''
         runtests()
-        withSonarQubeEnv('SONAR_Progress') {
-          runSonarScan()
-        }
       }
       post{
         always{


### PR DESCRIPTION

Temporarily removed the SonarQube scan step from the Jenkins CI pipeline after a persistent HTTP 401 authentication failure against sonar.progress.com.

**Notes: We will target a new Epic to integrate SonarQube static analysis into the Jenkins CI pipeline for every DevEx product following a single, shared pattern across repos. SonarQube project configuration (project key, name, exclusions, coverage paths) will live in a sonar-project.properties file at each repo root — not hardcoded in Jenkinsfiles or build scripts.**