### PR TITLE
MLE-31685: [MEDIUM] BDSA-2026-24084 in lz4java v1.11.0 (MarkLogic-DevExp-spark-connector)

### DIFF
--- a/marklogic-spark-connector/build.gradle
+++ b/marklogic-spark-connector/build.gradle
@@ -15,6 +15,9 @@ configurations {
 
       // Compile-only dependency, resolves CVE in 2.24.3
       force "org.apache.logging.log4j:log4j-layout-template-json:2.26.0"
+
+      // Compile/test dependency via Spark; resolves BDSA-2026-24084
+      force "at.yawk.lz4:lz4-java:1.11.1"
     }
   }
 }


### PR DESCRIPTION
Description:
## Summary
This PR remediates Black Duck finding BDSA-2026-24084 by forcing the Spark-transitive LZ4 dependency to a patched version.

Change made:
- Added a Gradle resolution override in build.gradle:
  - at.yawk.lz4:lz4-java:1.11.1

## Vulnerability Details
- Vulnerability ID: BDSA-2026-24084
- Severity: Medium
- CVSS: 5.7
- Component: lz4java
- Reported version: 1.11.0
- Patched version: 1.11.1

## Why this change
lz4-java is brought in transitively through Spark dependencies. Forcing 1.11.1 ensures the resolved dependency graph uses a patched version and clears the security finding.

## Validation
Dependency resolution was verified with:
`- ./gradlew --no-daemon :marklogic-spark-connector:dependencyInsight --dependency lz4 --configuration compileClasspath`

Result shows:
- at.yawk.lz4:lz4-java:1.11.1 (forced)
- prior transitive versions 1.11.0 and 1.10.3 resolve to 1.11.1

## Notes
There is an unrelated generated file default.json in the working tree; it should be excluded from this PR so the PR contains only the security remediation.