### PR TITLE
MLE-31746 Bump org.apache.thrift:libthrift to 0.24.0

### DIFF
--- a/marklogic-spark-connector/build.gradle
+++ b/marklogic-spark-connector/build.gradle
@@ -36,8 +36,8 @@ configurations.configureEach {
 dependencies {
   // Overrides are needed here for runtime dependencies so that Flux picks up the overridden dependency as well.
   constraints {
-    implementation("org.apache.thrift:libthrift:0.23.0") {
-      because "Bumping from 0.22.0 to 0.23.0 to eliminate several CVEs; this is brought in by jena-arq."
+    implementation("org.apache.thrift:libthrift:0.24.0") {
+      because "Bumping from 0.22.0 to 0.24.0 to eliminate several CVEs; this is brought in by jena-arq."
     }
   }
 


### PR DESCRIPTION
Bumping org.apache.thrift:libthrift to 0.24.0 from 0.23.0 to eliminate several CVEs brought in by jena-arq 5.6.0 which defaults to org.apache.thrift:libthrift:0.22.0

Jira Ticket: https://progresssoftware.atlassian.net/browse/MLE-31746