### PR TITLE
MLE-31549 fix NULL Pointer Dereference

### DIFF
--- a/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/WriteContext.java
+++ b/marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/WriteContext.java
@@ -168,13 +168,19 @@ public class WriteContext extends ContextSupport {
             .xmlNamespaces(NamespaceContextFactory.makePrefixesToNamespaces(getProperties()));
 
         if (hasOption(Options.WRITE_INCREMENTAL_JSON_EXCLUSIONS)) {
-            String[] jsonExclusions = getStringOption(Options.WRITE_INCREMENTAL_JSON_EXCLUSIONS).split("\\r?\\n");
-            builder.jsonExclusions(jsonExclusions);
+             String jsonOption = getStringOption(Options.WRITE_INCREMENTAL_JSON_EXCLUSIONS);
+             if (jsonOption != null) {
+                 String[] jsonExclusions = jsonOption.split("\\r?\\n");
+                 builder.jsonExclusions(jsonExclusions);
+             }
         }
 
         if (hasOption(Options.WRITE_INCREMENTAL_XML_EXCLUSIONS)) {
-            String[] xmlExclusions = getStringOption(Options.WRITE_INCREMENTAL_XML_EXCLUSIONS).split("\\r?\\n");
-            builder.xmlExclusions(xmlExclusions);
+             String xmlOption = getStringOption(Options.WRITE_INCREMENTAL_XML_EXCLUSIONS);
+             if (xmlOption != null) {
+                 String[] xmlExclusions = xmlOption.split("\\r?\\n");
+                 builder.xmlExclusions(xmlExclusions);
+             }
         }
 
         return builder.build();


### PR DESCRIPTION
Fix Polaris issue: 

[NULL Pointer Dereference | Issues | MarkLogic-DevExp-marklogic-spark-connector | MarkLogic-DevExp | Portfolio | Polaris](https://polaris.blackduck.com/portfolio/portfolios/8b7ad6f7-6dcb-49ec-bded-bfc4f190d4f8/portfolio-items/15ccd714-467f-4290-827e-385596e2ca86/projects/33aee2a7-35af-4d13-8070-3ff4d3f4e93c/issues/15866C49B65DADF8B1AA3CEEC8A69472?filter=triage%3Astatus%3Dnot-dismissed%2Cto-be-fixed)

Location:marklogic-spark-connector/src/main/java/com/marklogic/spark/writer/WriteContext.java